### PR TITLE
test: increase timeout

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -8,6 +8,7 @@ const defaultConfig = require('./packages/build/config/.mocharc.json');
 
 const MONOREPO_CONFIG = {
   parallel: true,
+  timeout: 10000,
 };
 
 module.exports = mergeMochaConfigs(


### PR DESCRIPTION
The macOS tests are timing out every 5-10 runs. Increasing the timeout to monitor for improvements.

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
