### PR TITLE
Supply authentication-jwt repositories with repository tags ...

### DIFF
--- a/extensions/authentication-jwt/src/jwt-authentication-component.ts
+++ b/extensions/authentication-jwt/src/jwt-authentication-component.ts
@@ -12,6 +12,7 @@ import {
   createBindingFromClass,
   inject,
 } from '@loopback/core';
+import {RepositoryTags} from '@loopback/repository';
 import {
   RefreshTokenConstants,
   RefreshTokenServiceBindings,
@@ -42,10 +43,12 @@ export class JWTAuthenticationComponent implements Component {
 
     // user bindings
     Binding.bind(UserServiceBindings.USER_SERVICE).toClass(MyUserService),
-    Binding.bind(UserServiceBindings.USER_REPOSITORY).toClass(UserRepository),
-    Binding.bind(UserServiceBindings.USER_CREDENTIALS_REPOSITORY).toClass(
-      UserCredentialsRepository,
-    ),
+    Binding.bind(UserServiceBindings.USER_REPOSITORY)
+      .toClass(UserRepository)
+      .tag(RepositoryTags.REPOSITORY),
+    Binding.bind(UserServiceBindings.USER_CREDENTIALS_REPOSITORY)
+      .toClass(UserCredentialsRepository)
+      .tag(RepositoryTags.REPOSITORY),
     createBindingFromClass(SecuritySpecEnhancer),
     ///refresh bindings
     Binding.bind(RefreshTokenServiceBindings.REFRESH_TOKEN_SERVICE).toClass(
@@ -63,9 +66,9 @@ export class JWTAuthenticationComponent implements Component {
       RefreshTokenConstants.REFRESH_ISSUER_VALUE,
     ),
     //refresh token repository binding
-    Binding.bind(RefreshTokenServiceBindings.REFRESH_REPOSITORY).toClass(
-      RefreshTokenRepository,
-    ),
+    Binding.bind(RefreshTokenServiceBindings.REFRESH_REPOSITORY)
+      .toClass(RefreshTokenRepository)
+      .tag(RepositoryTags.REPOSITORY),
   ];
   constructor(@inject(CoreBindings.APPLICATION_INSTANCE) app: Application) {
     registerAuthenticationStrategy(app, JWTAuthenticationStrategy);


### PR DESCRIPTION
... to make it discoverable by the findByTag function utilized by migrateSchema.
Fixes `npm migrate` omitting the tables when migrating the database schema.

Fixes #6416 (The auto creation issue is fixed by this PR, incompatibility with mysql remains, IDs are created as varchar and by that cannot be auto_increment columns)

## Checklist
(I don't know whether all items on this checklist apply to this fix. e.g. there are no tests in authentication-jwt, also nothing that affects example projects or the cli artifact templates.)

- [X] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [X] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated