### PR TITLE
perf(authentication-jwt): use faster bcrypt implementation if available

### DIFF
--- a/extensions/authentication-jwt/package-lock.json
+++ b/extensions/authentication-jwt/package-lock.json
@@ -4,6 +4,94 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@napi-rs/triples": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.0.2.tgz",
+			"integrity": "sha512-EL3SiX43m9poFSnhDx4d4fn9SSaqyO2rHsCNhETi9bWPmjXK3uPJ0QpPFtx39FEdHcz1vJmsiW41kqc0AgvtzQ==",
+			"optional": true
+		},
+		"@node-rs/bcrypt": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@node-rs/bcrypt/-/bcrypt-1.2.0.tgz",
+			"integrity": "sha512-1f51Vv2wcX2uZQ1OwmAuYkoxCKUleP8N/F1Li33tWrMiejQhC1Jw6tXQR6onyfzqV+ODii88zy5o0mB3MxSFjA==",
+			"optional": true,
+			"requires": {
+				"@node-rs/bcrypt-android-arm64": "^1.2.0",
+				"@node-rs/bcrypt-darwin-arm64": "^1.2.0",
+				"@node-rs/bcrypt-darwin-x64": "^1.2.0",
+				"@node-rs/bcrypt-linux-arm-gnueabihf": "^1.2.0",
+				"@node-rs/bcrypt-linux-arm64-gnu": "^1.2.0",
+				"@node-rs/bcrypt-linux-x64-gnu": "^1.2.0",
+				"@node-rs/bcrypt-linux-x64-musl": "^1.2.0",
+				"@node-rs/bcrypt-win32-ia32-msvc": "^1.2.0",
+				"@node-rs/bcrypt-win32-x64-msvc": "^1.2.0",
+				"@node-rs/helper": "^1.1.0"
+			}
+		},
+		"@node-rs/bcrypt-android-arm64": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@node-rs/bcrypt-android-arm64/-/bcrypt-android-arm64-1.2.0.tgz",
+			"integrity": "sha512-+M1z6t2R5Zpnm0kKcnIEvjX8n/FE/1mdW2KTGljkjyLYwH+9/KKd5zD0M3NnifA+3sRK29j9Nvx0a9wy3PXL4g==",
+			"optional": true
+		},
+		"@node-rs/bcrypt-darwin-arm64": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@node-rs/bcrypt-darwin-arm64/-/bcrypt-darwin-arm64-1.2.0.tgz",
+			"integrity": "sha512-Q8MIA7Q7TdJraM5fcMnMMEI5sKJQ+fQ0zEZlh3+HsMjnWIh9woXvnJGM2nK5KOpgpPG5uFcojN6ugVqh59p8Rw==",
+			"optional": true
+		},
+		"@node-rs/bcrypt-darwin-x64": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@node-rs/bcrypt-darwin-x64/-/bcrypt-darwin-x64-1.2.0.tgz",
+			"integrity": "sha512-5GogQdrCb9ufiKE1d5il9BX/UpC098QtD28FLwRSGoIbs7cyOUaAG4q0pYKfi57YIN66jq9zNkhpnXj4ynWUvg==",
+			"optional": true
+		},
+		"@node-rs/bcrypt-linux-arm-gnueabihf": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-arm-gnueabihf/-/bcrypt-linux-arm-gnueabihf-1.2.0.tgz",
+			"integrity": "sha512-wQfmWecW7f7tinaPcgn0PCuzlcoVZp38jxdmduI2SpS7EiNLGcauLqjz7IveKcL/uHuqMWQNOlCD2bb82cbrDw==",
+			"optional": true
+		},
+		"@node-rs/bcrypt-linux-arm64-gnu": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-arm64-gnu/-/bcrypt-linux-arm64-gnu-1.2.0.tgz",
+			"integrity": "sha512-/2xW3h3TBASPxZiGkDrPI67DGON2jDedXgrCBn2EicOPGGGJ1AMDdYMuzy1hBijq/MvWptmle9TjbFFaXbAEeQ==",
+			"optional": true
+		},
+		"@node-rs/bcrypt-linux-x64-gnu": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-x64-gnu/-/bcrypt-linux-x64-gnu-1.2.0.tgz",
+			"integrity": "sha512-5WT0PVdygdV0dBrkRLjZGntZduwsIGTbVZ4Egui8LihlrKndNU3YfJ6BrI+iPD5MRx+FCDIoer/sFslTzRwh0w==",
+			"optional": true
+		},
+		"@node-rs/bcrypt-linux-x64-musl": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-x64-musl/-/bcrypt-linux-x64-musl-1.2.0.tgz",
+			"integrity": "sha512-SOl0PWQ56sIGBu77ZYL0H5Un+lFHtHr9jwk4x7d7KMnFErVz/+OgWiSqGLXw2tnxuyzmfKVb42zrYHHINuVM2w==",
+			"optional": true
+		},
+		"@node-rs/bcrypt-win32-ia32-msvc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@node-rs/bcrypt-win32-ia32-msvc/-/bcrypt-win32-ia32-msvc-1.2.0.tgz",
+			"integrity": "sha512-hyKg+rr9VahoVYL+dk5RUQwcJSc8sFhvQkmHPYEwPaDIl4QLmwNiGBycne3jRtKg20LXY8cJ/ZZtPq7NeGOUjw==",
+			"optional": true
+		},
+		"@node-rs/bcrypt-win32-x64-msvc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@node-rs/bcrypt-win32-x64-msvc/-/bcrypt-win32-x64-msvc-1.2.0.tgz",
+			"integrity": "sha512-V+ENM1gK5msvuaGvt+tG+ce0ZANcIckRoV4YSzUqFIag41lSgwRrzDCeSEext/65LxO1FdhA1pZxrB4wj/ZbcA==",
+			"optional": true
+		},
+		"@node-rs/helper": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-1.1.0.tgz",
+			"integrity": "sha512-r43YnnrY5JNzDuXJdW3sBJrKzvejvFmFWbiItUEoBJsaPzOIWFMhXB7i5j4c9EMXcFfxveF4l7hT+rLmwtjrVQ==",
+			"optional": true,
+			"requires": {
+				"@napi-rs/triples": "^1.0.2",
+				"tslib": "^2.1.0"
+			}
+		},
 		"@types/bcryptjs": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz",
@@ -130,6 +218,12 @@
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+		},
+		"tslib": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+			"optional": true
 		},
 		"typescript": {
 			"version": "4.2.3",

--- a/extensions/authentication-jwt/package.json
+++ b/extensions/authentication-jwt/package.json
@@ -47,6 +47,9 @@
     "lodash": "^4.17.21",
     "typescript": "~4.2.3"
   },
+  "optionalDependencies": {
+    "@node-rs/bcrypt": "^1.2.0"
+  },
   "keywords": [
     "LoopBack",
     "Authentication",

--- a/extensions/authentication-jwt/src/services/user.service.ts
+++ b/extensions/authentication-jwt/src/services/user.service.ts
@@ -20,6 +20,14 @@ export type Credentials = {
   password: string;
 };
 
+const compareCredential = (function () {
+  try {
+    return require('@node-rs/bcrypt').compare;
+  } catch {
+    return compare;
+  }
+})();
+
 export class MyUserService implements UserService<User, Credentials> {
   constructor(
     @repository(UserRepository) public userRepository: UserRepository,
@@ -42,7 +50,7 @@ export class MyUserService implements UserService<User, Credentials> {
       throw new HttpErrors.Unauthorized(invalidCredentialsError);
     }
 
-    const passwordMatched = await compare(
+    const passwordMatched = await compareCredential(
       credentials.password,
       credentialsFound.password,
     );


### PR DESCRIPTION
See https://github.com/napi-rs/node-rs/tree/main/packages/bcrypt .

Faster and lighter, without postinstall and node-gyp scripts.
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
