### PR TITLE
docs: fix doc typo

### DIFF
--- a/docs/site/DEVELOPING.md
+++ b/docs/site/DEVELOPING.md
@@ -75,7 +75,7 @@ npm ci
 ```
 
 As part of `npm ci` or `npm i`, TypeScript project references are automatically
-updated for each package with in the monorepo.
+updated for each package within the monorepo.
 
 The next step is to compile all packages from TypeScript to JavaScript:
 
@@ -213,7 +213,7 @@ We use two tools to keep our codebase healthy:
 - [ESLint](https://typescript-eslint.io/) to statically analyse our source code
   and detect common problems.
 - [Prettier](https://prettier.io/) to keep our code always formatted the same
-  way, avoid style discussions in code reviews, and save everybody's time an
+  way, avoid style discussions in code reviews, and save everybody's time and
   energy.
 
 You can run both linters via the following npm script, just keep in mind that


### PR DESCRIPTION
Signed-off-by: Thanakrit Lee <thanakrit.lee.2014@gmail.com>

Fix minor typo in documentation.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated