### PR TITLE
Resolution Session Rework

### DIFF
--- a/examples/context/src/custom-inject-resolve.ts
+++ b/examples/context/src/custom-inject-resolve.ts
@@ -6,6 +6,7 @@
 import {
   BindingKey,
   Context,
+  describeInjection,
   inject,
   Injection,
   ResolutionSession,
@@ -24,7 +25,7 @@ const resolve: ResolverFunction = (
   session: ResolutionSession,
 ) => {
   console.log('Context: %s Binding: %s', ctx.name, session.currentBinding!.key);
-  const targetName = ResolutionSession.describeInjection(injection).targetName;
+  const targetName = describeInjection(injection).targetName;
   console.log('Injection: %s', targetName);
   return injection.member === 'prefix' ? new Date().toISOString() : 'John';
 };

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -26,7 +26,11 @@ import {BindingComparator} from './binding-sorter';
 import {BindingCreationPolicy, Context} from './context';
 import {ContextView, createViewGetter} from './context-view';
 import {JSONObject} from './json-types';
-import {ResolutionOptions, ResolutionSession} from './resolution-session';
+import {
+  describeInjection,
+  ResolutionOptions,
+  ResolutionSession,
+} from './resolution-session';
 import {BoundValue, Constructor, ValueOrPromise} from './value-promise';
 
 const INJECT_PARAMETERS_KEY = MetadataAccessor.create<
@@ -410,7 +414,7 @@ export function assertTargetType(
   expectedType: Function,
   expectedTypeName?: string,
 ) {
-  const targetName = ResolutionSession.describeInjection(injection).targetName;
+  const targetName = describeInjection(injection).targetName;
   const targetType = inspectTargetType(injection);
   if (targetType && targetType !== expectedType) {
     expectedTypeName = expectedTypeName ?? expectedType.name;
@@ -744,7 +748,7 @@ export function inspectInjections(binding: Readonly<Binding<unknown>>) {
  * @param injection - Injection information
  */
 function inspectInjection(injection: Readonly<Injection<unknown>>) {
-  const injectionInfo = ResolutionSession.describeInjection(injection);
+  const injectionInfo = describeInjection(injection);
   const descriptor: JSONObject = {};
   if (injectionInfo.targetName) {
     descriptor.targetName = injectionInfo.targetName;

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -130,35 +130,13 @@ export class ResolutionSession {
   }
 
   /**
-   * Describe the injection for debugging purpose
-   * @param injection - Injection object
-   */
-  static describeInjection(
-    injection: Readonly<Injection>,
-  ): InjectionDescriptor {
-    const name = getTargetName(
-      injection.target,
-      injection.member,
-      injection.methodDescriptorOrParameterIndex,
-    );
-    return {
-      targetName: name,
-      bindingSelector: injection.bindingSelector,
-      metadata: injection.metadata,
-    };
-  }
-
-  /**
    * Push the injection onto the session
    * @param injection - Injection The current injection
    */
   pushInjection(injection: Readonly<Injection>) {
     /* istanbul ignore if */
     if (debugSession.enabled) {
-      debugSession(
-        'Enter injection:',
-        ResolutionSession.describeInjection(injection),
-      );
+      debugSession('Enter injection:', describeInjection(injection));
     }
     this.stack.push({type: 'injection', value: injection});
     /* istanbul ignore if */
@@ -179,10 +157,7 @@ export class ResolutionSession {
     const injection = top.value;
     /* istanbul ignore if */
     if (debugSession.enabled) {
-      debugSession(
-        'Exit injection:',
-        ResolutionSession.describeInjection(injection),
-      );
+      debugSession('Exit injection:', describeInjection(injection));
       debugSession('Resolution path:', this.getResolutionPath() || '<empty>');
     }
     return injection;
@@ -289,7 +264,7 @@ export class ResolutionSession {
    */
   getInjectionPath() {
     return this.injectionStack
-      .map(i => ResolutionSession.describeInjection(i).targetName)
+      .map(i => describeInjection(i).targetName)
       .join(' --> ');
   }
 
@@ -307,10 +282,29 @@ export class ResolutionSession {
   }
 }
 
+/**
+ * Describe the injection for debugging purpose
+ * @param injection - Injection object
+ */
+export function describeInjection(
+  injection: Readonly<Injection>,
+): InjectionDescriptor {
+  const name = getTargetName(
+    injection.target,
+    injection.member,
+    injection.methodDescriptorOrParameterIndex,
+  );
+  return {
+    targetName: name,
+    bindingSelector: injection.bindingSelector,
+    metadata: injection.metadata,
+  };
+}
+
 function describe(e: ResolutionElement) {
   switch (e.type) {
     case 'injection':
-      return '@' + ResolutionSession.describeInjection(e.value).targetName;
+      return '@' + describeInjection(e.value).targetName;
     case 'binding':
       return e.value.key;
   }

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -276,6 +276,18 @@ export class ResolutionSession {
   toString() {
     return this.getResolutionPath();
   }
+
+  /**
+   * Describe the injection for debugging purpose
+   *
+   * @TODO remove in next major version
+   *
+   * @param injection - Injection object
+   * @returns {InjectionDescriptor}
+   */
+  static describeInjection(injection: Readonly<Injection>) {
+    return describeInjection(injection);
+  }
 }
 
 /**

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -383,24 +383,21 @@ export interface ResolutionContext<T = unknown> {
  * Error for context binding resolutions and dependency injections
  */
 export class ResolutionError extends Error {
-  constructor(
-    reason: string,
-    readonly resolutionCtx: Partial<ResolutionContext>,
-  ) {
-    super(`${reason} (${ResolutionError.buildMessage(resolutionCtx)})`);
+  constructor(reason: string, readonly ctx: Partial<ResolutionContext>) {
+    super(`${reason} (${ResolutionError.buildMessage(ctx)})`);
     this.name = ResolutionError.name;
   }
 
   /**
    * Build the error message for the resolution to include more contextual data
    * @param reason - Cause of the error
-   * @param resolutionCtx - Resolution context
+   * @param ctx - Resolution context
    */
-  private static buildMessage(resolutionCtx: Partial<ResolutionContext>) {
+  private static buildMessage(ctx: Partial<ResolutionContext>) {
     const details = {
-      context: resolutionCtx.context?.name ?? '',
-      binding: resolutionCtx.binding?.key ?? '',
-      resolutionPath: resolutionCtx.options?.session?.getResolutionPath() ?? '',
+      context: ctx.context?.name ?? '',
+      binding: ctx.binding?.key ?? '',
+      resolutionPath: ctx.options?.session?.getResolutionPath() ?? '',
     };
 
     return Object.entries(details)

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -134,13 +134,11 @@ export class ResolutionSession {
    * @param injection - Injection The current injection
    */
   pushInjection(injection: Readonly<Injection>) {
+    this.stack.push({type: 'injection', value: injection});
+
     /* istanbul ignore if */
     if (debugSession.enabled) {
       debugSession('Enter injection:', describeInjection(injection));
-    }
-    this.stack.push({type: 'injection', value: injection});
-    /* istanbul ignore if */
-    if (debugSession.enabled) {
       debugSession('Resolution path:', this.getResolutionPath());
     }
   }
@@ -190,14 +188,12 @@ export class ResolutionSession {
    * @param binding - Binding
    */
   pushBinding(binding: Readonly<Binding>) {
+    this.checkForCircularDependency(binding);
+    this.stack.push({type: 'binding', value: binding});
+
     /* istanbul ignore if */
     if (debugSession.enabled) {
       debugSession('Enter binding:', binding.toJSON());
-    }
-    this.checkForCircularDependency(binding);
-    this.stack.push({type: 'binding', value: binding});
-    /* istanbul ignore if */
-    if (debugSession.enabled) {
       debugSession('Resolution path:', this.getResolutionPath());
     }
   }

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -372,19 +372,11 @@ export interface ResolutionContext<T = unknown> {
  */
 export class ResolutionError extends Error {
   constructor(
-    message: string,
+    reason: string,
     readonly resolutionCtx: Partial<ResolutionContext>,
   ) {
-    super(ResolutionError.buildMessage(message, resolutionCtx));
+    super(`${reason} (${ResolutionError.buildMessage(resolutionCtx)})`);
     this.name = ResolutionError.name;
-  }
-
-  private static buildDetails(resolutionCtx: Partial<ResolutionContext>) {
-    return {
-      context: resolutionCtx.context?.name ?? '',
-      binding: resolutionCtx.binding?.key ?? '',
-      resolutionPath: resolutionCtx.options?.session?.getResolutionPath() ?? '',
-    };
   }
 
   /**
@@ -392,17 +384,16 @@ export class ResolutionError extends Error {
    * @param reason - Cause of the error
    * @param resolutionCtx - Resolution context
    */
-  private static buildMessage(
-    reason: string,
-    resolutionCtx: Partial<ResolutionContext>,
-  ) {
-    const details = ResolutionError.buildDetails(resolutionCtx);
+  private static buildMessage(resolutionCtx: Partial<ResolutionContext>) {
+    const details = {
+      context: resolutionCtx.context?.name ?? '',
+      binding: resolutionCtx.binding?.key ?? '',
+      resolutionPath: resolutionCtx.options?.session?.getResolutionPath() ?? '',
+    };
 
-    const info = Object.entries(details)
+    return Object.entries(details)
       .filter(([name, val]) => val !== '')
       .map(([name, val]) => `${name}: ${val}`)
       .join(', ');
-
-    return `${reason} (${info})`;
   }
 }

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -396,21 +396,13 @@ export class ResolutionError extends Error {
     reason: string,
     resolutionCtx: Partial<ResolutionContext>,
   ) {
-    const info = this.describeResolutionContext(resolutionCtx);
-    const message = `${reason} (${info})`;
-    return message;
-  }
-
-  private static describeResolutionContext(
-    resolutionCtx: Partial<ResolutionContext>,
-  ) {
     const details = ResolutionError.buildDetails(resolutionCtx);
-    const items: string[] = [];
-    for (const [name, val] of Object.entries(details)) {
-      if (val !== '') {
-        items.push(`${name}: ${val}`);
-      }
-    }
-    return items.join(', ');
+
+    const info = Object.entries(details)
+      .filter(([name, val]) => val !== '')
+      .map(([name, val]) => `${name}: ${val}`)
+      .join(', ');
+
+    return `${reason} (${info})`;
   }
 }

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -219,18 +219,30 @@ export class ResolutionSession {
     if (debugSession.enabled) {
       debugSession('Enter binding:', binding.toJSON());
     }
+    this.checkForCircularDependency(binding);
+    this.stack.push({type: 'binding', value: binding});
+    /* istanbul ignore if */
+    if (debugSession.enabled) {
+      debugSession('Resolution path:', this.getResolutionPath());
+    }
+  }
 
-    if (this.stack.find(i => isBinding(i) && i.value === binding)) {
+  /**
+   * @WIP
+   *
+   * @TODO get rid of an argument by checking
+   *       set.size === array.length instead
+   *       after binding is pushed
+   */
+  checkForCircularDependency(binding: Readonly<Binding>) {
+    const bindinbSet = new Set(this.bindingStack);
+
+    if (bindinbSet.has(binding)) {
       const msg =
         `Circular dependency detected: ` +
         `${this.getResolutionPath()} --> ${binding.key}`;
       debugSession(msg);
       throw new Error(msg);
-    }
-    this.stack.push({type: 'binding', value: binding});
-    /* istanbul ignore if */
-    if (debugSession.enabled) {
-      debugSession('Resolution path:', this.getResolutionPath());
     }
   }
 

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -278,9 +278,8 @@ export class ResolutionSession {
   }
 
   /**
+   * @deprecated
    * Describe the injection for debugging purpose
-   *
-   * @TODO remove in next major version
    *
    * @param injection - Injection object
    * @returns {InjectionDescriptor}

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -199,11 +199,12 @@ export class ResolutionSession {
   }
 
   /**
-   * @WIP
+   * @internalRemarks
+   * #TODO: get rid of an argument by checking
+   *        set.size === array.length instead
+   *        after binding is pushed
    *
-   * @TODO get rid of an argument by checking
-   *       set.size === array.length instead
-   *       after binding is pushed
+   * @experimental
    */
   private checkForCircularDependency(binding: Readonly<Binding>) {
     const bindinbSet = new Set(this.bindingStack);
@@ -278,11 +279,8 @@ export class ResolutionSession {
   }
 
   /**
-   * @deprecated
-   * Describe the injection for debugging purpose
-   *
-   * @param injection - Injection object
-   * @returns {InjectionDescriptor}
+   * {@inheritDoc describeInjection}
+   * @deprecated Use {@link describeInjection} instead.
    */
   static describeInjection(injection: Readonly<Injection>) {
     return describeInjection(injection);

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -4,14 +4,14 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {DecoratorFactory} from '@loopback/metadata';
-import debugModule from 'debug';
+import debugFactory from 'debug';
 import {Binding} from './binding';
 import {BindingSelector} from './binding-filter';
 import {Context} from './context';
 import {Injection, InjectionMetadata} from './inject';
 import {BoundValue, tryWithFinally, ValueOrPromise} from './value-promise';
 
-const debugSession = debugModule('loopback:context:resolver:session');
+const debug = debugFactory('loopback:context:resolver:session');
 const getTargetName = DecoratorFactory.getTargetName;
 
 /**
@@ -137,9 +137,9 @@ export class ResolutionSession {
     this.stack.push({type: 'injection', value: injection});
 
     /* istanbul ignore if */
-    if (debugSession.enabled) {
-      debugSession('Enter injection:', describeInjection(injection));
-      debugSession('Resolution path:', this.getResolutionPath());
+    if (debug.enabled) {
+      debug('Enter injection:', describeInjection(injection));
+      debug('Resolution path:', this.getResolutionPath());
     }
   }
 
@@ -154,9 +154,9 @@ export class ResolutionSession {
 
     const injection = top.value;
     /* istanbul ignore if */
-    if (debugSession.enabled) {
-      debugSession('Exit injection:', describeInjection(injection));
-      debugSession('Resolution path:', this.getResolutionPath() || '<empty>');
+    if (debug.enabled) {
+      debug('Exit injection:', describeInjection(injection));
+      debug('Resolution path:', this.getResolutionPath() || '<empty>');
     }
     return injection;
   }
@@ -192,9 +192,9 @@ export class ResolutionSession {
     this.stack.push({type: 'binding', value: binding});
 
     /* istanbul ignore if */
-    if (debugSession.enabled) {
-      debugSession('Enter binding:', binding.toJSON());
-      debugSession('Resolution path:', this.getResolutionPath());
+    if (debug.enabled) {
+      debug('Enter binding:', binding.toJSON());
+      debug('Resolution path:', this.getResolutionPath());
     }
   }
 
@@ -212,7 +212,7 @@ export class ResolutionSession {
       const msg =
         `Circular dependency detected: ` +
         `${this.getResolutionPath()} --> ${binding.key}`;
-      debugSession(msg);
+      debug(msg);
       throw new Error(msg);
     }
   }
@@ -227,9 +227,9 @@ export class ResolutionSession {
     }
     const binding = top.value;
     /* istanbul ignore if */
-    if (debugSession.enabled) {
-      debugSession('Exit binding:', binding?.toJSON());
-      debugSession('Resolution path:', this.getResolutionPath() || '<empty>');
+    if (debug.enabled) {
+      debug('Exit binding:', binding?.toJSON());
+      debug('Resolution path:', this.getResolutionPath() || '<empty>');
     }
     return binding;
   }

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -205,7 +205,7 @@ export class ResolutionSession {
    *       set.size === array.length instead
    *       after binding is pushed
    */
-  checkForCircularDependency(binding: Readonly<Binding>) {
+  private checkForCircularDependency(binding: Readonly<Binding>) {
     const bindinbSet = new Set(this.bindingStack);
 
     if (bindinbSet.has(binding)) {

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -15,6 +15,7 @@ import {
   Injection,
 } from './inject';
 import {
+  describeInjection,
   ResolutionError,
   ResolutionOptions,
   ResolutionSession,
@@ -129,10 +130,7 @@ function resolve<T>(
 ): ValueOrPromise<T> {
   /* istanbul ignore if */
   if (debug.enabled) {
-    debug(
-      'Resolving an injection:',
-      ResolutionSession.describeInjection(injection),
-    );
+    debug('Resolving an injection:', describeInjection(injection));
   }
 
   ctx = resolveContext(ctx, injection, session);


### PR DESCRIPTION
I think it's reasonable to do changes in small steps. In this batch:

1. describeInjection is now a free function. It's was not related to ResolutionSession. Having it as a free function both looks correct and much more convenient. 
2. debugModule => debugFactory, it is just to unify names across the package. In other files debugFactory is used.
3. Also discovered this grouping:
```ts
    if (debug.enabled) {
      debug('Exit binding:', binding?.toJSON());
      debug('Resolution path:', this.getResolutionPath() || '<empty>');
    }
```

## Checklist

- [+] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [+] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [+] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
