### PR TITLE
fix(docs): fix order by one property example

### DIFF
--- a/docs/site/Order-filter.md
+++ b/docs/site/Order-filter.md
@@ -43,7 +43,7 @@ Order by one property:
 Order by two or more properties:
 
 <pre>
-?filter[order][0]=<i>propertyName</i>%20<ASC|DESC>&filter[order][1]=<i>propertyName</i>%20<ASC|DESC>...
+?filter[order][0]=<i>propertyName</i> <ASC|DESC>&filter[order][1]=<i>propertyName</i> <ASC|DESC>...
 </pre>
 
 Where:

--- a/docs/site/Order-filter.md
+++ b/docs/site/Order-filter.md
@@ -17,7 +17,7 @@ descending (DESC) based on the specified property.
 Order by one property:
 
 <pre>
-{order: '<i>propertyName</i> <ASC|DESC>'}
+{order: ['<i>propertyName</i> <ASC|DESC>']}
 </pre>
 
 Order by two or more properties:
@@ -67,7 +67,7 @@ Return the three most expensive items, sorted by the `price` property:
 
 ```ts
 await itemRepository.find({
-  order: 'price DESC',
+  order: ['price DESC'],
   limit: 3,
 });
 ```

--- a/docs/site/Order-filter.md
+++ b/docs/site/Order-filter.md
@@ -43,7 +43,7 @@ Order by one property:
 Order by two or more properties:
 
 <pre>
-?filter[order][0]=<i>propertyName</i> <ASC|DESC>&filter[order][1]=<i>propertyName</i> <ASC|DESC>...
+?filter[order][0]=<i>propertyName</i>%20<ASC|DESC>&filter[order][1]=<i>propertyName</i>%20<ASC|DESC>...
 </pre>
 
 Where:


### PR DESCRIPTION
Whenever I call `{order: '<i>propertyName</i> <ASC|DESC>'}` I get an error similar to the following, so -I think- using the array is the right way.
```
error TS2345: Argument of type '{ order: string; limit: number; }' is not assignable to parameter of type 'Filter<Lists>'.
  Types of property 'order' are incompatible.
    Type 'string' is not assignable to type 'string[] | undefined'.

43     return this.find(filter);
```

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [X] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
