### PR TITLE
feat(cli): updates loopback-connector-grpc

### DIFF
--- a/packages/cli/lib/connectors.json
+++ b/packages/cli/lib/connectors.json
@@ -371,12 +371,18 @@
     },
     "package": {
       "name": "loopback-connector-grpc",
-      "version": "^1.3.0"
+      "version": "^2.0.0"
     },
     "settings": {
+      "host": {
+        "type": "string"
+      },
+      "port": {
+        "type": "number"
+      },
       "spec": {
         "type": "string",
-        "message": "HTTP URL/path to gRPC spec file (file name extension .yaml/.yml or .json)"
+        "message": "HTTP URL/path to gRPC spec file (file name extension .yaml/.yml or .json or .proto)"
       },
       "validate": {
         "type": "boolean",


### PR DESCRIPTION
Signed-off-by: Mario Estrada <marioestradarosa@yahoo.com>

Current the `lb4 datasource` -> `grpc` is forcing the installation of `loopback-connector-grpc` version ^1.3.x, however the latest version is ^2.0.0 . Also it is not asking for two important properties `host` and `port` number in the cli wizard. 

I have created the [gRPC client example](https://github.com/marioestradarosa/loopback-grpc-client-example) with the version ^2.0.0 which I had to update manually and is working fine. 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
