### PR TITLE
feat: allow context view to return proxies

### DIFF
--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -441,12 +441,14 @@ export class Context extends EventEmitter {
    * Create a view of the context chain with the given binding filter
    * @param filter - A function to match bindings
    * @param comparator - A function to sort matched bindings
+   * @param options - Resolution options
    */
   createView<T = unknown>(
     filter: BindingFilter,
     comparator?: BindingComparator,
+    options?: Omit<ResolutionOptions, 'session'>,
   ) {
-    const view = new ContextView<T>(this, filter, comparator);
+    const view = new ContextView<T>(this, filter, comparator, options);
     view.open();
     return view;
   }

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -67,7 +67,7 @@ export interface ResolverFunction {
 /**
  * An object to provide metadata for `@inject`
  */
-export interface InjectionMetadata extends ResolutionOptions {
+export interface InjectionMetadata extends Omit<ResolutionOptions, 'session'> {
   /**
    * Name of the decorator function, such as `@inject` or `@inject.setter`.
    * It's usually set by the decorator implementation.

--- a/packages/core/src/__tests__/acceptance/extension-point.acceptance.ts
+++ b/packages/core/src/__tests__/acceptance/extension-point.acceptance.ts
@@ -16,6 +16,7 @@ import {
   MetadataInspector,
 } from '@loopback/context';
 import {expect} from '@loopback/testlab';
+import {types} from 'util';
 import {
   addExtension,
   CoreTags,
@@ -187,6 +188,18 @@ describe('extension point', () => {
       const greeterService = await ctx.get<GreetingService>('greeter-service');
       const greeters = await greeterService.greeters();
       assertGreeterExtensions(greeters);
+    });
+
+    it('injects extensions with metadata', async () => {
+      class GreetingService {
+        @extensions('greeters', {asProxyWithInterceptors: true})
+        public greeters: Getter<Greeter[]>;
+      }
+      ctx.bind('greeter-service').toClass(GreetingService);
+      registerGreeters('greeters');
+      const greeterService = await ctx.get<GreetingService>('greeter-service');
+      const greeters = await greeterService.greeters();
+      greeters.forEach(g => expect(types.isProxy(g)).to.be.true());
     });
 
     it('injects multiple types of extensions', async () => {

--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.unit.ts
@@ -96,7 +96,7 @@ describe('RestServer', () => {
 
     it('honors gracePeriodForClose', async () => {
       const app = new Application({
-        rest: {gracePeriodForClose: 1000},
+        rest: {port: 0, gracePeriodForClose: 1000},
       });
       app.component(RestComponent);
       const server = await app.getServer(RestServer);


### PR DESCRIPTION
This PR allows resolution options to be set on ContextView and related injectors. The main use case is to allow extension point
to receive a list of proxies for extensions.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
