### PR TITLE
proposal: optionally support lb-ttsc, for ttypescript

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
 npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-if [ "$LINT_STAGED" == "0" ]; then
+if [ "$LINT_STAGED" = "0" ]; then
   echo "lint-staged disabled via LINT_STAGED env var"
 else
   npx --no-install lint-staged

--- a/packages/build/bin/compile-package.js
+++ b/packages/build/bin/compile-package.js
@@ -34,6 +34,11 @@ function run(argv, options) {
 
   const packageDir = utils.getPackageDir();
 
+  const runnerName = argv[1];
+  const TSC_CLI = runnerName.includes('lb-ttsc')
+    ? 'ttypescript/lib/tsc'
+    : 'typescript/lib/tsc';
+  debug(`Using ${TSC_CLI} to compile package`);
   const compilerOpts = argv.slice(2);
 
   const isTargetSet = utils.isOptionSet(compilerOpts, '--target');
@@ -138,7 +143,7 @@ function run(argv, options) {
 
   const validArgs = validArgsForBuild(args);
 
-  return utils.runCLI('typescript/lib/tsc', validArgs, {cwd, ...options});
+  return utils.runCLI(TSC_CLI, validArgs, {cwd, ...options});
 }
 
 /**

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -30,7 +30,8 @@
 				"lb-mocha": "bin/run-mocha.js",
 				"lb-nyc": "bin/run-nyc.js",
 				"lb-prettier": "bin/run-prettier.js",
-				"lb-tsc": "bin/compile-package.js"
+				"lb-tsc": "bin/compile-package.js",
+				"lb-ttsc": "bin/compile-package.js"
 			},
 			"engines": {
 				"node": "^10.16 || 12 || 14 || 16"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "bin": {
     "lb-tsc": "./bin/compile-package.js",
+    "lb-ttsc": "./bin/compile-package.js",
     "lb-eslint": "./bin/run-eslint.js",
     "lb-prettier": "./bin/run-prettier.js",
     "lb-mocha": "./bin/run-mocha.js",


### PR DESCRIPTION

This PR provides two things:
- :heavy_plus_sign: Fixes the `.husky/pre-commit: 4: [: unexpected operator` error on commit
- :heavy_plus_sign: Provides an optional `lb-ttsc` entry to allow consumers to optionally use `ttypescript` (to support things like `ts-auto-mock` in testing)

Signed-off-by: Matt <i.am@matthew.engineer>


### Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated