### PR TITLE
fix: clean up sandbox directories after tests

### DIFF
--- a/packages/boot/src/__tests__/acceptance/application-metadata.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/application-metadata.booter.acceptance.ts
@@ -11,6 +11,9 @@ import {BooterApp} from '../fixtures/application';
 describe('application metadata booter acceptance tests', () => {
   let app: BooterApp;
   const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
+
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 

--- a/packages/boot/src/__tests__/acceptance/component-application.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/component-application.booter.acceptance.ts
@@ -15,6 +15,8 @@ describe('component application booter acceptance tests', () => {
   let app: BooterApp;
   const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 

--- a/packages/boot/src/__tests__/acceptance/controller.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/controller.booter.acceptance.ts
@@ -15,6 +15,8 @@ describe('controller booter acceptance tests', () => {
   let app: BooterApp;
   const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 

--- a/packages/boot/src/__tests__/acceptance/crud-rest.api-builder.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/crud-rest.api-builder.acceptance.ts
@@ -16,6 +16,8 @@ describe('CRUD rest builder acceptance tests', () => {
   let app: BooterApp;
   const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(givenAppWithDataSource);
 

--- a/packages/boot/src/__tests__/acceptance/model-api.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/model-api.booter.acceptance.ts
@@ -28,6 +28,8 @@ describe('model API booter acceptance tests', () => {
   let app: BooterApp;
   const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(givenAppWithDataSource);
 

--- a/packages/boot/src/__tests__/integration/controller.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/controller.booter.integration.ts
@@ -16,6 +16,8 @@ describe('controller booter integration tests', () => {
 
   let app: BooterApp;
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 

--- a/packages/boot/src/__tests__/integration/datasource.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/datasource.booter.integration.ts
@@ -15,6 +15,8 @@ describe('datasource booter integration tests', () => {
 
   let app: BooterApp;
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 

--- a/packages/boot/src/__tests__/integration/interceptor.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/interceptor.booter.integration.ts
@@ -17,6 +17,8 @@ describe('interceptor script booter integration tests', () => {
 
   let app: BooterApp;
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(buildAppWithInterceptors);
 

--- a/packages/boot/src/__tests__/integration/lifecycle-observer.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/lifecycle-observer.booter.integration.ts
@@ -21,6 +21,8 @@ describe('lifecycle script booter integration tests', () => {
 
   let app: BooterApp;
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 

--- a/packages/boot/src/__tests__/integration/model.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/model.booter.integration.ts
@@ -14,6 +14,8 @@ describe('repository booter integration tests', () => {
 
   let app: BooterApp;
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 

--- a/packages/boot/src/__tests__/integration/repository.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/repository.booter.integration.ts
@@ -16,6 +16,8 @@ describe('repository booter integration tests', () => {
 
   let app: BooterApp;
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 

--- a/packages/boot/src/__tests__/integration/service.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/service.booter.integration.ts
@@ -15,6 +15,8 @@ describe('service booter integration tests', () => {
 
   let app: BooterApp;
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 

--- a/packages/boot/src/__tests__/unit/booters/booter-utils.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/booter-utils.unit.ts
@@ -10,6 +10,8 @@ import {discoverFiles, isClass, loadClassesFromFiles} from '../../..';
 describe('booter-utils unit tests', () => {
   const sandbox = new TestSandbox(resolve(__dirname, '../../../.sandbox'));
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
 
   describe('discoverFiles()', () => {

--- a/packages/boot/src/__tests__/unit/booters/controller.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/controller.booter.unit.ts
@@ -16,6 +16,8 @@ describe('controller booter unit tests', () => {
 
   let app: Application;
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 

--- a/packages/boot/src/__tests__/unit/booters/datasource.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/datasource.booter.unit.ts
@@ -24,6 +24,8 @@ describe('datasource booter unit tests', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let stub: sinon.SinonStub<[any?, ...any[]], void>;
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
   beforeEach(createStub);

--- a/packages/boot/src/__tests__/unit/booters/repository.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/repository.booter.unit.ts
@@ -24,6 +24,8 @@ describe('repository booter unit tests', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let stub: sinon.SinonStub<[any?, ...any[]], void>;
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
   beforeEach(createStub);

--- a/packages/boot/src/__tests__/unit/booters/service.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/service.booter.unit.ts
@@ -21,6 +21,8 @@ describe('service booter unit tests', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let stub: sinon.SinonStub<[any?, ...any[]], void>;
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
   beforeEach(createStub);

--- a/packages/cli/test/integration/generators/clone-example.integration.js
+++ b/packages/cli/test/integration/generators/clone-example.integration.js
@@ -22,6 +22,8 @@ const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 describe('cloneExampleFromGitHub (SLOW)', /** @this {Mocha.Suite} */ function () {
   this.timeout(20000);
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
 
   it('extracts project files', async () => {

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -45,6 +45,8 @@ describe('controller-generator extending BaseGenerator', baseTests);
 describe('generator-loopback4:controller', tests);
 
 describe('lb4 controller', () => {
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
 
   it('does not run without package.json', () => {

--- a/packages/cli/test/integration/generators/datasource.integration.js
+++ b/packages/cli/test/integration/generators/datasource.integration.js
@@ -61,6 +61,8 @@ describe('datasource-generator extending BaseGenerator', baseTests);
 describe('generator-loopback4:datasource', tests);
 
 describe('lb4 datasource integration', () => {
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
 
   it('does not run without package.json', () => {

--- a/packages/cli/test/integration/generators/import-lb3-models.integration.js
+++ b/packages/cli/test/integration/generators/import-lb3-models.integration.js
@@ -43,6 +43,8 @@ describe('lb4 import-lb3-models', function () {
     return loadLb3App(COFFEE_SHOP_EXAMPLE);
   }
 
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
 
   it('imports CoffeeShop model from lb3-example app', async () => {

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -36,6 +36,8 @@ describe('model-generator extending BaseGenerator', baseTests);
 describe('generator-loopback4:model', tests);
 
 describe('lb4 model integration', () => {
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
 
   it('does not run without package.json', () => {
@@ -261,52 +263,56 @@ describe('lb4 model integration', () => {
       basicModelFileChecks(expectedModelFile, expectedIndexFile);
     });
   });
-});
 
-describe('model generator using --config option', () => {
-  it('create models with valid json', async () => {
-    await testUtils
-      .executeGenerator(generator)
-      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
-      .withArguments(['--config', '{"name":"test", "base":"Entity"}', '--yes']);
-
-    basicModelFileChecks(expectedModelFile, expectedIndexFile);
-  });
-
-  it('does not run if pass invalid json', () => {
-    return expect(
-      testUtils
-        .executeGenerator(generator)
-        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
-        .withArguments([
-          '--config',
-          '{"name":"test", "base":"InvalidBaseModel"}',
-          '--yes',
-        ]),
-    ).to.be.rejectedWith(/Model was not found in/);
-  });
-
-  describe('model generator using --config option with model settings', () => {
-    it('creates a model with valid settings', async () => {
+  describe('model generator using --config option', () => {
+    it('create models with valid json', async () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
         .withArguments([
           '--config',
-          '{"name":"test", "base":"Entity", \
-          "modelSettings": {"annotations": \
-          [{"destinationClass": "class1","argument": 0}],\
-          "foreignKeys": {"fk_destination": {"name": "fk_destination"}}},\
-          "allowAdditionalProperties":true}',
+          '{"name":"test", "base":"Entity"}',
           '--yes',
         ]);
 
       basicModelFileChecks(expectedModelFile, expectedIndexFile);
+    });
 
-      assert.fileContent(
-        expectedModelFile,
-        /@model\({\n {2}settings: {\n {4}annotations: \[{destinationClass: 'class1', argument: 0}],\n {4}foreignKeys: {fk_destination: {name: 'fk_destination'}},\n {4}strict: false\n {2}}\n}\)/,
-      );
+    it('does not run if pass invalid json', () => {
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
+          .withArguments([
+            '--config',
+            '{"name":"test", "base":"InvalidBaseModel"}',
+            '--yes',
+          ]),
+      ).to.be.rejectedWith(/Model was not found in/);
+    });
+
+    describe('model generator using --config option with model settings', () => {
+      it('creates a model with valid settings', async () => {
+        await testUtils
+          .executeGenerator(generator)
+          .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
+          .withArguments([
+            '--config',
+            '{"name":"test", "base":"Entity", \
+          "modelSettings": {"annotations": \
+          [{"destinationClass": "class1","argument": 0}],\
+          "foreignKeys": {"fk_destination": {"name": "fk_destination"}}},\
+          "allowAdditionalProperties":true}',
+            '--yes',
+          ]);
+
+        basicModelFileChecks(expectedModelFile, expectedIndexFile);
+
+        assert.fileContent(
+          expectedModelFile,
+          /@model\({\n {2}settings: {\n {4}annotations: \[{destinationClass: 'class1', argument: 0}],\n {4}foreignKeys: {fk_destination: {name: 'fk_destination'}},\n {4}strict: false\n {2}}\n}\)/,
+        );
+      });
     });
   });
 });

--- a/packages/cli/test/unit/update-index.unit.js
+++ b/packages/cli/test/unit/update-index.unit.js
@@ -19,6 +19,8 @@ const sandbox = new TestSandbox(path.resolve(__dirname, '.sandbox'));
 const expectedFile = path.join(sandbox.path, 'index.ts');
 
 describe('update-index unit tests', () => {
+  after('delete sandbox', () => sandbox.delete());
+
   beforeEach('reset sandbox', () => sandbox.reset());
 
   it('creates index.ts when not present', async () => {

--- a/packages/testlab/src/__tests__/integration/test-sandbox.integration.ts
+++ b/packages/testlab/src/__tests__/integration/test-sandbox.integration.ts
@@ -126,6 +126,16 @@ describe('TestSandbox integration tests', () => {
     expect(await pathExists(path)).to.be.False();
   });
 
+  it('keeps the test sandbox with KEEP_TEST_SANDBOX env var', async () => {
+    process.env.KEEP_TEST_SANDBOX = '1';
+    try {
+      await sandbox.delete();
+      expect(await pathExists(path)).to.be.true();
+    } finally {
+      delete process.env.KEEP_TEST_SANDBOX;
+    }
+  });
+
   describe('after deleting sandbox', () => {
     const ERR = 'TestSandbox instance was deleted. Create a new instance.';
 
@@ -172,6 +182,6 @@ describe('TestSandbox integration tests', () => {
 
   async function deleteSandbox() {
     if (!(await pathExists(path))) return;
-    await remove(sandbox.path);
+    await remove(path);
   }
 });

--- a/packages/testlab/src/test-sandbox.ts
+++ b/packages/testlab/src/test-sandbox.ts
@@ -107,10 +107,13 @@ export class TestSandbox {
   }
 
   /**
-   * Deletes the TestSandbox.
+   * Deletes the TestSandbox. If `KEEP_TEST_SANDBOX` env variable is set, we
+   * leave the sandbox directory as-is on the file system.
    */
   async delete(): Promise<void> {
-    await remove(this.path);
+    if (!process.env.KEEP_TEST_SANDBOX) {
+      await remove(this.path);
+    }
     delete this._path;
   }
 


### PR DESCRIPTION
This is rework of https://github.com/strongloop/loopback-next/pull/5720.

There are 3 commits:

~1. Use unique sandbox subdirs for parallel testing (must-have)~ Extracted to https://github.com/strongloop/loopback-next/pull/5747

2. Add `KEEP_TEST_SANDBOX` env var to keep files for sandbox.delete (nice-to-have)

3. Add `after` hook to delete test sandbox directories (should-have)

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
