### PR TITLE
docs(graphql): bind graphql middleware to graphql server vs http rest…

### DIFF
--- a/examples/graphql/src/application.ts
+++ b/examples/graphql/src/application.ts
@@ -20,7 +20,14 @@ export class GraphqlDemoApplication extends BootMixin(
     super(options);
 
     this.component(GraphQLComponent);
+
     const server = this.getSync(GraphQLBindings.GRAPHQL_SERVER);
+    // To register one or more middlewares as per https://typegraphql.com/docs/middlewares.html
+    server.middleware((resolverData, next) => {
+      // It's invoked for each field resolver, query and mutation operations
+      return next();
+    });
+
     this.expressMiddleware('middleware.express.GraphQL', server.expressApp);
 
     // It's possible to register a graphql context resolver

--- a/extensions/graphql/README.md
+++ b/extensions/graphql/README.md
@@ -384,8 +384,11 @@ export class GraphqlDemoApplication extends BootMixin(
   constructor(options: ApplicationConfig = {}) {
     super(options);
 
+    const server = this.getSync(GraphQLBindings.GRAPHQL_SERVER);
+    this.expressMiddleware('middleware.express.GraphQL', server.expressApp);
+
     // Register a GraphQL middleware
-    this.middleware((resolverData, next) => {
+    server.middleware((resolverData, next) => {
       // It's invoked for each field resolver, query and mutation operations
       return next();
     });


### PR DESCRIPTION
… server

Signed-off-by: mrmodise <modisemorebodi@gmail.com>

This PR fixes a minor issue on the documentation whereby the middleware bindings are done against the LoopBack server instead of GraphQL server.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
