### PR TITLE
chore: export socketio types

### DIFF
--- a/extensions/socketio/src/index.ts
+++ b/extensions/socketio/src/index.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+export * from 'socket.io';
 export * from './booters';
 export * from './decorators';
 export * from './keys';
@@ -13,4 +14,3 @@ export * from './socketio.component';
 export * from './socketio.sequence';
 export * from './socketio.server';
 export * from './types';
-export {Socket} from 'socket.io';


### PR DESCRIPTION
Allow user to use types without install socket.io dependency on own project.

Signed-off-by: Matteo Padovano <mrbatista@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
