### PR TITLE
fix: make sure json schema ref is built correctly for the subclass

### DIFF
--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -16,6 +16,7 @@ import {
 import {expect} from '@loopback/testlab';
 import {
   buildModelCacheKey,
+  getJsonSchemaRef,
   getNavigationalPropertyForRelation,
   JsonSchema,
   metaToJsonProperty,
@@ -645,6 +646,46 @@ describe('build-schema', () => {
     it('includes custom title', () => {
       const key = buildModelCacheKey({title: 'NewProduct', partial: true});
       expect(key).to.equal('modelNewProductPartial');
+    });
+  });
+
+  describe('getJsonSchemaRef', () => {
+    @model()
+    class Base {
+      @property()
+      name: string;
+    }
+
+    @model()
+    class Sub extends Base {
+      @property()
+      age: number;
+    }
+    it('allows subclasses', () => {
+      const base = getJsonSchemaRef(Base);
+      expect(base).to.eql({
+        $ref: '#/definitions/Base',
+        definitions: {
+          Base: {
+            title: 'Base',
+            type: 'object',
+            properties: {name: {type: 'string'}},
+            additionalProperties: false,
+          },
+        },
+      });
+      const sub = getJsonSchemaRef(Sub);
+      expect(sub).to.eql({
+        $ref: '#/definitions/Sub',
+        definitions: {
+          Sub: {
+            title: 'Sub',
+            type: 'object',
+            properties: {name: {type: 'string'}, age: {type: 'number'}},
+            additionalProperties: false,
+          },
+        },
+      });
     });
   });
 });

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -120,7 +120,9 @@ export function getJsonSchema<T extends object>(
 ): JsonSchema {
   // In the near future the metadata will be an object with
   // different titles as keys
-  const cached = MetadataInspector.getClassMetadata(JSON_SCHEMA_KEY, ctor);
+  const cached = MetadataInspector.getClassMetadata(JSON_SCHEMA_KEY, ctor, {
+    ownMetadataOnly: true,
+  });
   const key = buildModelCacheKey(options);
   let schema = cached?.[key];
 


### PR DESCRIPTION
If we have a Sub model that extends from Base, and we call
getJsonSchemaRef(Base) before getJsonSchemaRef(Sub), the base schema
is returned as we have base json schema cached at the base class.

This PR makes sure each class has its own cache for json schema.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
