### PR TITLE
fix(doc): fix example for array of number

### DIFF
--- a/docs/site/LoopBack-types.md
+++ b/docs/site/LoopBack-types.md
@@ -149,7 +149,7 @@ The following are examples of how you can define array type properties:
     type: 'array',
     itemType: 'number',
   })
-  numAry?: number[]; // e.g ['42', '998', '1']
+  numAry?: number[]; // e.g [42, 998, 1]
 
   @property({
     type: 'array',


### PR DESCRIPTION
the example is showing the array of string instead of the array of number
