### PR TITLE
ci: add release automation

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,10 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
+      - uses: actions/setup-node@v2
       - name: Bootstrap benchmark tests
         run: |
           npm ci --ignore-scripts
@@ -64,10 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
+      - uses: actions/setup-node@v2
       - name: Bootstrap project
         run: |
           npm ci --ignore-scripts
@@ -87,10 +81,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Use Node.js 14
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
+      - uses: actions/setup-node@v2
       - name: Install monorepo tools
         run: |
           npm ci --ignore-scripts
@@ -103,10 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
+      - uses: actions/setup-node@v2
       - name: Bootstrap project
         run: |
           npm ci --ignore-scripts
@@ -115,3 +103,24 @@ jobs:
         run: npm run build
       - name: Verify doc changes
         run: ./bin/verify-doc-changes.sh
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name.schedule }}
+    needs: [ test, code-lint ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - name: Bootstrap project
+        run: |
+          npm ci --ignore-scripts
+          npm run postinstall
+      - name: Build project
+        run: npm run build
+      - name: Publish packages
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npx lerna version
+          npx lerna publish from-git --yes

--- a/docs/site/DEVELOPING.md
+++ b/docs/site/DEVELOPING.md
@@ -259,13 +259,13 @@ following commands to fix the problem:
 To rebuild `package-lock.json` for all packages.
 
 ```sh
-npm update-package-locks
+npm run update-package-locks
 ```
 
 To update `package-lock.json` for a list of packages:
 
 ```sh
-npm update-package-locks -- --scope <package-name-1> --scope <package-name-2>
+npm run update-package-locks -- --scope <package-name-1> --scope <package-name-2>
 ```
 
 ### Adding dependencies
@@ -757,6 +757,9 @@ The `release` script will automatically perform the tasks for all packages:
 
 If all steps are successful, it prompts you to publish packages into npm
 repository.
+
+> There is an automated process that creates a new version every 15 days. See
+> [continuous-integration.yaml](https://github.com/strongloop/loopback-next/blob/master/.github/workflows/continuous-integration.yaml)
 
 ## Adding a new package
 


### PR DESCRIPTION
This automates the publication of the packages on the 1st and 15th of each month.

Requires adding the secret `NPM_TOKEN` in the repository configuration

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
