### PR TITLE
Feature/native source maps in @loopback/build

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 const {mergeMochaConfigs} = require('./packages/build');
-const defaultConfig = require('./packages/build/config/.mocharc.json');
+const defaultConfig = require('./packages/build/config/.mocharc.js');
 
 const MONOREPO_CONFIG = {
   parallel: true,

--- a/packages/build/bin/run-mocha.js
+++ b/packages/build/bin/run-mocha.js
@@ -33,8 +33,8 @@ function run(argv, options) {
   if (typeof options === 'boolean') options = {dryRun: options};
   options = options || {};
   if (setMochaOpts) {
-    // Use the default `.mocharc.json` from `@loopback/build`
-    const mochaOptsFile = utils.getConfigFile('.mocharc.json');
+    // Use the default `.mocharc.js` from `@loopback/build`
+    const mochaOptsFile = utils.getConfigFile('.mocharc.js', '.mocharc.json');
     mochaOpts.unshift('--config', mochaOptsFile);
   }
 

--- a/packages/build/config/.mocharc.js
+++ b/packages/build/config/.mocharc.js
@@ -1,0 +1,10 @@
+const semver = require('semver');
+
+const canUseBuiltinSourceMaps = semver.gte(process.version, 'v12.11.0');
+module.exports = {
+  require: !canUseBuiltinSourceMaps ? ['source-map-support/register'] : [],
+  recursive: true,
+  exit: true,
+  reporter: 'dot',
+  'enable-source-maps': canUseBuiltinSourceMaps,
+};

--- a/packages/build/config/.mocharc.json
+++ b/packages/build/config/.mocharc.json
@@ -1,7 +1,0 @@
-{
-  "require": ["source-map-support/register"],
-  "recursive": true,
-  "exit": true,
-  "reporter": "dot"
-}
-

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -688,6 +688,7 @@
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1",
 						"is-callable": "^1.2.2",
+						"is-negative-zero": "^2.0.0",
 						"is-regex": "^1.1.1",
 						"object-inspect": "^1.8.0",
 						"object-keys": "^1.1.1",
@@ -702,8 +703,30 @@
 					"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
 					"requires": {
 						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.0",
 						"has-symbols": "^1.0.1",
 						"object-keys": "^1.1.1"
+					},
+					"dependencies": {
+						"es-abstract": {
+							"version": "1.18.0-next.1",
+							"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+							"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+							"requires": {
+								"es-to-primitive": "^1.2.1",
+								"function-bind": "^1.1.1",
+								"has": "^1.0.3",
+								"has-symbols": "^1.0.1",
+								"is-callable": "^1.2.2",
+								"is-negative-zero": "^2.0.0",
+								"is-regex": "^1.1.1",
+								"object-inspect": "^1.8.0",
+								"object-keys": "^1.1.1",
+								"object.assign": "^4.1.1",
+								"string.prototype.trimend": "^1.0.1",
+								"string.prototype.trimstart": "^1.0.1"
+							}
+						}
 					}
 				}
 			}
@@ -1190,6 +1213,11 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
 			"integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw=="
+		},
+		"is-negative-zero": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+			"integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
 		},
 		"is-number": {
 			"version": "7.0.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -31,6 +31,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.1.2",
     "rimraf": "^3.0.2",
+    "semver": "^7.3.2",
     "source-map-support": "^0.5.19",
     "typescript": "~4.0.3"
   },

--- a/packages/build/test/integration/scripts.integration.js
+++ b/packages/build/test/integration/scripts.integration.js
@@ -249,7 +249,7 @@ describe('mocha', /** @this {Mocha.Suite} */ function () {
 
   function cleanup() {
     const run = require('../../bin/run-clean');
-    run(['node', 'bin/run-clean', '.mocharc.json']);
+    run(['node', 'bin/run-clean', '.mocharc.js']);
   }
 
   beforeEach(() => {
@@ -262,12 +262,12 @@ describe('mocha', /** @this {Mocha.Suite} */ function () {
     process.chdir(cwd);
   });
 
-  it('loads built-in .mocharc.json file', () => {
+  it('loads built-in .mocharc.js file', () => {
     const run = require('../../bin/run-mocha');
     const command = run(['node', 'bin/run-mocha', '"dist/__tests__"'], true);
     const builtInMochaOptsFile = path.join(
       __dirname,
-      '../../config/.mocharc.json',
+      '../../config/.mocharc.js',
     );
     assert(
       command.indexOf(builtInMochaOptsFile) !== -1,
@@ -281,14 +281,14 @@ describe('mocha', /** @this {Mocha.Suite} */ function () {
       [
         'node',
         'bin/run-mocha',
-        '--config custom/.mocharc.json',
+        '--config custom/.mocharc.js',
         '"dist/__tests__"',
       ],
       true,
     );
     assert(
-      command.indexOf('--config custom/.mocharc.json') !== -1,
-      '--config custom/.mocharc.json should be honored',
+      command.indexOf('--config custom/.mocharc.js') !== -1,
+      '--config custom/.mocharc.js should be honored',
     );
   });
 
@@ -304,20 +304,20 @@ describe('mocha', /** @this {Mocha.Suite} */ function () {
     process.env.LANG = LANG;
   });
 
-  it('loads .mocharc.json specific project file', () => {
+  it('loads .mocharc.js specific project file', () => {
     const run = require('../../bin/run-mocha');
     const buitInMochaOptsPath = path.join(
       __dirname,
-      '../../config/.mocharc.json',
+      '../../config/.mocharc.js',
     );
-    const destPath = path.join(__dirname, './fixtures/.mocharc.json');
+    const destPath = path.join(__dirname, './fixtures/.mocharc.js');
 
     fs.copyFileSync(buitInMochaOptsPath, destPath);
 
     const command = run(['node', 'bin/run-mocha', '"dist/__tests__"'], true);
     assert(
       command.indexOf('--config') === -1,
-      'should skip built-in .mocharc.json file when specific project file exist',
+      'should skip built-in .mocharc.js file when specific project file exist',
     );
   });
 });

--- a/packages/cli/.mocharc.js
+++ b/packages/cli/.mocharc.js
@@ -10,7 +10,7 @@ const debug = require('debug')('loopback:cli:test');
 const {mergeMochaConfigs} = require('@loopback/build');
 
 // Start with the default config from `@loopback/build`
-const defaultConfig = require('@loopback/build/config/.mocharc.json');
+const defaultConfig = require('@loopback/build/config/.mocharc.js');
 debug('Default mocha config:', defaultConfig);
 
 // Resolve `./test/snapshot-matcher.js` to get the absolute path

--- a/packages/cli/generators/project/templates/.mocharc.js
+++ b/packages/cli/generators/project/templates/.mocharc.js
@@ -1,0 +1,9 @@
+const semver = require('semver');
+
+const canUseBuiltinSourceMaps = semver.gte(process.version, 'v12.11.0');
+module.exports = {
+  require: !canUseBuiltinSourceMaps ? ['source-map-support/register'] : [],
+  recursive: true,
+  exit: true,
+  'enable-source-maps': canUseBuiltinSourceMaps,
+};

--- a/packages/cli/generators/project/templates/.mocharc.json
+++ b/packages/cli/generators/project/templates/.mocharc.json
@@ -1,5 +1,0 @@
-{
-  "exit": true,
-  "recursive": true,
-  "require": "source-map-support/register"
-}

--- a/packages/cli/snapshots/integration/generators/app.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/app.integration.snapshots.js
@@ -7,12 +7,16 @@
 
 'use strict';
 
-exports[`app-generator specific files creates .mocharc.json 1`] = `
-{
-  "exit": true,
-  "recursive": true,
-  "require": "source-map-support/register"
-}
+exports[`app-generator specific files creates .mocharc.js 1`] = `
+const semver = require('semver');
+
+const canUseBuiltinSourceMaps = semver.gte(process.version, 'v12.11.0');
+module.exports = {
+  require: !canUseBuiltinSourceMaps ? ['source-map-support/register'] : [],
+  recursive: true,
+  exit: true,
+  'enable-source-maps': canUseBuiltinSourceMaps,
+};
 
 `;
 

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -94,8 +94,8 @@ describe('app-generator specific files', () => {
     assert.fileContent('.gitignore', /^\*\.tsbuildinfo$/m);
   });
 
-  it('creates .mocharc.json', () => {
-    assertFilesToMatchSnapshot({}, '.mocharc.json');
+  it('creates .mocharc.js', () => {
+    assertFilesToMatchSnapshot({}, '.mocharc.js');
   });
 });
 


### PR DESCRIPTION
- Added `.mocharc.js` for `packages/build`, for dynamic mocha config.
- Used `enable-source-maps` flag depending on node version.
- in the beginning Left `.mocharc.json` untouched in `packages/build` because it's being copied to created projects, and tests and users depend on it (it's my guess here, need your approval 😃)
- Later changed to `.mocharc.js` in the dependent tests and scripts and remove `.mocharc.json`

Implements #6393 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
