### PR TITLE
feat(docs): generate Jekyll friendly pages for README files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ benchmark/dist
 packages/tsdocs/fixtures/monorepo/docs
 packages/tsdocs/fixtures/monorepo/packages/pkg1/docs
 /docs/site/readmes
+/docs/site/README-*.md
 /docs/apidocs/reports-temp
 /docs/apidocs/models
 *.tsbuildinfo

--- a/docs/bin/copy-readmes.js
+++ b/docs/bin/copy-readmes.js
@@ -9,7 +9,7 @@
 /*
  * This is an internal script to gather READMEs of all packages
  * in our monorepo and copy them to `site/readmes` for consumption
- * from the docs.
+ * from the docs. It also generates Jekyll friendly pages for README files.
  */
 
 const Project = require('@lerna/project');
@@ -18,11 +18,14 @@ const path = require('path');
 
 const REPO_ROOT = path.resolve(__dirname, '../..');
 const DEST_ROOT = path.resolve(__dirname, '../site/readmes/loopback-next');
+const SITE_ROOT = path.resolve(__dirname, '../site');
 
-copyReadmes().catch(err => {
-  console.error('Unhandled error.', err);
-  process.exit(1);
-});
+if (require.main === module) {
+  copyReadmes().catch(err => {
+    console.error('Unhandled error.', err);
+    process.exit(1);
+  });
+}
 
 async function copyReadmes() {
   // Remove the original folder so we remove files from deleted packages
@@ -31,22 +34,109 @@ async function copyReadmes() {
   const project = new Project(REPO_ROOT);
   const allPackages = await project.getPackages();
 
-  const packages = allPackages.filter(isDocumented).map(pkg => ({
-    name: pkg.name,
-    location: path.relative(REPO_ROOT, pkg.location),
-  }));
+  const packages = allPackages
+    .filter(shouldCopyReadme)
+    .map(pkg => {
+      let shortName = pkg.name;
+      if (pkg.name.startsWith('@loopback/')) {
+        shortName = pkg.name.substring('@loopback/'.length);
+      }
 
-  for (const {location} of packages) {
-    const src = path.join(REPO_ROOT, location, 'README.md');
-    const dest = path.join(DEST_ROOT, location, 'README.md');
-    await fs.copy(src, dest, {overwrite: true});
+      const location = path.relative(REPO_ROOT, pkg.location);
+      const meta = {
+        name: pkg.name,
+        shortName,
+        isPrivate: pkg.isPrivate,
+        location,
+        dir: path.dirname(location),
+      };
+      return meta;
+    })
+    .sort((a, b) => b.location.localeCompare(a.location));
+
+  const packagesByDir = {};
+  packages.forEach(pkg => {
+    let list = packagesByDir[pkg.dir];
+    if (list == null) {
+      list = [];
+      packagesByDir[pkg.dir] = list;
+    }
+    list.push(pkg);
+  });
+
+  // Index page for all README files
+  const readmeIndexPage = [
+    `---
+lang: en
+title: 'README Docs'
+keywords: LoopBack 4.0, LoopBack 4
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/readme.index.html
+---
+
+## README documents`,
+  ];
+
+  for (const dir in packagesByDir) {
+    const arr = packagesByDir[dir].filter(shouldPublishReadme);
+    if (arr.length) {
+      // Add an entry to the index for each dir
+      readmeIndexPage.push(`\n### ${dir}\n`);
+    }
+    for (const {location, name, shortName} of packagesByDir[dir]) {
+      const src = path.join(REPO_ROOT, location, 'README.md');
+      const dest = path.join(DEST_ROOT, location, 'README.md');
+      await fs.copy(src, dest, {overwrite: true});
+
+      if (!shouldPublishReadme({name, location})) continue;
+
+      // Build a Jekyll page for the README file
+      // Unfortunately our `readme` layout expects the md file to be under `site`
+      const readmePage = `README-${shortName}.md`;
+      const md = `---
+lang: en
+title: 'README - ${name}'
+keywords: LoopBack 4.0, LoopBack 4, README
+layout: readme
+source: loopback-next
+file: ${location}/README.md
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/readme.${shortName}.html
+---
+`;
+      // Write `site/README-<pkg-name>.md`, such as `README-extension-health.md`
+      await fs.writeFile(path.join(SITE_ROOT, readmePage), md, 'utf-8');
+
+      // Add an entry to the index
+      readmeIndexPage.push(`- [${name}](${readmePage})`);
+    }
   }
+
+  // Write `site/README-index.md`
+  await fs.writeFile(
+    path.join(SITE_ROOT, 'README-index.md'),
+    readmeIndexPage.join('\n'),
+    'utf-8',
+  );
 }
 
-function isDocumented(pkg) {
+/**
+ * Control if README for the given package should be copied
+ * @param {object} pkg
+ */
+function shouldCopyReadme(pkg) {
   return (
+    !pkg.isPrivate &&
     !pkg.name.startsWith('@loopback/sandbox-') &&
     pkg.name !== '@loopback/docs' &&
     pkg.name !== '@loopback/benchmark'
   );
+}
+
+/**
+ * Test if README should be published for the given package
+ * @param {object} pkg
+ */
+function shouldPublishReadme(pkg) {
+  return !pkg.location.startsWith('packages/');
 }

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -832,6 +832,10 @@ children:
       url: submitting_a_pr.html
       output: 'web, pdf'
 
+- title: 'READMEs'
+  url: readme.index.html
+  output: 'web, pdf'
+
 - title: 'Reference'
   url: Reference.html
   output: 'web, pdf'


### PR DESCRIPTION
This PR automates generation of pages from README files.

<img width="753" alt="Screen Shot 2019-12-04 at 10 40 45 PM" src="https://user-images.githubusercontent.com/540892/70210399-64a4cd80-16e7-11ea-9f17-d9995bc0e321.png">


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
