### PR TITLE
docs(todos demo): gives warning to new users of unimplemented functionality resulting in `POST /todos` failure

### DIFF
--- a/docs/site/tutorials/todo/todo-tutorial-putting-it-together.md
+++ b/docs/site/tutorials/todo/todo-tutorial-putting-it-together.md
@@ -54,6 +54,8 @@ That's it! You've just created your first LoopBack 4 application!
 
 _Note: Use **CTRL+C** to stop the application_
 
+Minor bug note: You may see 500 errors from the `GET /todos` in explorer - see [#issue 4977](https://github.com/strongloop/loopback-next/issues/4977), affects all projects invoking @param.filter(ModelHere)
+
 ### Where to go from here
 
 There are still a ton of features you can use to build on top of the


### PR DESCRIPTION
As getFIlterJsonSchemaFor() is not yet Model-Aware, filter options are unset and default to
'String'. This one line note in the tutorial warns users and links in the issue for more information.

issue #4977

first PR - worked hard to follow guidance - hope it's correct.
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
