### PR TITLE
fix(openapi-v3): allow classes decorated with `@model` as response model

### DIFF
--- a/packages/openapi-v3/src/__tests__/unit/decorators/response.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/response.decorator.unit.ts
@@ -52,12 +52,29 @@ describe('@oas.response decorator', () => {
       bar: string;
     }
 
+    @model()
+    class Base {
+      @property()
+      name: string;
+    }
+
     const successSchema: ResponseObject = {
       description: httpStatus['200'],
       content: {
         'application/json': {
           schema: {
             $ref: '#/components/schemas/SuccessModel',
+          },
+        },
+      },
+    };
+
+    const baseSchema: ResponseObject = {
+      description: httpStatus['200'],
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Base',
           },
         },
       },
@@ -93,6 +110,20 @@ describe('@oas.response decorator', () => {
       expect(
         actualSpec.components?.schemas?.SuccessModel,
       ).to.not.be.undefined();
+    });
+
+    it('supports @oas.response for a model class not extending Model', () => {
+      class MyController {
+        @get('/greet')
+        @oas.response(200, Base)
+        greet() {
+          return new Base();
+        }
+      }
+
+      const actualSpec = getControllerSpec(MyController);
+      expect(actualSpec.paths['/greet'].get.responses[200]).to.eql(baseSchema);
+      expect(actualSpec.components?.schemas?.Base).to.not.be.undefined();
     });
 
     it('supports multiple @oas.response decorators on a method', () => {

--- a/packages/openapi-v3/src/build-responses-from-metadata.ts
+++ b/packages/openapi-v3/src/build-responses-from-metadata.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {DecoratorFactory} from '@loopback/core';
-import {Model} from '@loopback/repository';
+import {DecoratorFactory, MetadataInspector} from '@loopback/core';
+import {Model, MODEL_KEY} from '@loopback/repository';
 import {
   ContentObject,
   OperationObject,
@@ -21,7 +21,11 @@ declare type ResponseMap = Map<
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isModel<T extends Model>(c: any): c is T {
-  return c?.prototype instanceof Model;
+  return (
+    c?.prototype instanceof Model ||
+    // Allowing classes decorated with `@model` but not extending from `Model`
+    MetadataInspector.getClassMetadata(MODEL_KEY, c) != null
+  );
 }
 
 /**


### PR DESCRIPTION
If a class is decorated with `@model` but not extending `Model`, it is not
honored by `@response` currently.


Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
