### PR TITLE
refactor(graphql): pass playground config via app bindings

### DIFF
--- a/extensions/graphql/README.md
+++ b/extensions/graphql/README.md
@@ -101,6 +101,7 @@ config, such as:
 const app = new Application({
   graphql: {
     asMiddlewareOnly: true,
+    enablePlayground: false, // to disable playground
   },
 });
 ```

--- a/extensions/graphql/src/__tests__/unit/graphql.component.unit.ts
+++ b/extensions/graphql/src/__tests__/unit/graphql.component.unit.ts
@@ -19,11 +19,13 @@ describe('GraphQL component', () => {
     const app = new Application({
       graphql: {
         asMiddlewareOnly: true,
+        enablePlayground: true,
       },
     });
     app.component(GraphQLComponent);
     expect(app.getConfigSync(GraphQLBindings.GRAPHQL_SERVER)).to.eql({
       asMiddlewareOnly: true,
+      enablePlayground: true,
     });
   });
 

--- a/extensions/graphql/src/graphql.server.ts
+++ b/extensions/graphql/src/graphql.server.ts
@@ -149,8 +149,8 @@ export class GraphQLServer extends Context implements Server {
 
     // Create ApolloServerExpress GraphQL server
     const serverConfig: ApolloServerExpressConfig = {
-      // enable GraphQL Playground
-      playground: true,
+      // enable GraphQL Playground unless configured otherwise
+      playground: this.options?.enablePlayground ?? true,
       context: graphqlContextResolver,
       subscriptions: false,
       ...this.options.apollo,

--- a/extensions/graphql/src/types.ts
+++ b/extensions/graphql/src/types.ts
@@ -44,4 +44,8 @@ export interface GraphQLServerOptions extends HttpOptions {
    * Use as a middleware for RestServer instead of a standalone server
    */
   asMiddlewareOnly?: boolean;
+  /**
+   * Enable or disable graphql playground
+   */
+  enablePlayground?: boolean;
 }


### PR DESCRIPTION
Signed-off-by: mrmodise <modisemorebodi@gmail.com>

Resolves an issue whereby playground is not disabled even when NODE_ENV is set to production. The value defaults to true unless provided otherwise
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
