### PR TITLE
Fixing dependencies to support yarn2 strict mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ benchmark/dist
 # Docs preview
 docs/_loopback.io/
 docs/_preview/
+
+# IDE files
+/.idea

--- a/packages/cli/generators/openapi/spec-loader.js
+++ b/packages/cli/generators/openapi/spec-loader.js
@@ -5,7 +5,7 @@
 
 'use strict';
 const chalk = require('chalk');
-const SwaggerParser = require('swagger-parser');
+const SwaggerParser = require('@apidevtools/swagger-parser');
 const swagger2openapi = require('swagger2openapi');
 const {debugJson, cloneSpecObject} = require('./utils');
 const {generateControllerSpecs} = require('./spec-helper');

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,6 +10,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@apidevtools/swagger-parser": "^10.0.2",
     "@lerna/project": "^3.21.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^3.0.4",
     "@phenomnomnominal/tsquery": "^4.1.1",
@@ -19,6 +20,7 @@
     "debug": "^4.3.1",
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",
+    "inquirer": "^7.3.3",
     "inquirer-autocomplete-prompt": "^1.3.0",
     "json5": "^2.1.3",
     "latest-version": "^5.1.0",
@@ -27,6 +29,7 @@
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.4",
     "natural-compare": "^1.4.0",
+    "openapi-types": "^7.0.1",
     "pacote": "^11.1.13",
     "pluralize": "^8.0.0",
     "regenerate": "^1.4.2",
@@ -35,7 +38,6 @@
     "spdx-license-list": "^6.3.0",
     "stringify-object": "^3.3.0",
     "strong-globalize": "^6.0.5",
-    "swagger-parser": "^10.0.2",
     "swagger2openapi": "^7.0.4",
     "tabtab": "^3.0.2",
     "terminal-link": "^2.1.1",

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -26,6 +26,7 @@
     "@loopback/core": "^2.13.1"
   },
   "dependencies": {
+    "@loopback/repository": "^3.3.0",
     "@loopback/repository-json-schema": "^3.2.0",
     "debug": "^4.3.1",
     "http-status": "^1.5.0",


### PR DESCRIPTION
Yarn2 PnP strict mode requires that dependencies were strictly defined within packages which use them and yarn2 throw an exception during the project launch.

```
Error: @loopback/repository-json-schema tried to access @loopback/repository (a peer dependency) but it isn't provided by its ancestors; this makes the require call ambiguous and unsound.
Required package: @loopback/repository (via "@loopback/repository")
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
