### PR TITLE
chore: use defineProperty to name a generated class

### DIFF
--- a/packages/express/src/middleware-interceptor.ts
+++ b/packages/express/src/middleware-interceptor.ts
@@ -285,30 +285,20 @@ export function defineInterceptorProvider<
   className = buildName(middlewareFactory, className);
   assert(className, 'className is missing and it cannot be inferred.');
 
-  const defineNamedClass = new Function(
-    'middlewareFactory',
-    'defaultMiddlewareConfig',
-    'MiddlewareInterceptorProvider',
-    'createInterceptor',
-    `return class ${className} extends MiddlewareInterceptorProvider {
-       constructor(middlewareConfig) {
-         super(
-           middlewareFactory,
-           middlewareConfig,
-         );
-         if (this.middlewareConfig == null) {
-           this.middlewareConfig = defaultMiddlewareConfig;
-         }
-       }
-     };`,
-  );
+  const cls = class extends ExpressMiddlewareInterceptorProvider<CFG, CTX> {
+    constructor(middlewareConfig?: CFG) {
+      super(middlewareFactory, middlewareConfig);
+      if (this.middlewareConfig == null) {
+        this.middlewareConfig = defaultMiddlewareConfig;
+      }
+    }
+  };
 
-  const cls = defineNamedClass(
-    middlewareFactory,
-    defaultMiddlewareConfig,
-    ExpressMiddlewareInterceptorProvider,
-    createInterceptor,
-  );
+  Object.defineProperty(cls, 'name', {
+    value: className,
+    configurable: false,
+  });
+
   if (options?.injectConfiguration === 'watch') {
     // Inject the config view
     config.view()(cls, '', 0);

--- a/packages/repository/src/define-model-class.ts
+++ b/packages/repository/src/define-model-class.ts
@@ -52,19 +52,19 @@ export function defineModelClass<
   definition: ModelDefinition,
 ): DynamicModelCtor<BaseCtor, Props> {
   const modelName = definition.name;
-  const defineNamedModelClass = new Function(
-    base.name,
-    `return class ${modelName} extends ${base.name} {}`,
-  );
-  const modelClass = defineNamedModelClass(base) as DynamicModelCtor<
-    BaseCtor,
-    Props
-  >;
-  assert.equal(modelClass.name, modelName);
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  class CustomModelClass extends (base as any) {}
+
+  Object.defineProperty(CustomModelClass, 'name', {
+    value: modelName,
+    configurable: false,
+  });
+
+  assert.equal(CustomModelClass.name, modelName);
   // Apply `@model(definition)` to the generated class
-  model(definition)(modelClass);
-  return modelClass;
+  model(definition)(CustomModelClass);
+  return CustomModelClass as DynamicModelCtor<BaseCtor, Props>;
 }
 
 /**

--- a/packages/repository/src/define-repository-class.ts
+++ b/packages/repository/src/define-repository-class.ts
@@ -102,19 +102,22 @@ export function defineRepositoryClass<
   baseRepositoryClass: BaseRepositoryClass<M, R>,
 ): ModelRepositoryClass<PrototypeOf<M>, R> {
   const repoName = modelClass.name + 'Repository';
-  const defineNamedRepo = new Function(
-    'ModelCtor',
-    'BaseRepository',
-    `return class ${repoName} extends BaseRepository {
-      constructor(dataSource) {
-        super(ModelCtor, dataSource);
-      }
-    };`,
-  );
 
-  const repo = defineNamedRepo(modelClass, baseRepositoryClass);
-  assert.equal(repo.name, repoName);
-  return repo;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  class CustomRepoClass extends (baseRepositoryClass as any) {
+    constructor(dataSource: juggler.DataSource) {
+      super(modelClass, dataSource);
+    }
+  }
+
+  Object.defineProperty(CustomRepoClass, 'name', {
+    value: repoName,
+    configurable: false,
+  });
+
+  assert.equal(CustomRepoClass.name, repoName);
+
+  return CustomRepoClass as ModelRepositoryClass<PrototypeOf<M>, R>;
 }
 
 /**

--- a/packages/rest-crud/src/crud-rest.controller.ts
+++ b/packages/rest-crud/src/crud-rest.controller.ts
@@ -263,13 +263,13 @@ export function defineCrudRestController<
   }
 
   const controllerName = modelName + 'Controller';
-  const defineNamedController = new Function(
-    'controllerClass',
-    `return class ${controllerName} extends controllerClass {}`,
-  );
-  const controller = defineNamedController(CrudRestControllerImpl);
-  assert.equal(controller.name, controllerName);
-  return controller;
+  const controllerClass = class extends CrudRestControllerImpl {};
+  Object.defineProperty(controllerClass, 'name', {
+    value: controllerName,
+    configurable: false,
+  });
+  assert.equal(controllerClass.name, controllerName);
+  return controllerClass;
 }
 
 function getIdSchema<T extends Entity>(


### PR DESCRIPTION
Use Object.defineProperty to name generated classes

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
