### PR TITLE
test: fix `principal` typo

### DIFF
--- a/packages/security/src/__tests__/unit/principal.unit.ts
+++ b/packages/security/src/__tests__/unit/principal.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019. All Rights Reserved.
+// Copyright IBM Corp. 2019,2021. All Rights Reserved.
 // Node module: @loopback/security
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
@@ -6,7 +6,7 @@
 import {expect} from '@loopback/testlab';
 import {Principal, securityId, TypedPrincipal} from '../..';
 
-describe('typed principle', () => {
+describe('typed principal', () => {
   it('returns the security id', () => {
     const principal: Principal = {[securityId]: 'auser'};
     const typedPrincipal = new TypedPrincipal(principal, 'USER');


### PR DESCRIPTION
Found a minor typo in the tests while browsing the source code.

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
