### PR TITLE
jsonSchema composition for inheritance and includeRelations

### DIFF
--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -1019,27 +1019,54 @@ describe('build-schema', () => {
 
       const expectedSchema: JsonSchema = {
         definitions: {
+          Category: {
+            additionalProperties: false,
+            description:
+              '(tsType: Category, schemaOptions: { includeRelations: false })',
+            properties: {
+              id: {
+                type: 'number',
+              },
+            },
+            title: 'Category',
+          },
+          Product: {
+            title: 'Product',
+            description:
+              `(tsType: Product, ` +
+              `schemaOptions: { includeRelations: false })`,
+            properties: {
+              id: {type: 'number'},
+              categoryId: {type: 'number'},
+            },
+            additionalProperties: false,
+          },
           ProductWithRelations: {
             title: 'ProductWithRelations',
             description:
               `(tsType: ProductWithRelations, ` +
               `schemaOptions: { includeRelations: true })`,
+            allOf: [
+              {$ref: '#/definitions/Product'},
+              {
+                properties: {
+                  category: {$ref: '#/definitions/CategoryWithRelations'},
+                },
+              },
+            ],
+          },
+        },
+        allOf: [
+          {$ref: '#/definitions/Category'},
+          {
             properties: {
-              id: {type: 'number'},
-              categoryId: {type: 'number'},
-              category: {$ref: '#/definitions/CategoryWithRelations'},
+              products: {
+                type: 'array',
+                items: {$ref: '#/definitions/ProductWithRelations'},
+              },
             },
-            additionalProperties: false,
           },
-        },
-        properties: {
-          id: {type: 'number'},
-          products: {
-            type: 'array',
-            items: {$ref: '#/definitions/ProductWithRelations'},
-          },
-        },
-        additionalProperties: false,
+        ],
         title: 'CategoryWithRelations',
         description:
           `(tsType: CategoryWithRelations, ` +
@@ -1066,28 +1093,53 @@ describe('build-schema', () => {
       }
       const expectedSchema: JsonSchema = {
         definitions: {
-          ProductWithRelations: {
-            title: 'ProductWithRelations',
+          CategoryWithoutProp: {
+            additionalProperties: false,
             description:
-              `(tsType: ProductWithRelations, ` +
-              `schemaOptions: { includeRelations: true })`,
+              '(tsType: CategoryWithoutProp, schemaOptions: { includeRelations: false })',
+            title: 'CategoryWithoutProp',
+          },
+          Product: {
+            title: 'Product',
+            description:
+              '(tsType: Product, schemaOptions: { includeRelations: false })',
             properties: {
-              id: {type: 'number'},
-              categoryId: {type: 'number'},
-              category: {
-                $ref: '#/definitions/CategoryWithoutPropWithRelations',
+              categoryId: {
+                type: 'number',
+              },
+              id: {
+                type: 'number',
               },
             },
             additionalProperties: false,
           },
-        },
-        properties: {
-          products: {
-            type: 'array',
-            items: {$ref: '#/definitions/ProductWithRelations'},
+          ProductWithRelations: {
+            allOf: [
+              {$ref: '#/definitions/Product'},
+              {
+                properties: {
+                  category: {
+                    $ref: '#/definitions/CategoryWithoutPropWithRelations',
+                  },
+                },
+              },
+            ],
+            description:
+              '(tsType: ProductWithRelations, schemaOptions: { includeRelations: true })',
+            title: 'ProductWithRelations',
           },
         },
-        additionalProperties: false,
+        allOf: [
+          {$ref: '#/definitions/CategoryWithoutProp'},
+          {
+            properties: {
+              products: {
+                type: 'array',
+                items: {$ref: '#/definitions/ProductWithRelations'},
+              },
+            },
+          },
+        ],
         title: 'CategoryWithoutPropWithRelations',
         description:
           `(tsType: CategoryWithoutPropWithRelations, ` +

--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -313,15 +313,15 @@ describe('build-schema', () => {
         title: 'ParentWithItsChildren',
         includeRelations: true,
       });
-      expect(schema.properties).to.containEql({
-        children: {
-          type: 'array',
-          // The reference here should be `ChildWithRelations`,
-          // instead of `ParentWithItsChildren`
-          items: {$ref: '#/definitions/ChildWithRelations'},
+      expect(schema.allOf).to.containEql({
+        properties: {
+          children: {
+            type: 'array',
+            // The reference here should be `ChildWithRelations`,
+            // instead of `ParentWithItsChildren`
+            items: {$ref: '#/definitions/ChildWithRelations'},
+          },
         },
-        benchmarkId: {type: 'string'},
-        color: {type: 'string'},
       });
       // The recursive calls should NOT inherit
       // `title` from the previous call's `options`.
@@ -332,8 +332,7 @@ describe('build-schema', () => {
           title: 'ChildWithRelations',
           description:
             '(tsType: ChildWithRelations, schemaOptions: { includeRelations: true })',
-          properties: {name: {type: 'string'}},
-          additionalProperties: false,
+          allOf: [{$ref: '#/definitions/Child'}, {properties: {}}],
         },
       });
     });

--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -422,13 +422,19 @@ describe('build-schema', () => {
       const newUserSchema = modelToJsonSchema(NewUser, {});
       expect(newUserSchema).to.eql({
         title: 'NewUser',
-        properties: {
-          id: {type: 'string'},
-          name: {type: 'string'},
-          password: {type: 'string'},
+        allOf: [
+          {$ref: `#/definitions/User`},
+          {
+            properties: {
+              password: {type: 'string'},
+            },
+            required: ['password'],
+            additionalProperties: false,
+          },
+        ],
+        definitions: {
+          User: userSchema,
         },
-        required: ['name', 'password'],
-        additionalProperties: false,
       });
     });
 


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
Implement a workaround for enum duplication in a generated OpenAPI spec [mentioned here](https://github.com/strongloop/loopback-next/issues/3033#issuecomment-634097517).
As of `@loopback/repository-json-schema@2.4.2` both inheritance and `getModelSchemaRef(SomeModel, {includeRelations: true})` produce duplication in definitions. If an enum type property is present in `SomeModel` and a client is generated from such a spec (via [typescript-fetch](https://openapi-generator.tech/docs/generators/typescript-fetch) in my case), `SomeModel` and `SomeModelWithRelations` will have incompatible types in generated code. Same happens if a model inherits another one with an enum in it.
This PR replaces all inherited props with `allOf` composition and a `$ref` to a parent schema in both cases.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
