### PR TITLE
feat: adding polymorphic relations support for models

### DIFF
--- a/docs/site/Polymorphic-relations.md
+++ b/docs/site/Polymorphic-relations.md
@@ -1,0 +1,123 @@
+---
+lang: en
+title: 'hasManyThrough Relation'
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Model Relation
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/HasManyThrough-relation.html
+---
+
+## Overview
+
+LoopBack supports _polymorphic relations_ in which a model can belong to more
+than one other model, on a single association.
+
+The examples below use the following example models: `Delivery`, `Letter`,
+`Parcel`, where a `Delivery` may contain a `Deliverable` - either a `Letter` or
+a `Parcel`.
+
+## Model definition
+
+We first define `Deliverable`s:
+
+```javascript
+class Deliverable extends Entity {
+}
+
+class Letter extends Deliverable {
+}
+
+class Parcel extends Deliverable {
+}
+...
+```
+
+The relation between the `Delivery` and `Deliverable`s is: `Delivery` `hasOne`
+`Deliverable`; the relation is polymorphic.
+
+```javascript
+class Delivery extends Entity {
+@hasOne(() => Deliverable, {polymorphic: true})
+  deliverable: Deliverable;
+
+deliverableType: string;
+}
+...
+```
+
+A customized discriminator can be specified. The discriminator parameter
+specifies the name of a field in the model indicating the actual type of the
+`Deliverable`.
+
+```javascript
+class Delivery extends Entity {
+@hasOne(() => Deliverable, {polymorphic: {discriminator: "deliverable_type"}})
+  deliverable: Deliverable;
+
+deliverable_type: string;
+}
+...
+```
+
+## Setting up repository
+
+The only difference on the repository class is that instead of having a single
+repository getter, a dictionary of subclass repository getters is passed into
+the repository factory creater.
+
+```javascript
+export class DeliveryRepository extends DefaultCrudRepository {
+  public readonly deliverable: HasOneRepositoryFactory<Deliverable, typeof Delivery.prototype.id>;
+
+  constructor(
+    dataSource: juggler.DataSource,
+    @repository.getter('LetterRepository')
+    protected letterRepositoryGetter: Getter<EntityCrudRepository<Deliverable, typeof Deliverable.prototype.id, DeliverableRelations>>,
+    @repository.getter('ParcelRepository')
+    protected parcelRepositoryGetter: Getter<EntityCrudRepository<Deliverable, typeof Deliverable.prototype.id, DeliverableRelations>>,
+  ) {
+    super(Delivery, dataSource);
+    this.deliverable = this.createHasOneRepositoryFactoryFor(
+      'deliverable',
+      // use a dictionary of repoGetters instead of a single repoGetter instance
+      {Letter: letterRepositoryGetter, Parcel: parcelRepositoryGetter},
+    );
+    this.registerInclusionResolver('deliverable', this.deliverable.inclusionResolver);
+  }
+}
+...
+```
+
+## Operations
+
+The polymorphic relation supports queries with inclusions
+
+```javascript
+const result = await deliveryRepo.findById(delivery1.id, {
+  include: ['deliverable'],
+});
+...
+```
+
+The instances of polymorphic relations can be created through repository
+operations
+
+```javascript
+deliveryRepo
+.deliverable(deliveryId)
+.create(letter1Data, {polymorphicType: "Letter"});
+...
+```
+
+## belongsTo, hasMany, hasManyThrough relations
+
+Polymorphic relation on `belongsTo` is similar to `hasOne`.
+
+Polymorphic relation is not supported on `hasMany` relations. However, there is
+an easy workaround: having a `hasMany` relation on a non-polymorphic concrete
+type which `hasOne` polymorphic relation with an abstract polymorphic type. For
+example, `Delivery` `hasMany` `DeliveryDeliverablePair` and
+`DeliveryDeliverablePair` `hasOne` `Deliverable`.
+
+The polymorphic relation on `hasManyThrough` relation is on the target model,
+not the through model. The discriminator is defined on the through model, and
+the target model is polymorphic.

--- a/packages/filter/src/query.ts
+++ b/packages/filter/src/query.ts
@@ -174,6 +174,8 @@ export type Fields<MT = AnyObject> =
 export interface Inclusion {
   relation: string;
 
+  targetType?: string;
+
   // Technically, we should restrict the filter to target model.
   // That is unfortunately rather difficult to achieve, because
   // an Entity does not provide type information about related models.

--- a/packages/repository-tests/src/crud/relations/acceptance/belongs-to.inclusion-resolver.polymorphic.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/belongs-to.inclusion-resolver.polymorphic.relation.acceptance.ts
@@ -1,0 +1,221 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect, skipIf, toJSON} from '@loopback/testlab';
+import {Suite} from 'mocha';
+import {
+  CrudFeatures,
+  CrudRepositoryCtor,
+  CrudTestContext,
+  DataSourceOptions,
+} from '../../..';
+import {
+  deleteAllModelsInDefaultDataSource,
+  withCrudCtx,
+} from '../../../helpers.repository-tests';
+import {
+  Contact,
+  ContactRepository,
+  Customer,
+  CustomerRepository,
+  Supplier,
+  SupplierRepository,
+} from '../fixtures/models';
+import {givenBoundCrudRepositories} from '../helpers';
+
+export function belongsToInclusionResolverPolymorphicAcceptance(
+  dataSourceOptions: DataSourceOptions,
+  repositoryClass: CrudRepositoryCtor,
+  features: CrudFeatures,
+) {
+  skipIf<[(this: Suite) => void], void>(
+    !features.supportsInclusionResolvers,
+    describe,
+    'BelongsTo inclusion resolvers - polymorphic - acceptance',
+    suite,
+  );
+  function suite() {
+    before(deleteAllModelsInDefaultDataSource);
+    let customerRepo: CustomerRepository;
+    let supplierRepo: SupplierRepository;
+    let contactRepo: ContactRepository;
+
+    before(
+      withCrudCtx(async function setupRepository(ctx: CrudTestContext) {
+        // this helper should create the inclusion resolvers and also
+        // register inclusion resolvers for us
+        ({customerRepo, supplierRepo, contactRepo} = givenBoundCrudRepositories(
+          ctx.dataSource,
+          repositoryClass,
+          features,
+        ));
+        expect(customerRepo.contact.inclusionResolver).to.be.Function();
+        expect(supplierRepo.contact.inclusionResolver).to.be.Function();
+        expect(contactRepo.stakeholder.inclusionResolver).to.be.Function();
+
+        await ctx.dataSource.automigrate([
+          Customer.name,
+          Supplier.name,
+          Contact.name,
+        ]);
+      }),
+    );
+
+    beforeEach(async () => {
+      await customerRepo.deleteAll();
+      await supplierRepo.deleteAll();
+      await contactRepo.deleteAll();
+    });
+
+    it('throws an error if it tries to query nonexistent relation names', async () => {
+      const customer = await customerRepo.create({name: 'customer'});
+      await contactRepo.create({
+        stakeholderId: customer.id,
+      });
+      await expect(
+        contactRepo.find({include: ['shipment']}),
+      ).to.be.rejectedWith(`Invalid "filter.include" entries: "shipment"`);
+    });
+
+    it('returns single model instance including single related instance', async () => {
+      const thor = await customerRepo.create({name: 'Thor'});
+      const contact = await contactRepo.create({
+        stakeholderId: thor.id,
+      });
+      const result = await contactRepo.find({
+        include: ['stakeholder'],
+      });
+
+      const expected = {
+        ...contact,
+        isShipped: features.emptyValue,
+        shipmentInfo: features.emptyValue,
+        stakeholder: {
+          ...thor,
+          parentId: features.emptyValue,
+        },
+      };
+      expect(toJSON(result)).to.deepEqual([toJSON(expected)]);
+    });
+
+    it('returns multiple model instances including related instances', async () => {
+      const thor = await customerRepo.create({
+        name: 'Thor',
+        paymentMethodType: 'CreditCard',
+      });
+      const odin = await supplierRepo.create({name: 'Odin'});
+      const thorContact = await contactRepo.create({
+        stakeholderId: thor.id,
+      });
+      const odinContact = await contactRepo.create({
+        stakeholderId: odin.id,
+        stakeholderType: 'Supplier',
+      });
+
+      const result = await contactRepo.find({
+        include: ['stakeholder'],
+      });
+
+      const expected = [
+        {
+          ...thorContact,
+          isShipped: features.emptyValue,
+          shipmentInfo: features.emptyValue,
+          stakeholder: {
+            ...thor,
+            parentId: features.emptyValue,
+          },
+        },
+        {
+          ...odinContact,
+          isShipped: features.emptyValue,
+          shipmentInfo: features.emptyValue,
+          stakeholder: {
+            ...odin,
+            parentId: features.emptyValue,
+          },
+        },
+      ];
+      expect(toJSON(result)).to.deepEqual(toJSON(expected));
+    });
+
+    it('returns a specified instance including its related model instances', async () => {
+      const thor = await customerRepo.create({name: 'Thor'});
+      const odin = await supplierRepo.create({name: 'Odin'});
+      const bella = await supplierRepo.create({name: 'Bella'});
+      await contactRepo.create({
+        stakeholderId: thor.id,
+      });
+      await contactRepo.create({
+        stakeholderId: bella.id,
+        stakeholderType: 'Supplier',
+      });
+      const odinContact = await contactRepo.create({
+        stakeholderId: odin.id,
+        stakeholderType: 'Supplier',
+      });
+
+      const result = await contactRepo.findById(odinContact.id, {
+        include: ['stakeholder'],
+      });
+      const expected = {
+        ...odinContact,
+        isShipped: features.emptyValue,
+        shipmentInfo: features.emptyValue,
+        stakeholder: {
+          ...odin,
+          parentId: features.emptyValue,
+        },
+      };
+      expect(toJSON(result)).to.deepEqual(toJSON(expected));
+    });
+
+    it('queries entities with null foreign key', async () => {
+      const customer = await customerRepo.create({
+        name: 'Thor',
+      });
+
+      const contact1 = await contactRepo.create({
+        stakeholderId: customer.id,
+      });
+
+      const contact2 = await contactRepo.create({});
+
+      const expected = [
+        {
+          ...contact1,
+          isShipped: features.emptyValue,
+          shipmentInfo: features.emptyValue,
+          stakeholder: {
+            ...customer,
+            parentId: features.emptyValue,
+          },
+        },
+        {
+          ...contact2,
+          stakeholderId: features.emptyValue,
+          isShipped: features.emptyValue,
+          shipmentInfo: features.emptyValue,
+        },
+      ];
+
+      const result = await contactRepo.find({include: ['stakeholder']});
+      expect(toJSON(result)).to.deepEqual(toJSON(expected));
+    });
+
+    it('throws error if the target repository does not have the registered resolver', async () => {
+      const customer = await customerRepo.create({name: 'customer'});
+      await contactRepo.create({
+        stakeholderId: customer.id,
+      });
+      // unregister the resolver
+      contactRepo.inclusionResolvers.delete('stakeholder');
+
+      await expect(
+        contactRepo.find({include: ['stakeholder']}),
+      ).to.be.rejectedWith(`Invalid "filter.include" entries: "stakeholder"`);
+    });
+  }
+}

--- a/packages/repository-tests/src/crud/relations/acceptance/belongs-to.polymorphic.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/belongs-to.polymorphic.relation.acceptance.ts
@@ -1,0 +1,88 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect, toJSON} from '@loopback/testlab';
+import {
+  deleteAllModelsInDefaultDataSource,
+  withCrudCtx,
+} from '../../../helpers.repository-tests';
+import {
+  CrudFeatures,
+  CrudRepositoryCtor,
+  CrudTestContext,
+  DataSourceOptions,
+} from '../../../types.repository-tests';
+import {
+  Contact,
+  ContactRepository,
+  Customer,
+  CustomerRepository,
+  Supplier,
+  SupplierRepository,
+} from '../fixtures/models';
+import {givenBoundCrudRepositories} from '../helpers';
+
+export function belongsToRelationPolymorphicAcceptance(
+  dataSourceOptions: DataSourceOptions,
+  repositoryClass: CrudRepositoryCtor,
+  features: CrudFeatures,
+) {
+  describe('BelongsTo relation (acceptance)', () => {
+    before(deleteAllModelsInDefaultDataSource);
+
+    let customerRepo: CustomerRepository;
+    let supplierRepo: SupplierRepository;
+    let contactRepo: ContactRepository;
+
+    before(
+      withCrudCtx(async function setupRepository(ctx: CrudTestContext) {
+        ({customerRepo, supplierRepo, contactRepo} = givenBoundCrudRepositories(
+          ctx.dataSource,
+          repositoryClass,
+          features,
+        ));
+        const models = [Customer, Supplier, Contact];
+        await ctx.dataSource.automigrate(models.map(m => m.name));
+      }),
+    );
+    beforeEach(async () => {
+      await contactRepo.deleteAll();
+    });
+
+    it('can find customer from contact', async () => {
+      const customer = await customerRepo.create({
+        name: 'McForder customer',
+      });
+      const contact = await contactRepo.create({
+        stakeholderId: customer.id,
+        stakeholderType: 'Customer',
+      });
+
+      const result = await contactRepo.stakeholder(contact.id, 'Customer');
+      // adding parentId to customer so MySQL doesn't complain about null vs
+      // undefined
+      expect(toJSON(result)).to.deepEqual(
+        toJSON({...customer, parentId: features.emptyValue}),
+      );
+    });
+
+    it('can find supplier from contact', async () => {
+      const supplier = await supplierRepo.create({
+        name: 'McForder supplier',
+      });
+      const contact = await contactRepo.create({
+        stakeholderId: supplier.id,
+        stakeholderType: 'Supplier',
+      });
+
+      const result = await contactRepo.stakeholder(contact.id, 'Supplier');
+      // adding parentId to customer so MySQL doesn't complain about null vs
+      // undefined
+      expect(toJSON(result)).to.deepEqual(
+        toJSON({...supplier, parentId: features.emptyValue}),
+      );
+    });
+  });
+}

--- a/packages/repository-tests/src/crud/relations/acceptance/has-many-through-inclusion-resolver.polymorphic.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-many-through-inclusion-resolver.polymorphic.acceptance.ts
@@ -1,0 +1,255 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect, skipIf, toJSON} from '@loopback/testlab';
+import {Suite} from 'mocha';
+import {
+  CrudFeatures,
+  CrudRepositoryCtor,
+  CrudTestContext,
+  DataSourceOptions,
+} from '../../..';
+import {
+  deleteAllModelsInDefaultDataSource,
+  withCrudCtx,
+} from '../../../helpers.repository-tests';
+import {
+  Customer,
+  CustomerPromotionLink,
+  CustomerPromotionLinkRepository,
+  CustomerRepository,
+  FreeDelivery,
+  FreeDeliveryRepository,
+  HalfPrice,
+  HalfPriceRepository,
+} from '../fixtures/models';
+import {givenBoundCrudRepositories} from '../helpers';
+
+export function hasManyThroughInclusionResolverPolymorphicAcceptance(
+  dataSourceOptions: DataSourceOptions,
+  repositoryClass: CrudRepositoryCtor,
+  features: CrudFeatures,
+) {
+  skipIf<[(this: Suite) => void], void>(
+    !features.supportsInclusionResolvers,
+    describe,
+    'HasManyThrough inclusion resolvers - polymorphic - acceptance',
+    suite,
+  );
+  function suite() {
+    describe('HasManyThrough inclusion resolver', () => {
+      before(deleteAllModelsInDefaultDataSource);
+      let customerRepo: CustomerRepository;
+      let freeDeliveryRepo: FreeDeliveryRepository;
+      let halfPriceRepo: HalfPriceRepository;
+      let customerPromotionLinkRepo: CustomerPromotionLinkRepository;
+
+      before(
+        withCrudCtx(async function setupRepository(ctx: CrudTestContext) {
+          // this helper should create the inclusion resolvers and also
+          // register inclusion resolvers for us
+          ({
+            customerRepo,
+            freeDeliveryRepo,
+            halfPriceRepo,
+            customerPromotionLinkRepo,
+          } = givenBoundCrudRepositories(
+            ctx.dataSource,
+            repositoryClass,
+            features,
+          ));
+          expect(customerRepo.promotions.inclusionResolver).to.be.Function();
+
+          await ctx.dataSource.automigrate([
+            Customer.name,
+            FreeDelivery.name,
+            HalfPrice.name,
+            CustomerPromotionLink.name,
+          ]);
+        }),
+      );
+
+      beforeEach(async () => {
+        await customerRepo.deleteAll();
+        await freeDeliveryRepo.deleteAll();
+        await halfPriceRepo.deleteAll();
+        await customerPromotionLinkRepo.deleteAll();
+      });
+
+      it('throws an error if tries to query nonexistent relation names', async () => {
+        const customer = await customerRepo.create({name: 'customer'});
+        await customerRepo
+          .promotions(customer.id)
+          .create({description: 'crown'}, {polymorphicType: 'HalfPrice'});
+
+        await expect(
+          customerRepo.find({include: ['crown']}),
+        ).to.be.rejectedWith(`Invalid "filter.include" entries: "crown"`);
+      });
+
+      it('returns single model instance including single related instance', async () => {
+        const zelda = await customerRepo.create({name: 'Zelda'});
+        const freeDelivery = await customerRepo.promotions(zelda.id).create(
+          {description: 'crown'},
+          {
+            throughData: {promotiontype: 'FreeDelivery'},
+            polymorphicType: 'FreeDelivery',
+          },
+        );
+
+        const result = await customerRepo.find({
+          include: ['promotions'],
+        });
+
+        expect(toJSON(result)).to.deepEqual([
+          toJSON({
+            ...zelda,
+            parentId: features.emptyValue,
+            promotions: [freeDelivery],
+          }),
+        ]);
+      });
+
+      it('returns multiple model instances including related instances', async () => {
+        const link = await customerRepo.create({name: 'Link'});
+        const halfPrice = await customerRepo.promotions(link.id).create(
+          {description: 'halfPrice'},
+          {
+            throughData: {promotiontype: 'HalfPrice'},
+            polymorphicType: 'HalfPrice',
+          },
+        );
+        const freeDelivery = await customerRepo.promotions(link.id).create(
+          {description: 'freeDelivery'},
+          {
+            throughData: {promotiontype: 'FreeDelivery'},
+            polymorphicType: 'FreeDelivery',
+          },
+        );
+        const freeDelivery2 = await customerRepo.promotions(link.id).create(
+          {description: 'freeDelivery 2'},
+          {
+            throughData: {promotiontype: 'FreeDelivery'},
+            polymorphicType: 'FreeDelivery',
+          },
+        );
+
+        const result = await customerRepo.find({
+          include: ['promotions'],
+        });
+
+        const expected = [
+          {
+            ...link,
+            parentId: features.emptyValue,
+            promotions: [halfPrice, freeDelivery, freeDelivery2],
+          },
+        ];
+
+        expect(toJSON(result)).to.deepEqual(toJSON(expected));
+      });
+
+      it('returns a specified instance including its related model instances', async () => {
+        const link = await customerRepo.create({name: 'Link'});
+        const zelda = await customerRepo.create({name: 'Zelda'});
+
+        await customerRepo.promotions(link.id).create(
+          {description: 'crown'},
+          {
+            throughData: {promotiontype: 'HalfPrice'},
+            polymorphicType: 'HalfPrice',
+          },
+        );
+        const zeldaPromotion1 = await customerRepo.promotions(zelda.id).create(
+          {description: 'shield'},
+          {
+            throughData: {promotiontype: 'FreeDelivery'},
+            polymorphicType: 'FreeDelivery',
+          },
+        );
+        const zeldaPromotion2 = await customerRepo.promotions(zelda.id).create(
+          {description: 'green hat'},
+          {
+            throughData: {promotiontype: 'FreeDelivery'},
+            polymorphicType: 'FreeDelivery',
+          },
+        );
+
+        const result = await customerRepo.findById(zelda.id, {
+          include: ['promotions'],
+        });
+        const expected = {
+          ...zelda,
+          parentId: features.emptyValue,
+          promotions: [zeldaPromotion1, zeldaPromotion2],
+        };
+        expect(toJSON(result)).to.deepEqual(toJSON(expected));
+      });
+
+      it('honours field scope when returning a model', async () => {
+        const link = await customerRepo.create({name: 'Link'});
+        const zelda = await customerRepo.create({name: 'Zelda'});
+        const sword = await customerRepo.promotions(link.id).create(
+          {description: 'master sword'},
+          {
+            throughData: {promotiontype: 'HalfPrice'},
+            polymorphicType: 'HalfPrice',
+          },
+        );
+        const shield = await customerRepo.promotions(zelda.id).create(
+          {description: 'shield'},
+          {
+            throughData: {promotiontype: 'FreeDelivery'},
+            polymorphicType: 'FreeDelivery',
+          },
+        );
+        const hat = await customerRepo.promotions(zelda.id).create(
+          {description: 'hat'},
+          {
+            throughData: {promotiontype: 'HalfPrice'},
+            polymorphicType: 'HalfPrice',
+          },
+        );
+
+        const result = await customerRepo.find({
+          include: [{relation: 'promotions', scope: {fields: {id: false}}}],
+        });
+
+        const expected = [
+          {
+            ...link,
+            parentId: features.emptyValue,
+            promotions: [{description: sword.description}],
+          },
+          {
+            ...zelda,
+            parentId: features.emptyValue,
+            promotions: [
+              {description: shield.description},
+              {description: hat.description},
+            ],
+          },
+        ];
+
+        expect(toJSON(result)).to.deepEqual(toJSON(expected));
+      });
+
+      it('honours limit scope when returning a model', async () => {
+        const link = await customerRepo.create({name: 'Link'});
+        await customerRepo
+          .cartItems(link.id)
+          .create({description: 'master sword'});
+        await customerRepo.cartItems(link.id).create({description: 'shield'});
+
+        const result = await customerRepo.find({
+          include: [{relation: 'cartItems', scope: {limit: 1}}],
+        });
+
+        expect(result.length).to.eql(1);
+        expect(result[0].cartItems.length).to.eql(1);
+      });
+    });
+  }
+}

--- a/packages/repository-tests/src/crud/relations/acceptance/has-many-through.relation.polymorphic.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-many-through.relation.polymorphic.acceptance.ts
@@ -1,0 +1,494 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect, toJSON} from '@loopback/testlab';
+import {
+  CrudFeatures,
+  CrudRepositoryCtor,
+  CrudTestContext,
+  DataSourceOptions,
+} from '../../..';
+import {
+  deleteAllModelsInDefaultDataSource,
+  MixedIdType,
+  withCrudCtx,
+} from '../../../helpers.repository-tests';
+import {
+  Customer,
+  CustomerPromotionLink,
+  CustomerPromotionLinkRepository,
+  CustomerRepository,
+  FreeDelivery,
+  FreeDeliveryRepository,
+  HalfPrice,
+  HalfPriceRepository,
+} from '../fixtures/models';
+import {givenBoundCrudRepositories} from '../helpers';
+
+export function hasManyThroughRelationAcceptance(
+  dataSourceOptions: DataSourceOptions,
+  repositoryClass: CrudRepositoryCtor,
+  features: CrudFeatures,
+) {
+  describe('HasManyThrough relation polymorphic (acceptance)', () => {
+    before(deleteAllModelsInDefaultDataSource);
+    let customerRepo: CustomerRepository;
+    let freeDeliveryRepo: FreeDeliveryRepository;
+    let halfPriceRepo: HalfPriceRepository;
+    let customerPromotionLinkRepo: CustomerPromotionLinkRepository;
+    let existingCustomerId: MixedIdType;
+
+    before(
+      withCrudCtx(async function setupRepository(ctx: CrudTestContext) {
+        ({
+          customerRepo,
+          freeDeliveryRepo,
+          halfPriceRepo,
+          customerPromotionLinkRepo,
+        } = givenBoundCrudRepositories(
+          ctx.dataSource,
+          repositoryClass,
+          features,
+        ));
+        await ctx.dataSource.automigrate([
+          Customer.name,
+          FreeDelivery.name,
+          HalfPrice.name,
+          CustomerPromotionLink.name,
+        ]);
+      }),
+    );
+
+    beforeEach(async () => {
+      await customerRepo.deleteAll();
+      await freeDeliveryRepo.deleteAll();
+      await halfPriceRepo.deleteAll();
+      await customerPromotionLinkRepo.deleteAll();
+    });
+
+    beforeEach(async () => {
+      existingCustomerId = (await givenPersistedCustomerInstance()).id;
+    });
+
+    it('creates an instance of the related model alone with a through model', async () => {
+      const promo = await customerRepo.promotions(existingCustomerId).create(
+        {description: 'free delivery promo'},
+        {
+          throughData: {
+            description: 'a through model',
+            promotiontype: 'FreeDelivery',
+          },
+          polymorphicType: 'FreeDelivery',
+        },
+      );
+
+      expect(toJSON(promo)).containDeep(
+        toJSON({
+          id: promo.id,
+          description: 'free delivery promo',
+        }),
+      );
+
+      const persistedPromo = await freeDeliveryRepo.findById(promo.id);
+      expect(toJSON(persistedPromo)).to.deepEqual(toJSON(promo));
+      const persistedLink = await customerPromotionLinkRepo.find();
+      expect(toJSON(persistedLink[0])).to.containDeep(
+        toJSON({
+          customerId: existingCustomerId,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          promotion_id: promo.id,
+          description: 'a through model',
+        }),
+      );
+    });
+
+    it('finds instances of the related model', async () => {
+      const freeDelivery = await customerRepo
+        .promotions(existingCustomerId)
+        .create(
+          {description: 'free delivery promo'},
+          {
+            throughData: {
+              description: 'a through model',
+              promotiontype: 'FreeDelivery',
+            },
+            polymorphicType: 'FreeDelivery',
+          },
+        );
+      const notMyPromo = await freeDeliveryRepo.create({
+        description: "someone else's promo",
+      });
+      const notMyPromo2 = await halfPriceRepo.create({
+        description: "someone else's promo 2",
+      });
+      const result = await customerRepo
+        .promotions(existingCustomerId)
+        .find(undefined, {
+          throughOptions: {discriminator: 'promotiontype'},
+          polymorphicType: ['FreeDelivery'],
+        });
+      expect(toJSON(result)).to.containDeep(toJSON([freeDelivery]));
+      expect(toJSON(result[0])).to.not.containEql(toJSON(notMyPromo));
+      expect(toJSON(result[0])).to.not.containEql(toJSON(notMyPromo2));
+    });
+
+    it('patches instances', async () => {
+      const promo1 = await customerRepo.promotions(existingCustomerId).create(
+        {description: 'free delivery promo'},
+        {
+          throughData: {
+            description: 'a through model',
+            promotiontype: 'FreeDelivery',
+          },
+          polymorphicType: 'FreeDelivery',
+        },
+      );
+      const promo2 = await customerRepo.promotions(existingCustomerId).create(
+        {description: 'half price promo 2'},
+        {
+          throughData: {
+            description: 'a through model',
+            promotiontype: 'HalfPrice',
+          },
+          polymorphicType: 'HalfPrice',
+        },
+      );
+      const promo3 = await customerRepo.promotions(existingCustomerId).create(
+        {description: 'free delivery promo 3'},
+        {
+          throughData: {
+            description: 'a through model',
+            promotiontype: 'FreeDelivery',
+          },
+          polymorphicType: 'FreeDelivery',
+        },
+      );
+      const count = await customerRepo.promotions(existingCustomerId).patch(
+        {
+          FreeDelivery: {description: 'updated free delivery'},
+          HalfPrice: {description: 'updated half price'},
+        },
+        undefined,
+        {
+          throughOptions: {discriminator: 'promotiontype'},
+          isPolymorphic: true,
+        },
+      );
+
+      expect(count.count).to.equal(3);
+      const result = await customerRepo
+        .promotions(existingCustomerId)
+        .find(undefined, {
+          throughOptions: {discriminator: 'promotiontype'},
+          polymorphicType: ['HalfPrice', 'FreeDelivery'],
+        });
+      expect(toJSON(result)).to.containDeep(
+        toJSON([
+          {id: promo1.id, description: 'updated free delivery'},
+          {id: promo2.id, description: 'updated half price'},
+          {id: promo3.id, description: 'updated free delivery'},
+        ]),
+      );
+    });
+
+    it('patches an instance based on the filter', async () => {
+      const promo1 = await customerRepo.promotions(existingCustomerId).create(
+        {description: 'promo group 1'},
+        {
+          throughData: {
+            description: 'a through model',
+            promotiontype: 'FreeDelivery',
+          },
+          polymorphicType: 'FreeDelivery',
+        },
+      );
+      const promo2 = await customerRepo.promotions(existingCustomerId).create(
+        {description: 'promo group 2'},
+        {
+          throughData: {
+            description: 'a through model',
+            promotiontype: 'FreeDelivery',
+          },
+          polymorphicType: 'FreeDelivery',
+        },
+      );
+      const promo3 = await customerRepo.promotions(existingCustomerId).create(
+        {description: 'promo group 1'},
+        {
+          throughData: {
+            description: 'a through model',
+            promotiontype: 'HalfPrice',
+          },
+          polymorphicType: 'HalfPrice',
+        },
+      );
+      const count = await customerRepo.promotions(existingCustomerId).patch(
+        {HalfPrice: {description: 'promo group 2'}},
+        {id: promo3.id},
+        {
+          throughOptions: {discriminator: 'promotiontype'},
+          isPolymorphic: true,
+        },
+      );
+
+      expect(count.count).to.equal(1);
+      const result = await customerRepo
+        .promotions(existingCustomerId)
+        .find(undefined, {
+          throughOptions: {discriminator: 'promotiontype'},
+          polymorphicType: ['HalfPrice', 'FreeDelivery'],
+        });
+      expect(toJSON(result)).to.containDeep(
+        toJSON([
+          {id: promo1.id, description: 'promo group 1'},
+          {id: promo2.id, description: 'promo group 2'},
+          {id: promo3.id, description: 'promo group 2'},
+        ]),
+      );
+    });
+
+    it('throws error when query tries to change the target id', async () => {
+      // a diff id for CartItem instance
+      const anotherId = (await givenPersistedCustomerInstance()).id;
+      await customerRepo.promotions(existingCustomerId).create(
+        {description: 'promo group 1'},
+        {
+          throughData: {
+            description: 'a through model',
+            promotiontype: 'HalfPrice',
+          },
+          polymorphicType: 'HalfPrice',
+        },
+      );
+
+      await expect(
+        customerRepo
+          .promotions(existingCustomerId)
+          .patch({HalfPrice: {id: anotherId}}, undefined, {
+            throughOptions: {discriminator: 'promotiontype'},
+            isPolymorphic: true,
+          }),
+      ).to.be.rejectedWith(/Property "id" cannot be changed!/);
+    });
+
+    it('deletes many instances and their through models', async () => {
+      await customerRepo.promotions(existingCustomerId).create(
+        {description: 'promo group 1'},
+        {
+          throughData: {
+            description: 'a through model to be deleted',
+            promotiontype: 'HalfPrice',
+          },
+          polymorphicType: 'HalfPrice',
+        },
+      );
+      await customerRepo.promotions(existingCustomerId).create(
+        {description: 'promo group 1'},
+        {
+          throughData: {
+            description: 'a through model to be deleted 2',
+            promotiontype: 'HalfPrice',
+          },
+          polymorphicType: 'HalfPrice',
+        },
+      );
+      await customerRepo.promotions(existingCustomerId).create(
+        {description: 'promo group 1'},
+        {
+          throughData: {
+            description: 'a through model to be deleted 3',
+            promotiontype: 'FreeDelivery',
+          },
+          polymorphicType: 'FreeDelivery',
+        },
+      );
+
+      let links = await customerPromotionLinkRepo.find();
+      let halfPrice = await halfPriceRepo.find();
+      let freeDelivery = await freeDeliveryRepo.find();
+      expect(links).have.length(3);
+      expect(halfPrice).have.length(2);
+      expect(freeDelivery).have.length(1);
+
+      await customerRepo.promotions(existingCustomerId).delete(undefined, {
+        throughOptions: {discriminator: 'promotiontype'},
+        polymorphicType: ['HalfPrice', 'FreeDelivery'],
+      });
+      links = await customerPromotionLinkRepo.find();
+      halfPrice = await halfPriceRepo.find();
+      freeDelivery = await freeDeliveryRepo.find();
+      expect(halfPrice).have.length(0);
+      expect(freeDelivery).have.length(0);
+      expect(links).have.length(0);
+    });
+
+    it('deletes corresponding through models when the target gets deleted', async () => {
+      const promotion = await customerRepo
+        .promotions(existingCustomerId)
+        .create(
+          {description: 'promo group 1'},
+          {
+            throughData: {
+              description: 'a through model to be deleted',
+              promotiontype: 'HalfPrice',
+            },
+            polymorphicType: 'HalfPrice',
+          },
+        );
+      const anotherId = (await givenPersistedCustomerInstance()).id;
+      // another through model that links to the same item
+      await customerPromotionLinkRepo.create({
+        customerId: anotherId,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        promotion_id: promotion.id,
+        promotiontype: 'HalfPrice',
+      });
+
+      let links = await customerPromotionLinkRepo.find();
+      let halfPrice = await halfPriceRepo.find();
+      expect(links).have.length(2);
+      expect(halfPrice).have.length(1);
+
+      await customerRepo.promotions(existingCustomerId).delete(undefined, {
+        throughOptions: {discriminator: 'promotiontype'},
+        polymorphicType: ['HalfPrice', 'FreeDelivery'],
+      });
+      links = await customerPromotionLinkRepo.find();
+      halfPrice = await halfPriceRepo.find();
+      expect(links).have.length(0);
+      expect(halfPrice).have.length(0);
+    });
+
+    it('deletes instances based on the filter', async () => {
+      await customerRepo.promotions(existingCustomerId).create(
+        {description: 'promo group 1'},
+        {
+          throughData: {
+            description: 'a through model to be deleted',
+            promotiontype: 'HalfPrice',
+          },
+          polymorphicType: 'HalfPrice',
+        },
+      );
+      await customerRepo.promotions(existingCustomerId).create(
+        {description: 'promo group 2'},
+        {
+          throughData: {
+            description: 'a through model to be deleted',
+            promotiontype: 'FreeDelivery',
+          },
+          polymorphicType: 'FreeDelivery',
+        },
+      );
+
+      let links = await customerPromotionLinkRepo.find();
+      let freeDelivery = await freeDeliveryRepo.find();
+      let halfPrice = await halfPriceRepo.find();
+      expect(links).have.length(2);
+      expect(freeDelivery).have.length(1);
+      expect(halfPrice).have.length(1);
+
+      await customerRepo.promotions(existingCustomerId).delete(
+        {description: 'does not exist'},
+        {
+          throughOptions: {discriminator: 'promotiontype'},
+          polymorphicType: ['HalfPrice', 'FreeDelivery'],
+        },
+      );
+      links = await customerPromotionLinkRepo.find();
+      freeDelivery = await freeDeliveryRepo.find();
+      halfPrice = await halfPriceRepo.find();
+      expect(links).have.length(2);
+      expect(freeDelivery).have.length(1);
+      expect(halfPrice).have.length(1);
+
+      await customerRepo.promotions(existingCustomerId).delete(
+        {description: 'promo group 2'},
+        {
+          throughOptions: {discriminator: 'promotiontype'},
+          polymorphicType: ['HalfPrice', 'FreeDelivery'],
+        },
+      );
+      links = await customerPromotionLinkRepo.find();
+      freeDelivery = await freeDeliveryRepo.find();
+      halfPrice = await halfPriceRepo.find();
+      expect(links).have.length(1);
+      expect(freeDelivery).have.length(0);
+      expect(halfPrice).have.length(1);
+    });
+
+    it('links a target model to a source model', async () => {
+      const freeDelivery = await freeDeliveryRepo.create({
+        description: 'a free delivery promotion',
+      });
+
+      let targets = await customerRepo
+        .promotions(existingCustomerId)
+        .find(undefined, {
+          throughOptions: {discriminator: 'promotiontype'},
+          polymorphicType: ['HalfPrice', 'FreeDelivery'],
+        });
+      expect(targets).to.be.empty();
+
+      await customerRepo
+        .promotions(existingCustomerId)
+        .link(freeDelivery.id, {throughData: {promotiontype: 'FreeDelivery'}});
+
+      targets = await customerRepo
+        .promotions(existingCustomerId)
+        .find(undefined, {
+          throughOptions: {discriminator: 'promotiontype'},
+          polymorphicType: ['HalfPrice', 'FreeDelivery'],
+        });
+      expect(targets).to.deepEqual([freeDelivery]);
+
+      const link = await customerPromotionLinkRepo.find();
+      expect(toJSON(link[0])).to.containEql(
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        toJSON({customerId: existingCustomerId, promotion_id: freeDelivery.id}),
+      );
+    });
+
+    it('unlinks a target model from a source model', async () => {
+      const promotion1 = await customerRepo
+        .promotions(existingCustomerId)
+        .create(
+          {description: 'promo group 1'},
+          {
+            throughData: {
+              description: 'a through model to be deleted',
+              promotiontype: 'HalfPrice',
+            },
+            polymorphicType: 'HalfPrice',
+          },
+        );
+
+      let targets = await customerRepo
+        .promotions(existingCustomerId)
+        .find(undefined, {
+          throughOptions: {discriminator: 'promotiontype'},
+          polymorphicType: ['HalfPrice', 'FreeDelivery'],
+        });
+      expect(targets).to.deepEqual([promotion1]);
+
+      await customerRepo.promotions(existingCustomerId).unlink(promotion1.id);
+
+      targets = await customerRepo
+        .promotions(existingCustomerId)
+        .find(undefined, {
+          throughOptions: {discriminator: 'promotiontype'},
+          polymorphicType: ['HalfPrice', 'FreeDelivery'],
+        });
+      expect(targets).to.be.empty();
+
+      const link = await customerPromotionLinkRepo.find();
+      expect(link).to.be.empty();
+    });
+
+    async function givenPersistedCustomerInstance() {
+      return customerRepo.create({name: 'a customer'});
+    }
+  });
+}

--- a/packages/repository-tests/src/crud/relations/acceptance/has-one.inclusion-resolver.polymorphic.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-one.inclusion-resolver.polymorphic.acceptance.ts
@@ -1,0 +1,208 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect, skipIf, toJSON} from '@loopback/testlab';
+import {Suite} from 'mocha';
+import {
+  CrudFeatures,
+  CrudRepositoryCtor,
+  CrudTestContext,
+  DataSourceOptions,
+} from '../../..';
+import {
+  deleteAllModelsInDefaultDataSource,
+  withCrudCtx,
+} from '../../../helpers.repository-tests';
+import {
+  CardInfoRepository,
+  Cash,
+  CashRepository,
+  CreditCard,
+  CreditCardRepository,
+  Customer,
+  CustomerRepository,
+} from '../fixtures/models';
+import {givenBoundCrudRepositories} from '../helpers';
+
+export function hasOneInclusionResolverPolymorphicAcceptance(
+  dataSourceOptions: DataSourceOptions,
+  repositoryClass: CrudRepositoryCtor,
+  features: CrudFeatures,
+) {
+  skipIf<[(this: Suite) => void], void>(
+    !features.supportsInclusionResolvers,
+    describe,
+    'HasOne inclusion resolvers - polymorphic - acceptance',
+    suite,
+  );
+  function suite() {
+    before(deleteAllModelsInDefaultDataSource);
+    let customerRepo: CustomerRepository;
+    let creditCardRepo: CreditCardRepository;
+    let cashRepo: CashRepository;
+    let cardInfoRepo: CardInfoRepository;
+
+    before(
+      withCrudCtx(async function setupRepository(ctx: CrudTestContext) {
+        // this helper should create the inclusion resolvers and also
+        // register inclusion resolvers for us
+        ({customerRepo, creditCardRepo, cashRepo, cardInfoRepo} =
+          givenBoundCrudRepositories(
+            ctx.dataSource,
+            repositoryClass,
+            features,
+          ));
+        expect(customerRepo.paymentMethod.inclusionResolver).to.be.Function();
+
+        await ctx.dataSource.automigrate([
+          Customer.name,
+          CreditCard.name,
+          Cash.name,
+        ]);
+      }),
+    );
+
+    beforeEach(async () => {
+      await customerRepo.deleteAll();
+      await creditCardRepo.deleteAll();
+      await cashRepo.deleteAll();
+      await cardInfoRepo.deleteAll();
+    });
+
+    it('throws an error if it tries to query nonexistent relation names', async () => {
+      const customer = await customerRepo.create({
+        name: 'customer',
+        paymentMethodType: 'CreditCard',
+      });
+      await creditCardRepo.create({
+        customerId: customer.id,
+      });
+      await expect(customerRepo.find({include: ['home']})).to.be.rejectedWith(
+        `Invalid "filter.include" entries: "home"`,
+      );
+    });
+
+    it('returns single model instance including single related instance', async () => {
+      const thor = await customerRepo.create({
+        name: 'Thor',
+        paymentMethodType: 'CreditCard',
+      });
+      const thorCreditCard = await creditCardRepo.create({
+        customerId: thor.id,
+      });
+      const result = await customerRepo.find({
+        include: ['paymentMethod'],
+      });
+
+      const expected = {
+        ...thor,
+        parentId: features.emptyValue,
+        paymentMethod: thorCreditCard,
+      };
+      expect(toJSON(result)).to.deepEqual([toJSON(expected)]);
+    });
+
+    it('returns multiple model instances including related instances', async () => {
+      const thor = await customerRepo.create({
+        name: 'Thor',
+        paymentMethodType: 'Cash',
+      });
+      const odin = await customerRepo.create({
+        name: 'Odin',
+        paymentMethodType: 'CreditCard',
+      });
+      const thorCash = await cashRepo.create({
+        customerId: thor.id,
+      });
+      const odinCreditCard = await creditCardRepo.create({
+        customerId: odin.id,
+      });
+
+      const result = await customerRepo.find({
+        include: ['paymentMethod'],
+      });
+
+      const expected = [
+        {
+          ...thor,
+          parentId: features.emptyValue,
+          paymentMethod: thorCash,
+        },
+        {
+          ...odin,
+          parentId: features.emptyValue,
+          paymentMethod: odinCreditCard,
+        },
+      ];
+      expect(toJSON(result)).to.deepEqual(toJSON(expected));
+    });
+
+    it('returns a specified instance including its related model instance', async () => {
+      const thor = await customerRepo.create({
+        name: 'Thor',
+        paymentMethodType: 'Cash',
+      });
+      const odin = await customerRepo.create({
+        name: 'Odin',
+        paymentMethodType: 'CreditCard',
+      });
+      const bella = await customerRepo.create({
+        name: 'Bella',
+        paymentMethodType: 'CreditCard',
+      });
+      await cashRepo.create({
+        customerId: thor.id,
+      });
+      await creditCardRepo.create({
+        customerId: odin.id,
+      });
+      const bellaPaymentMethod = await creditCardRepo.create({
+        customerId: bella.id,
+      });
+      const bellaCardInfo = await creditCardRepo
+        .cardInfo(bellaPaymentMethod.id)
+        .create({cardHolder: 'bella!'});
+      bellaPaymentMethod.cardInfo = bellaCardInfo;
+      const result = await customerRepo.findById(bella.id, {
+        include: [
+          {
+            relation: 'paymentMethod',
+            scope: {
+              include: [
+                {
+                  relation: 'cardInfo',
+                  targetType: 'CreditCard',
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      const expected = {
+        ...bella,
+        parentId: features.emptyValue,
+        paymentMethod: bellaPaymentMethod,
+      };
+      expect(toJSON(result)).to.deepEqual(toJSON(expected));
+    });
+
+    it('throws error if the target repository does not have the registered resolver', async () => {
+      const customer = await customerRepo.create({
+        name: 'customer',
+        paymentMethodType: 'CreditCard',
+      });
+      await creditCardRepo.create({
+        customerId: customer.id,
+      });
+      // unregister the resolver
+      customerRepo.inclusionResolvers.delete('paymentMethod');
+
+      await expect(
+        customerRepo.find({include: ['paymentMethod']}),
+      ).to.be.rejectedWith(`Invalid "filter.include" entries: "paymentMethod"`);
+    });
+  }
+}

--- a/packages/repository-tests/src/crud/relations/acceptance/has-one.relation.polymorphic.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-one.relation.polymorphic.acceptance.ts
@@ -1,0 +1,328 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {DataObject, EntityNotFoundError} from '@loopback/repository';
+import {expect, toJSON} from '@loopback/testlab';
+import {
+  CrudFeatures,
+  CrudRepositoryCtor,
+  CrudTestContext,
+  DataSourceOptions,
+} from '../../..';
+import {
+  deleteAllModelsInDefaultDataSource,
+  MixedIdType,
+  withCrudCtx,
+} from '../../../helpers.repository-tests';
+import {
+  Cash,
+  CashRepository,
+  CreditCard,
+  CreditCardRepository,
+  Customer,
+  CustomerRepository,
+  PaymentMethod,
+} from '../fixtures/models';
+import {givenBoundCrudRepositories} from '../helpers';
+
+export function hasOneRelationPolymorphicAcceptance(
+  dataSourceOptions: DataSourceOptions,
+  repositoryClass: CrudRepositoryCtor,
+  features: CrudFeatures,
+) {
+  describe('hasOne relation polymorphic (acceptance)', () => {
+    let customerRepo: CustomerRepository;
+    let creditCardRepo: CreditCardRepository;
+    let cashRepo: CashRepository;
+    let existingCustomerId: MixedIdType;
+
+    before(deleteAllModelsInDefaultDataSource);
+
+    before(
+      withCrudCtx(async function setupRepository(ctx: CrudTestContext) {
+        ({customerRepo, creditCardRepo, cashRepo} = givenBoundCrudRepositories(
+          ctx.dataSource,
+          repositoryClass,
+          features,
+        ));
+        const models = [Customer, CreditCard, Cash];
+        await ctx.dataSource.automigrate(models.map(m => m.name));
+      }),
+    );
+
+    beforeEach(async () => {
+      await customerRepo.deleteAll();
+      await creditCardRepo.deleteAll();
+      await cashRepo.deleteAll();
+      existingCustomerId = (await givenPersistedCustomerInstance()).id;
+    });
+
+    it('can create an instance of the related model', async () => {
+      const address = await createCustomerPaymentMethod(
+        existingCustomerId,
+        {},
+        'CreditCard',
+      );
+      expect(toJSON(address)).to.containDeep(
+        toJSON({
+          customerId: existingCustomerId,
+        }),
+      );
+
+      const persisted = await creditCardRepo.findById(address.id);
+      expect(toJSON(persisted)).to.deepEqual(
+        toJSON({
+          ...address,
+          zipcode: features.emptyValue,
+          city: features.emptyValue,
+          province: features.emptyValue,
+        }),
+      );
+    });
+
+    // We do not enforce referential integrity at the moment. It is up to
+    // our users to set up unique constraint(s) between related models at the
+    // database level
+    it.skip('refuses to create related model instance twice', async () => {
+      const creditCard = await createCustomerPaymentMethod(
+        existingCustomerId,
+        {},
+        'CreditCard',
+      );
+      await expect(
+        createCustomerPaymentMethod(existingCustomerId, {}, 'Cash'),
+      ).to.be.rejectedWith(/Duplicate entry for PaymentMethod.customerId/);
+      expect(creditCard.toObject()).to.containDeep({
+        customerId: existingCustomerId,
+      });
+
+      const persisted = await creditCardRepo.findById(creditCard.id);
+      expect(persisted.toObject()).to.deepEqual(creditCard.toObject());
+    });
+
+    it('can find instance of the related model', async () => {
+      const creditCard = await createCustomerPaymentMethod(
+        existingCustomerId,
+        {},
+        'CreditCard',
+      );
+      const foundCreditCard = await findCustomerPaymentMethod(
+        existingCustomerId,
+        'CreditCard',
+      );
+      expect(toJSON(foundCreditCard)).to.containEql(toJSON(creditCard));
+      expect(toJSON(foundCreditCard)).to.deepEqual(
+        toJSON({
+          ...creditCard,
+        }),
+      );
+
+      const persisted = await creditCardRepo.find({
+        where: {customerId: existingCustomerId},
+      });
+      expect(persisted[0]).to.deepEqual(foundCreditCard);
+    });
+
+    it('reports EntityNotFound error when related model is deleted', async () => {
+      const paymentMethod = await createCustomerPaymentMethod(
+        existingCustomerId,
+        {},
+        'CreditCard',
+      );
+      await creditCardRepo.deleteById(paymentMethod.id);
+
+      await expect(
+        findCustomerPaymentMethod(existingCustomerId, 'CreditCard'),
+      ).to.be.rejectedWith(EntityNotFoundError);
+    });
+
+    it('can PATCH hasOne instances', async () => {
+      const paymentMethod = await createCustomerPaymentMethod(
+        existingCustomerId,
+        {},
+        'CreditCard',
+      );
+
+      const patchObject = {cardNumber: 46458921} as DataObject<PaymentMethod>;
+      const arePatched = await patchCustomerPaymentMethod(
+        existingCustomerId,
+        {CreditCard: patchObject as DataObject<CreditCard>} as {
+          [polymorphicType: string]: DataObject<CreditCard>;
+        },
+        true,
+      );
+
+      expect(arePatched).to.deepEqual({count: 1});
+      const patchedData = await creditCardRepo.findById(paymentMethod.id);
+
+      expect(toJSON(patchedData)).to.deepEqual(
+        toJSON({
+          id: paymentMethod.id,
+          customerId: existingCustomerId,
+          cardNumber: 46458921,
+        }),
+      );
+    });
+
+    it('patches the related instance only', async () => {
+      const bob = await customerRepo.create({name: 'Bob'});
+      await customerRepo
+        .paymentMethod(bob.id)
+        .create({cardNumber: 12345} as DataObject<PaymentMethod>, {
+          polymorphicType: 'CreditCard',
+        });
+
+      const alice = await customerRepo.create({name: 'Alice'});
+      await customerRepo
+        .paymentMethod(alice.id)
+        .create({cardNumber: 67890} as DataObject<PaymentMethod>, {
+          polymorphicType: 'CreditCard',
+        });
+
+      const result = await patchCustomerPaymentMethod(
+        alice.id,
+        {
+          CreditCard: {
+            cardNumber: 7894512,
+          } as DataObject<CreditCard>,
+        } as {[polymorphicType: string]: DataObject<CreditCard>},
+        true,
+      );
+
+      expect(result).to.deepEqual({count: 1});
+
+      const foundBob = await customerRepo
+        .paymentMethod(bob.id)
+        .get(undefined, {polymorphicType: 'CreditCard'});
+      expect(toJSON(foundBob)).to.containDeep({cardNumber: 12345});
+
+      const foundAlice = await customerRepo
+        .paymentMethod(bob.id)
+        .get(undefined, {polymorphicType: 'CreditCard'});
+      expect(toJSON(foundAlice)).to.containDeep({cardNumber: 12345});
+    });
+
+    it('throws an error when PATCH tries to change the foreignKey', async () => {
+      const anotherId = (await givenPersistedCustomerInstance()).id;
+      await expect(
+        patchCustomerPaymentMethod(
+          existingCustomerId,
+          {
+            CreditCard: {
+              customerId: anotherId,
+            } as DataObject<CreditCard>,
+          } as {[polymorphicType: string]: DataObject<CreditCard>},
+          true,
+        ),
+      ).to.be.rejectedWith(/Property "customerId" cannot be changed!/);
+    });
+
+    it('can DELETE hasOne relation instances', async () => {
+      await createCustomerPaymentMethod(existingCustomerId, {}, 'CreditCard');
+
+      const areDeleted = await deleteCustomerPaymentMethod(
+        existingCustomerId,
+        'CreditCard',
+      );
+      expect(areDeleted).to.deepEqual({count: 1});
+
+      await expect(
+        findCustomerPaymentMethod(existingCustomerId, 'CreditCard'),
+      ).to.be.rejectedWith(EntityNotFoundError);
+    });
+
+    it('deletes the related model instance only', async () => {
+      const bob = await customerRepo.create({name: 'Bob'});
+      await customerRepo
+        .paymentMethod(bob.id)
+        .create({}, {polymorphicType: 'CreditCard'});
+
+      const alice = await customerRepo.create({name: 'Alice'});
+      await customerRepo
+        .paymentMethod(alice.id)
+        .create({}, {polymorphicType: 'Cash'});
+
+      const brown = await customerRepo.create({name: 'Brown'});
+      await customerRepo
+        .paymentMethod(brown.id)
+        .create({}, {polymorphicType: 'Cash'});
+
+      const result = await deleteCustomerPaymentMethod(alice.id, 'Cash');
+
+      expect(result).to.deepEqual({count: 1});
+
+      const found = await cashRepo.find();
+      expect(found).to.have.length(1);
+    });
+
+    it('deletes the related model instance with wrong type', async () => {
+      const bob = await customerRepo.create({name: 'Bob'});
+      await customerRepo
+        .paymentMethod(bob.id)
+        .create({}, {polymorphicType: 'CreditCard'});
+
+      const alice = await customerRepo.create({name: 'Alice'});
+      await customerRepo
+        .paymentMethod(alice.id)
+        .create({}, {polymorphicType: 'Cash'});
+
+      const brown = await customerRepo.create({name: 'Brown'});
+      await customerRepo
+        .paymentMethod(brown.id)
+        .create({}, {polymorphicType: 'Cash'});
+
+      const result = await deleteCustomerPaymentMethod(alice.id, 'CreditCard');
+
+      expect(result).to.deepEqual({count: 0});
+
+      const found = await cashRepo.find();
+      expect(found).to.have.length(2);
+    });
+
+    /*---------------- HELPERS -----------------*/
+
+    async function createCustomerPaymentMethod(
+      customerId: MixedIdType,
+      paymentMethodData: DataObject<PaymentMethod>,
+      polymorphicTypeName: string,
+    ): Promise<PaymentMethod> {
+      return customerRepo
+        .paymentMethod(customerId)
+        .create(paymentMethodData, {polymorphicType: polymorphicTypeName});
+    }
+
+    async function findCustomerPaymentMethod(
+      customerId: MixedIdType,
+      polymorphicType: string,
+    ) {
+      return customerRepo
+        .paymentMethod(customerId)
+        .get(undefined, {polymorphicType: polymorphicType});
+    }
+
+    async function patchCustomerPaymentMethod(
+      customerId: MixedIdType,
+      paymentMethodData: DataObject<PaymentMethod>,
+      isMultipleTypes: boolean,
+    ) {
+      return customerRepo
+        .paymentMethod(customerId)
+        .patch(paymentMethodData, {isPolymorphic: isMultipleTypes});
+    }
+
+    async function deleteCustomerPaymentMethod(
+      customerId: MixedIdType,
+      polymorphicType: string,
+    ) {
+      return customerRepo
+        .paymentMethod(customerId)
+        .delete({polymorphicType: polymorphicType});
+    }
+
+    async function givenPersistedCustomerInstance() {
+      return customerRepo.create({name: 'a customer'});
+    }
+  });
+}

--- a/packages/repository-tests/src/crud/relations/fixtures/models/contact.model.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/contact.model.ts
@@ -1,0 +1,56 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  belongsTo,
+  BelongsToAccessor,
+  Entity,
+  EntityCrudRepository,
+  model,
+  property,
+} from '@loopback/repository';
+import {MixedIdType} from '../../../../helpers.repository-tests';
+import {CustomerWithRelations} from './customer.model';
+import {Stakeholder} from './stakeholder.model';
+
+@model()
+export class Contact extends Entity {
+  @property({
+    id: true,
+    generated: true,
+    useDefaultIdType: true,
+  })
+  id: MixedIdType;
+  @property({
+    type: 'string',
+  })
+  name: string;
+  @property({
+    type: 'string',
+  })
+  email: string;
+
+  @belongsTo(() => Stakeholder, {polymorphic: true})
+  stakeholderId: MixedIdType;
+
+  @property({
+    type: 'string',
+    required: true,
+    default: 'Customer',
+  })
+  stakeholderType: string;
+}
+
+export interface ContactRelations {
+  stakeholder?: CustomerWithRelations;
+}
+
+export type ContactWithRelations = Contact & ContactRelations;
+
+export interface ContactRepository
+  extends EntityCrudRepository<Contact, typeof Contact.prototype.id> {
+  // define additional members like relation methods here
+  stakeholder: BelongsToAccessor<Stakeholder, MixedIdType>;
+}

--- a/packages/repository-tests/src/crud/relations/fixtures/models/customer-promotion-link.model.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/customer-promotion-link.model.ts
@@ -1,0 +1,52 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  Entity,
+  EntityCrudRepository,
+  model,
+  property,
+} from '@loopback/repository';
+import {MixedIdType} from '../../../../helpers.repository-tests';
+
+@model()
+export class CustomerPromotionLink extends Entity {
+  @property({
+    id: true,
+    generated: true,
+    useDefaultIdType: true,
+  })
+  id: MixedIdType;
+
+  @property()
+  customerId: MixedIdType;
+
+  @property()
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  promotion_id: MixedIdType;
+
+  @property({
+    type: 'string',
+    default: 'HalfPrice',
+    required: true,
+  })
+  promotiontype: string;
+
+  @property({
+    type: 'string',
+  })
+  description?: string;
+}
+
+export interface CustomerPromotionLinkRelations {}
+
+export type CustomerPromotionLinkWithRelations = CustomerPromotionLink &
+  CustomerPromotionLinkRelations;
+
+export interface CustomerPromotionLinkRepository
+  extends EntityCrudRepository<
+    CustomerPromotionLink,
+    typeof CustomerPromotionLink.prototype.id
+  > {}

--- a/packages/repository-tests/src/crud/relations/fixtures/models/customer.model.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/customer.model.ts
@@ -5,7 +5,6 @@
 
 import {
   belongsTo,
-  Entity,
   EntityCrudRepository,
   hasMany,
   HasManyRepositoryFactory,
@@ -19,18 +18,19 @@ import {BelongsToAccessor} from '@loopback/repository/src';
 import {MixedIdType} from '../../../../helpers.repository-tests';
 import {Address, AddressWithRelations} from './address.model';
 import {CartItem, CartItemWithRelations} from './cart-item.model';
+import {Contact, ContactWithRelations} from './contact.model';
 import {CustomerCartItemLink} from './customer-cart-item-link.model';
+import {CustomerPromotionLink} from './customer-promotion-link.model';
 import {Order, OrderWithRelations} from './order.model';
+import {
+  PaymentMethod,
+  PaymentMethodWithRelations,
+} from './payment-method.model';
+import {Promotion, PromotionWithRelations} from './promotion.model';
+import {Stakeholder} from './stakeholder.model';
 
 @model()
-export class Customer extends Entity {
-  @property({
-    id: true,
-    generated: true,
-    useDefaultIdType: true,
-  })
-  id: MixedIdType;
-
+export class Customer extends Stakeholder {
   @property({
     type: 'string',
   })
@@ -50,6 +50,25 @@ export class Customer extends Entity {
 
   @hasMany(() => CartItem, {through: {model: () => CustomerCartItemLink}})
   cartItems: CartItem[];
+
+  @hasMany(() => Promotion, {
+    through: {
+      model: () => CustomerPromotionLink,
+      keyTo: 'promotion_id',
+      polymorphic: {discriminator: 'promotiontype'},
+    },
+  })
+  promotions: Promotion[];
+
+  @hasOne(() => PaymentMethod, {polymorphic: true})
+  paymentMethod: PaymentMethod;
+
+  @property({
+    type: 'string',
+    required: true,
+    default: 'CreditCard',
+  })
+  paymentMethodType: string;
 }
 
 export interface CustomerRelations {
@@ -58,6 +77,9 @@ export interface CustomerRelations {
   customers?: CustomerWithRelations[];
   parentCustomer?: CustomerWithRelations;
   cartItems?: CartItemWithRelations[];
+  paymentMethod: PaymentMethodWithRelations;
+  promotions?: PromotionWithRelations[];
+  contact?: ContactWithRelations;
 }
 
 export type CustomerWithRelations = Customer & CustomerRelations;
@@ -75,4 +97,12 @@ export interface CustomerRepository
     CustomerCartItemLink,
     MixedIdType
   >;
+  promotions: HasManyThroughRepositoryFactory<
+    Promotion,
+    MixedIdType,
+    CustomerPromotionLink,
+    MixedIdType
+  >;
+  paymentMethod: HasOneRepositoryFactory<PaymentMethod, MixedIdType>;
+  contact: HasOneRepositoryFactory<Contact, MixedIdType>;
 }

--- a/packages/repository-tests/src/crud/relations/fixtures/models/index.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/index.ts
@@ -5,9 +5,15 @@
 
 export * from './address.model';
 export * from './cart-item.model';
+export * from './contact.model';
 export * from './customer-cart-item-link.model';
+export * from './customer-promotion-link.model';
 export * from './customer.model';
 export * from './order.model';
+export * from './payment-method.model';
+export * from './promotion.model';
 export * from './shipment.model';
+export * from './stakeholder.model';
+export * from './supplier.model';
 export * from './user-link.model';
 export * from './user.model';

--- a/packages/repository-tests/src/crud/relations/fixtures/models/payment-method.model.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/payment-method.model.ts
@@ -1,0 +1,118 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  belongsTo,
+  Entity,
+  EntityCrudRepository,
+  hasOne,
+  HasOneRepositoryFactory,
+  model,
+  property,
+} from '@loopback/repository';
+import {BelongsToAccessor} from '@loopback/repository/src';
+import {Customer, CustomerWithRelations} from '.';
+import {MixedIdType} from '../../../../helpers.repository-tests';
+import {Stakeholder} from './stakeholder.model';
+
+@model()
+export class PaymentMethod extends Entity {
+  @property({
+    id: true,
+    generated: true,
+    useDefaultIdType: true,
+  })
+  id: MixedIdType;
+
+  @belongsTo(() => Stakeholder)
+  customerId: MixedIdType;
+}
+
+export interface PaymentMethodRelations {
+  customer?: CustomerWithRelations[];
+}
+
+export type PaymentMethodWithRelations = PaymentMethod & PaymentMethodRelations;
+
+@model()
+export class CardInfo extends Entity {
+  @property({
+    id: true,
+    generated: true,
+    useDefaultIdType: true,
+  })
+  id: MixedIdType;
+
+  @belongsTo(() => CreditCard)
+  creditCardId: MixedIdType;
+
+  @property({
+    type: 'string',
+    required: true,
+    default: 'default holder',
+  })
+  cardHolder: string;
+}
+
+export interface CardInfoRelations {
+  creditCard?: CreditCardWithRelations[];
+}
+
+export type CardInfoWithRelations = CardInfo & CardInfoRelations;
+
+@model()
+export class CreditCard extends PaymentMethod {
+  @property({
+    type: 'number',
+    required: true,
+    default: 0,
+  })
+  cardNumber: number;
+
+  @hasOne(() => CardInfo)
+  cardInfo: CardInfo;
+}
+
+export interface CreditCardRelations {
+  customer?: CustomerWithRelations[];
+  cardInfo: CardInfoWithRelations;
+}
+
+export type CreditCardWithRelations = CreditCard & CreditCardRelations;
+
+@model()
+export class Cash extends PaymentMethod {
+  @property({
+    type: 'string',
+    required: true,
+    default: 'default cash detail',
+  })
+  detail: string;
+}
+
+export interface CashRelations {
+  customer?: CustomerWithRelations[];
+}
+
+export type CashWithRelations = Cash & CashRelations;
+
+export interface CreditCardRepository
+  extends EntityCrudRepository<CreditCard, typeof CreditCard.prototype.id> {
+  // define additional members like relation methods here
+  customer: BelongsToAccessor<Customer, MixedIdType>;
+  cardInfo: HasOneRepositoryFactory<CardInfo, MixedIdType>;
+}
+
+export interface CashRepository
+  extends EntityCrudRepository<Cash, typeof Cash.prototype.id> {
+  // define additional members like relation methods here
+  customer: BelongsToAccessor<Customer, MixedIdType>;
+}
+
+export interface CardInfoRepository
+  extends EntityCrudRepository<CardInfo, typeof CardInfo.prototype.id> {
+  // define additional members like relation methods here
+  creditCard: BelongsToAccessor<CreditCard, MixedIdType>;
+}

--- a/packages/repository-tests/src/crud/relations/fixtures/models/promotion.model.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/promotion.model.ts
@@ -1,0 +1,67 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  Entity,
+  EntityCrudRepository,
+  model,
+  property,
+} from '@loopback/repository';
+import {MixedIdType} from '../../../../helpers.repository-tests';
+
+@model()
+export class Promotion extends Entity {
+  @property({
+    id: true,
+    generated: true,
+    useDefaultIdType: true,
+  })
+  id: MixedIdType;
+
+  @property({
+    type: 'string',
+  })
+  description: string;
+}
+
+export interface PromotionRelations {}
+
+export type PromotionWithRelations = Promotion & PromotionRelations;
+
+export interface PromotionRepository
+  extends EntityCrudRepository<Promotion, typeof Promotion.prototype.id> {}
+
+@model()
+export class FreeDelivery extends Promotion {
+  @property({
+    type: 'string',
+  })
+  name: string;
+}
+
+export interface FreeDeliveryRelations {}
+
+export type FreeDeliveryWithRelations = FreeDelivery & FreeDeliveryRelations;
+
+export interface FreeDeliveryRepository
+  extends EntityCrudRepository<
+    FreeDelivery,
+    typeof FreeDelivery.prototype.id
+  > {}
+
+@model()
+export class HalfPrice extends Promotion {
+  @property({
+    type: 'string',
+  })
+  name: string;
+}
+
+export interface HalfPriceRelations {}
+
+export type HalfPriceWithRelations = HalfPrice & HalfPriceRelations;
+
+export interface HalfPriceRepository
+  extends EntityCrudRepository<HalfPrice, typeof HalfPrice.prototype.id> {}

--- a/packages/repository-tests/src/crud/relations/fixtures/models/stakeholder.model.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/stakeholder.model.ts
@@ -1,0 +1,33 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Entity, hasOne, model, property} from '@loopback/repository';
+import {MixedIdType} from '../../../../helpers.repository-tests';
+import {Contact} from './contact.model';
+
+@model()
+export class Stakeholder extends Entity {
+  @property({
+    id: true,
+    generated: true,
+    useDefaultIdType: true,
+  })
+  id: MixedIdType;
+
+  @hasOne(() => Contact)
+  contact: Contact;
+}
+
+// export interface StakeholderRelations {
+//   contact: ContactWithRelations;
+// }
+
+// export type StakeholderWithRelations = Stakeholder & StakeholderRelations;
+
+// export interface StakeholderRepository
+//   extends EntityCrudRepository<Stakeholder, typeof Stakeholder.prototype.id> {
+//   // define additional members like relation methods here
+//   contact: HasOneRepositoryFactory<Contact, MixedIdType>;
+// }

--- a/packages/repository-tests/src/crud/relations/fixtures/models/supplier.model.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/supplier.model.ts
@@ -1,0 +1,35 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  EntityCrudRepository,
+  HasOneRepositoryFactory,
+  model,
+  property,
+} from '@loopback/repository';
+import {MixedIdType} from '../../../../helpers.repository-tests';
+import {Contact} from './contact.model';
+import {PaymentMethodWithRelations} from './payment-method.model';
+import {Stakeholder} from './stakeholder.model';
+
+@model()
+export class Supplier extends Stakeholder {
+  @property({
+    type: 'string',
+  })
+  name: string;
+}
+
+export interface SupplierRelations {
+  contact?: PaymentMethodWithRelations;
+}
+
+export type SupplierWithRelations = Supplier & SupplierRelations;
+
+export interface SupplierRepository
+  extends EntityCrudRepository<Supplier, typeof Supplier.prototype.id> {
+  // define additional members like relation methods here
+  contact: HasOneRepositoryFactory<Contact, MixedIdType>;
+}

--- a/packages/repository-tests/src/crud/relations/fixtures/repositories/contact.repository.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/repositories/contact.repository.ts
@@ -1,0 +1,44 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Getter} from '@loopback/core';
+import {
+  BelongsToAccessor,
+  BelongsToDefinition,
+  createBelongsToAccessor,
+  juggler,
+} from '@loopback/repository';
+import {CrudRepositoryCtor} from '../../../..';
+import {Contact, ContactRelations, Stakeholder} from '../models';
+
+export function createContactRepo(repoClass: CrudRepositoryCtor) {
+  return class ContactRepository extends repoClass<
+    Contact,
+    typeof Contact.prototype.id,
+    ContactRelations
+  > {
+    public readonly stakeholder: BelongsToAccessor<
+      Stakeholder,
+      typeof Contact.prototype.id
+    >;
+
+    constructor(
+      db: juggler.DataSource,
+      stakeholderRepositoryGetter: {
+        [repoType: string]: Getter<typeof repoClass.prototype>;
+      },
+    ) {
+      super(Contact, db);
+      // create a belongsto relation from this public method
+      const stakeholderMeta =
+        this.entityClass.definition.relations['stakeholder'];
+      this.stakeholder = createBelongsToAccessor(
+        stakeholderMeta as BelongsToDefinition,
+        stakeholderRepositoryGetter,
+        this,
+      );
+    }
+  };
+}

--- a/packages/repository-tests/src/crud/relations/fixtures/repositories/customer-promotion-link.repository.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/repositories/customer-promotion-link.repository.ts
@@ -1,0 +1,20 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {juggler} from '@loopback/repository';
+import {CrudRepositoryCtor} from '../../../..';
+import {CustomerPromotionLink, CustomerPromotionLinkRelations} from '../models';
+// create the CustomerCartItemLinkRepo by calling this func so that it can be extended from CrudRepositoryCtor
+export function createCustomerPromotionLinkRepo(repoClass: CrudRepositoryCtor) {
+  return class CustomerPromotionLinkRepository extends repoClass<
+    CustomerPromotionLink,
+    typeof CustomerPromotionLink.prototype.id,
+    CustomerPromotionLinkRelations
+  > {
+    constructor(db: juggler.DataSource) {
+      super(CustomerPromotionLink, db);
+    }
+  };
+}

--- a/packages/repository-tests/src/crud/relations/fixtures/repositories/customer.repository.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/repositories/customer.repository.ts
@@ -22,10 +22,14 @@ import {CrudRepositoryCtor} from '../../../../types.repository-tests';
 import {
   Address,
   CartItem,
+  Contact,
   Customer,
   CustomerCartItemLink,
+  CustomerPromotionLink,
   CustomerRelations,
   Order,
+  PaymentMethod,
+  Promotion,
 } from '../models';
 
 // create the CustomerRepo by calling this func so that it can be extended from CrudRepositoryCtor
@@ -58,12 +62,37 @@ export function createCustomerRepo(repoClass: CrudRepositoryCtor) {
       typeof CustomerCartItemLink.prototype.id
     >;
 
+    public readonly promotions: HasManyThroughRepositoryFactory<
+      Promotion,
+      typeof Promotion.prototype.id,
+      CustomerPromotionLink,
+      typeof CustomerPromotionLink.prototype.id
+    >;
+
+    public readonly paymentMethod: HasOneRepositoryFactory<
+      PaymentMethod,
+      typeof Customer.prototype.id
+    >;
+
+    public readonly contact: HasOneRepositoryFactory<
+      Contact,
+      typeof Customer.prototype.id
+    >;
+
     constructor(
       db: juggler.DataSource,
       orderRepositoryGetter: Getter<typeof repoClass.prototype>,
       addressRepositoryGetter: Getter<typeof repoClass.prototype>,
       cartItemRepositoryGetter: Getter<typeof repoClass.prototype>,
       customerCartItemLinkRepositoryGetter: Getter<typeof repoClass.prototype>,
+      promotionRepositoryGetter: {
+        [repoType: string]: Getter<typeof repoClass.prototype>;
+      },
+      customerPromotionLinkRepositoryGetter: Getter<typeof repoClass.prototype>,
+      paymentMethodRepositoryGetter: {
+        [repoType: string]: Getter<typeof repoClass.prototype>;
+      },
+      contactRepositoryGetter: Getter<typeof repoClass.prototype>,
     ) {
       super(Customer, db);
       const ordersMeta = this.entityClass.definition.relations['orders'];
@@ -94,6 +123,24 @@ export function createCustomerRepo(repoClass: CrudRepositoryCtor) {
         cartItemsMeta as HasManyDefinition,
         cartItemRepositoryGetter,
         customerCartItemLinkRepositoryGetter,
+      );
+      const promotionsMeta =
+        this.entityClass.definition.relations['promotions'];
+      this.promotions = createHasManyThroughRepositoryFactory(
+        promotionsMeta as HasManyDefinition,
+        promotionRepositoryGetter,
+        customerPromotionLinkRepositoryGetter,
+      );
+      const paymentMethodMeta =
+        this.entityClass.definition.relations['paymentMethod'];
+      this.paymentMethod = createHasOneRepositoryFactory(
+        paymentMethodMeta as HasOneDefinition,
+        paymentMethodRepositoryGetter,
+      );
+      const contactMeta = this.entityClass.definition.relations['contact'];
+      this.contact = createHasOneRepositoryFactory(
+        contactMeta as HasOneDefinition,
+        contactRepositoryGetter,
       );
     }
   };

--- a/packages/repository-tests/src/crud/relations/fixtures/repositories/index.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/repositories/index.ts
@@ -5,9 +5,14 @@
 
 export * from './address.repository';
 export * from './cart-item.repository';
+export * from './contact.repository';
 export * from './customer-cart-item-link.repository';
+export * from './customer-promotion-link.repository';
 export * from './customer.repository';
 export * from './order.repository';
+export * from './payment-method.repository';
+export * from './promotion.repository';
 export * from './shipment.repository';
-export * from './user.repository';
+export * from './supplier.repository';
 export * from './user-link.repository';
+export * from './user.repository';

--- a/packages/repository-tests/src/crud/relations/fixtures/repositories/payment-method.repository.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/repositories/payment-method.repository.ts
@@ -1,0 +1,118 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Getter} from '@loopback/core';
+import {
+  BelongsToAccessor,
+  BelongsToDefinition,
+  createBelongsToAccessor,
+  createHasOneRepositoryFactory,
+  HasOneDefinition,
+  HasOneRepositoryFactory,
+  juggler,
+} from '@loopback/repository';
+import {CrudRepositoryCtor} from '../../../..';
+import {
+  CardInfo,
+  CardInfoRelations,
+  Cash,
+  CashRelations,
+  CreditCard,
+  CreditCardRelations,
+  Customer,
+} from '../models';
+
+export function createCreditCardRepo(repoClass: CrudRepositoryCtor) {
+  return class CreditCardRepository extends repoClass<
+    CreditCard,
+    typeof CreditCard.prototype.id,
+    CreditCardRelations
+  > {
+    public readonly customer: BelongsToAccessor<
+      Customer,
+      typeof CreditCard.prototype.id
+    >;
+
+    public readonly cardInfo: HasOneRepositoryFactory<
+      CardInfo,
+      typeof CreditCard.prototype.id
+    >;
+
+    constructor(
+      db: juggler.DataSource,
+      customerRepositoryGetter: Getter<typeof repoClass.prototype>,
+      cardInfoRepositoryGetter: Getter<typeof repoClass.prototype>,
+    ) {
+      super(CreditCard, db);
+      // create a belongsto relation from this public method
+      const customerMeta = this.entityClass.definition.relations['customer'];
+      this.customer = createBelongsToAccessor(
+        customerMeta as BelongsToDefinition,
+        customerRepositoryGetter,
+        this,
+      );
+      const cardInfoMeta = this.entityClass.definition.relations['cardInfo'];
+      this.cardInfo = createHasOneRepositoryFactory(
+        cardInfoMeta as HasOneDefinition,
+        cardInfoRepositoryGetter,
+      );
+    }
+  };
+}
+
+export function createCashRepo(repoClass: CrudRepositoryCtor) {
+  return class CashRepository extends repoClass<
+    Cash,
+    typeof Cash.prototype.id,
+    CashRelations
+  > {
+    public readonly customer: BelongsToAccessor<
+      Customer,
+      typeof Cash.prototype.id
+    >;
+
+    constructor(
+      db: juggler.DataSource,
+      customerRepositoryGetter: Getter<typeof repoClass.prototype>,
+    ) {
+      super(Cash, db);
+      // create a belongsto relation from this public method
+      const customerMeta = this.entityClass.definition.relations['customer'];
+      this.customer = createBelongsToAccessor(
+        customerMeta as BelongsToDefinition,
+        customerRepositoryGetter,
+        this,
+      );
+    }
+  };
+}
+
+export function createCardInfoRepo(repoClass: CrudRepositoryCtor) {
+  return class CardInfoRepository extends repoClass<
+    CardInfo,
+    typeof CardInfo.prototype.id,
+    CardInfoRelations
+  > {
+    public readonly creditCard: BelongsToAccessor<
+      CreditCard,
+      typeof CardInfo.prototype.id
+    >;
+
+    constructor(
+      db: juggler.DataSource,
+      creditCardRepositoryGetter: Getter<typeof repoClass.prototype>,
+    ) {
+      super(CardInfo, db);
+      // create a belongsto relation from this public method
+      const creditCardMeta =
+        this.entityClass.definition.relations['creditCard'];
+      this.creditCard = createBelongsToAccessor(
+        creditCardMeta as BelongsToDefinition,
+        creditCardRepositoryGetter,
+        this,
+      );
+    }
+  };
+}

--- a/packages/repository-tests/src/crud/relations/fixtures/repositories/promotion.repository.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/repositories/promotion.repository.ts
@@ -1,0 +1,37 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {juggler} from '@loopback/repository';
+import {CrudRepositoryCtor} from '../../../..';
+import {
+  FreeDelivery,
+  FreeDeliveryRelations,
+  HalfPrice,
+  HalfPriceRelations,
+} from '../models';
+
+export function createFreeDeliveryRepo(repoClass: CrudRepositoryCtor) {
+  return class FreeDeliveryRepository extends repoClass<
+    FreeDelivery,
+    typeof FreeDelivery.prototype.id,
+    FreeDeliveryRelations
+  > {
+    constructor(db: juggler.DataSource) {
+      super(FreeDelivery, db);
+    }
+  };
+}
+
+export function createHalfPriceRepo(repoClass: CrudRepositoryCtor) {
+  return class HalfPriceRepository extends repoClass<
+    HalfPrice,
+    typeof HalfPrice.prototype.id,
+    HalfPriceRelations
+  > {
+    constructor(db: juggler.DataSource) {
+      super(HalfPrice, db);
+    }
+  };
+}

--- a/packages/repository-tests/src/crud/relations/fixtures/repositories/supplier.repository.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/repositories/supplier.repository.ts
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Getter} from '@loopback/core';
+import {
+  createHasOneRepositoryFactory,
+  HasOneDefinition,
+  HasOneRepositoryFactory,
+  juggler,
+} from '@loopback/repository';
+import {CrudRepositoryCtor} from '../../../../types.repository-tests';
+import {Contact, Supplier, SupplierRelations} from '../models';
+
+// create the SupplierRepo by calling this func so that it can be extended from CrudRepositoryCtor
+export function createSupplierRepo(repoClass: CrudRepositoryCtor) {
+  return class SupplierRepository extends repoClass<
+    Supplier,
+    typeof Supplier.prototype.id,
+    SupplierRelations
+  > {
+    public readonly contact: HasOneRepositoryFactory<
+      Contact,
+      typeof Supplier.prototype.id
+    >;
+
+    constructor(
+      db: juggler.DataSource,
+      contactRepositoryGetter: Getter<typeof repoClass.prototype>,
+    ) {
+      super(Supplier, db);
+      const contactMeta = this.entityClass.definition.relations['contact'];
+      this.contact = createHasOneRepositoryFactory(
+        contactMeta as HasOneDefinition,
+        contactRepositoryGetter,
+      );
+    }
+  };
+}

--- a/packages/repository/src/__tests__/unit/repositories/has-many-through-repository-factory.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/has-many-through-repository-factory.unit.ts
@@ -12,8 +12,8 @@ import {
   model,
   property,
 } from '../../..';
-import {createHasManyThroughRepositoryFactory} from '../../../relations/has-many/has-many-through.repository-factory';
 import {HasManyThroughResolvedDefinition} from '../../../relations/has-many/has-many-through.helpers';
+import {createHasManyThroughRepositoryFactory} from '../../../relations/has-many/has-many-through.repository-factory';
 
 describe('createHasManyThroughRepositoryFactory', () => {
   let categoryProductLinkRepo: CategoryProductLinkRepository;
@@ -100,6 +100,7 @@ describe('createHasManyThroughRepositoryFactory', () => {
       model: () => CategoryProductLink,
       keyFrom: 'categoryId',
       keyTo: 'productId',
+      polymorphic: false,
     },
   };
 

--- a/packages/repository/src/__tests__/unit/repositories/relations-helpers/include-field-if-not.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/relations-helpers/include-field-if-not.unit.ts
@@ -1,0 +1,141 @@
+import {Fields} from '@loopback/filter';
+import {expect} from '@loopback/testlab';
+import {includeFieldIfNot} from '../../../..';
+
+describe('includeFieldIfNot', () => {
+  type MD = {
+    field1: string;
+    field2: number;
+    field3: {field4: string; field5: boolean};
+  };
+
+  it('no-operation case 1 - empty dictionary', async () => {
+    const fields: Fields<MD> = {};
+
+    const result = includeFieldIfNot(fields, 'field1');
+    let after: Fields<MD>;
+    if (result === false) {
+      after = fields;
+    } else {
+      after = result;
+    }
+
+    expect(after).to.eql(fields);
+  });
+
+  it('no-operation case 2 - empty array', async () => {
+    const fields = [] as Fields<MD>;
+
+    const result = includeFieldIfNot(fields, 'field1');
+    let after: Fields<MD>;
+    if (result === false) {
+      after = fields;
+    } else {
+      after = result;
+    }
+
+    expect(after).to.eql(fields);
+  });
+
+  it('no-operation case 3 - included in dictionary', async () => {
+    const fields: Fields<MD> = {
+      field1: true,
+    };
+
+    const result = includeFieldIfNot(fields, 'field1');
+    let after: Fields<MD>;
+    if (result === false) {
+      after = fields;
+    } else {
+      after = result;
+    }
+
+    expect(after).to.eql(fields);
+  });
+
+  it('no-operation case 4 - included in array', async () => {
+    const fields = ['field1'] as Fields<MD>;
+
+    const result = includeFieldIfNot(fields, 'field1');
+    let after: Fields<MD>;
+    if (result === false) {
+      after = fields;
+    } else {
+      after = result;
+    }
+
+    expect(after).to.eql(fields);
+  });
+
+  it('dictionary form - other field included', async () => {
+    const fields: Fields<MD> = {
+      field2: true,
+    };
+
+    const result = includeFieldIfNot(fields, 'field1');
+    let after: Fields<MD>;
+    if (result === false) {
+      after = fields;
+    } else {
+      after = result;
+    }
+
+    expect(after).to.eql({
+      field1: true,
+      field2: true,
+    });
+  });
+
+  it('array form - other field included', async () => {
+    const fields = ['field2'] as Fields<MD>;
+
+    const result = includeFieldIfNot(fields, 'field1');
+    let after: Fields<MD>;
+    if (result === false) {
+      after = fields;
+    } else {
+      after = result;
+    }
+
+    expect(after).to.eql({
+      field1: true,
+      field2: true,
+    });
+  });
+
+  it('dictionary form - field excluded', async () => {
+    const fields: Fields<MD> = {
+      field1: false,
+    };
+
+    const result = includeFieldIfNot(fields, 'field1');
+    let after: Fields<MD>;
+    if (result === false) {
+      after = fields;
+    } else {
+      after = result;
+    }
+
+    expect(after).to.eql({});
+  });
+
+  it('dictionary form - field excluded with other field included', async () => {
+    const fields: Fields<MD> = {
+      field1: false,
+      field2: true,
+    };
+
+    const result = includeFieldIfNot(fields, 'field1');
+    let after: Fields<MD>;
+    if (result === false) {
+      after = fields;
+    } else {
+      after = result;
+    }
+
+    expect(after).to.eql({
+      field1: true,
+      field2: true,
+    });
+  });
+});

--- a/packages/repository/src/__tests__/unit/repositories/relations-helpers/resolve-belongs-to-metadata.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/relations-helpers/resolve-belongs-to-metadata.unit.ts
@@ -79,6 +79,41 @@ describe('resolveBelongsToMetadata', () => {
         keyFrom: 'categoryId',
         target: () => Category,
         keyTo: 'id',
+        polymorphic: false,
+      });
+    });
+
+    it('resolves metadata using polymorphic', () => {
+      Category.definition.addProperty('productType', {
+        type: 'string',
+        required: true,
+      });
+
+      const metadata = {
+        name: 'category',
+        type: RelationType.belongsTo,
+        targetsMany: false,
+
+        source: Product,
+        keyFrom: 'categoryId',
+
+        target: () => Category,
+        keyTo: 'id',
+
+        polymorphic: {discriminator: 'productType'},
+      };
+
+      const meta = resolveBelongsToMetadata(metadata as BelongsToDefinition);
+
+      expect(meta).to.eql({
+        name: 'category',
+        type: RelationType.belongsTo,
+        targetsMany: false,
+        source: Product,
+        keyFrom: 'categoryId',
+        target: () => Category,
+        keyTo: 'id',
+        polymorphic: {discriminator: 'productType'},
       });
     });
 
@@ -105,6 +140,7 @@ describe('resolveBelongsToMetadata', () => {
         keyFrom: 'categoryId',
         target: () => Category,
         keyTo: 'id',
+        polymorphic: false,
       });
     });
 
@@ -131,6 +167,7 @@ describe('resolveBelongsToMetadata', () => {
         keyFrom: 'categoryId',
         target: () => Category,
         keyTo: 'id',
+        polymorphic: false,
       });
     });
 
@@ -157,6 +194,37 @@ describe('resolveBelongsToMetadata', () => {
         keyFrom: 'categoryId',
         target: () => Category,
         keyTo: 'id',
+        polymorphic: false,
+      });
+    });
+
+    it('infers polymorphic discriminator not provided', async () => {
+      const metadata = {
+        name: 'category',
+        type: RelationType.belongsTo,
+        targetsMany: false,
+
+        source: Product,
+        // no keyFrom
+
+        target: () => Category,
+        // no keyTo
+
+        polymorphic: true,
+        // no discriminator
+      };
+
+      const meta = resolveBelongsToMetadata(metadata as BelongsToDefinition);
+
+      expect(meta).to.eql({
+        name: 'category',
+        type: RelationType.belongsTo,
+        targetsMany: false,
+        source: Product,
+        keyFrom: 'categoryId',
+        target: () => Category,
+        keyTo: 'id',
+        polymorphic: {discriminator: 'categoryType'},
       });
     });
   });

--- a/packages/repository/src/__tests__/unit/repositories/relations-helpers/resolve-has-many-through-metadata.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/relations-helpers/resolve-has-many-through-metadata.unit.ts
@@ -193,7 +193,7 @@ describe('HasManyThroughHelpers', () => {
       );
     });
 
-    describe('resolves through.keyTo/keyFrom', () => {
+    describe('resolves through.keyTo/keyFrom/polymorphic', () => {
       it('resolves metadata with complete hasManyThrough definition', () => {
         const metadata = {
           name: 'products',
@@ -208,13 +208,14 @@ describe('HasManyThroughHelpers', () => {
             model: () => CategoryProductLink,
             keyFrom: 'categoryId',
             keyTo: 'productId',
+            polymorphic: {discriminator: 'productType'},
           },
         };
         const meta = resolveHasManyThroughMetadata(
           metadata as HasManyDefinition,
         );
 
-        expect(meta).to.eql(relationMetaData);
+        expect(meta).to.eql(relationMetaDataWithPolymorphicDiscriminator);
       });
 
       it('infers through.keyFrom if it is not provided', () => {
@@ -262,6 +263,31 @@ describe('HasManyThroughHelpers', () => {
         );
 
         expect(meta).to.eql(relationMetaData);
+      });
+
+      it('infers through.polymorphic.discriminator if polymorphic equals to true', () => {
+        const metadata = {
+          name: 'products',
+          type: RelationType.hasMany,
+          targetsMany: true,
+          source: Category,
+          keyFrom: 'id',
+          target: () => Product,
+          keyTo: 'id',
+
+          through: {
+            model: () => CategoryProductLink,
+            keyFrom: 'categoryId',
+            keyTo: 'productId',
+            polymorphic: true,
+          },
+        };
+
+        const meta = resolveHasManyThroughMetadata(
+          metadata as HasManyDefinition,
+        );
+
+        expect(meta).to.eql(relationMetaDataWithPolymorphicDiscriminator);
       });
 
       it('throws if through.keyFrom is not provided in through', async () => {
@@ -392,6 +418,23 @@ describe('HasManyThroughHelpers', () => {
       model: () => CategoryProductLink,
       keyFrom: 'categoryId',
       keyTo: 'productId',
+      polymorphic: false,
+    },
+  } as HasManyThroughResolvedDefinition;
+
+  const relationMetaDataWithPolymorphicDiscriminator = {
+    name: 'products',
+    type: 'hasMany',
+    targetsMany: true,
+    source: Category,
+    keyFrom: 'id',
+    target: () => Product,
+    keyTo: 'id',
+    through: {
+      model: () => CategoryProductLink,
+      keyFrom: 'categoryId',
+      keyTo: 'productId',
+      polymorphic: {discriminator: 'productType'},
     },
   } as HasManyThroughResolvedDefinition;
 

--- a/packages/repository/src/__tests__/unit/repositories/relations-helpers/resolve-has-one-metadata.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/relations-helpers/resolve-has-one-metadata.unit.ts
@@ -52,6 +52,35 @@ describe('resolveHasOneMetadata', () => {
         keyFrom: 'id',
         target: () => Category,
         keyTo: 'productId',
+        polymorphic: false,
+      });
+    });
+
+    it('resolves metadata using polymorphic', () => {
+      const metadata = {
+        name: 'category',
+        type: RelationType.hasOne,
+        targetsMany: false,
+
+        source: Product,
+        keyFrom: 'id',
+
+        target: () => Category,
+        keyTo: 'productId',
+
+        polymorphic: {discriminator: 'productType'},
+      };
+      const meta = resolveHasOneMetadata(metadata as HasOneDefinition);
+
+      expect(meta).to.eql({
+        name: 'category',
+        type: 'hasOne',
+        targetsMany: false,
+        source: Product,
+        keyFrom: 'id',
+        target: () => Category,
+        keyTo: 'productId',
+        polymorphic: {discriminator: 'productType'},
       });
     });
 
@@ -77,6 +106,7 @@ describe('resolveHasOneMetadata', () => {
         keyFrom: 'id',
         target: () => Category,
         keyTo: 'productId',
+        polymorphic: false,
       });
     });
 
@@ -103,6 +133,7 @@ describe('resolveHasOneMetadata', () => {
         keyFrom: 'id',
         target: () => Category,
         keyTo: 'productId',
+        polymorphic: false,
       });
     });
 
@@ -151,6 +182,39 @@ describe('resolveHasOneMetadata', () => {
         keyFrom: 'id',
         target: () => Category,
         keyTo: 'categoryId',
+        polymorphic: false,
+      });
+    });
+
+    it('infers polymorphic discriminator not provided', async () => {
+      Category.definition.addProperty('categoryId', {type: 'number'});
+
+      const metadata = {
+        name: 'category',
+        type: RelationType.hasOne,
+        targetsMany: false,
+
+        source: Category,
+        // no keyFrom
+
+        target: () => Category,
+        // no keyTo
+
+        polymorphic: true,
+        // no discriminator
+      };
+
+      const meta = resolveHasOneMetadata(metadata as HasOneDefinition);
+
+      expect(meta).to.eql({
+        name: 'category',
+        type: 'hasOne',
+        targetsMany: false,
+        source: Category,
+        keyFrom: 'id',
+        target: () => Category,
+        keyTo: 'categoryId',
+        polymorphic: {discriminator: 'categoryType'},
       });
     });
   });

--- a/packages/repository/src/errors/index.ts
+++ b/packages/repository/src/errors/index.ts
@@ -5,3 +5,4 @@
 
 export * from './entity-not-found.error';
 export * from './invalid-relation.error';
+export * from './invalid-polymorphism.error';

--- a/packages/repository/src/errors/invalid-polymorphism.error.ts
+++ b/packages/repository/src/errors/invalid-polymorphism.error.ts
@@ -1,0 +1,28 @@
+export class InvalidPolymorphismError<Props extends object = {}> extends Error {
+  code: string;
+
+  constructor(
+    typeName: string,
+    discriminator?: string,
+    extraProperties?: Props,
+  ) {
+    const message = discriminator
+      ? `Invalid class name ${typeName} by discriminator ${discriminator}. Please check polymorphic types and the discriminator.`
+      : `Invalid class name ${typeName}. Please check polymorphic types and the discriminator.`;
+    super(message);
+
+    Error.captureStackTrace(this, this.constructor);
+
+    this.code = 'INVALID_POLYMORPHISM';
+
+    Object.assign(this, extraProperties);
+  }
+}
+
+export function isInvalidPolymorphismError(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  e: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): e is InvalidPolymorphismError<any> {
+  return e instanceof InvalidPolymorphismError;
+}

--- a/packages/repository/src/relations/belongs-to/belongs-to.inclusion-resolver.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.inclusion-resolver.ts
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Filter, InclusionFilter} from '@loopback/filter';
+import {includeFieldIfNot, InvalidPolymorphismError} from '../../';
 import {AnyObject, Options} from '../../common-types';
 import {Entity} from '../../model';
 import {EntityCrudRepository} from '../../repositories';
@@ -28,7 +29,8 @@ import {resolveBelongsToMetadata} from './belongs-to.helpers';
  * Notice: scope field for inclusion is not supported yet
  *
  * @param meta - resolved BelongsToMetadata
- * @param getTargetRepo - target repository i.e where related instances are
+ * @param getTargetRepoDict - dictionary of target model type - target repository
+ * i.e where related instances for different types are
  */
 export function createBelongsToInclusionResolver<
   Target extends Entity,
@@ -36,36 +38,125 @@ export function createBelongsToInclusionResolver<
   TargetRelations extends object,
 >(
   meta: BelongsToDefinition,
-  getTargetRepo: Getter<
-    EntityCrudRepository<Target, TargetID, TargetRelations>
-  >,
+  getTargetRepoDict: {
+    [repoType: string]: Getter<
+      EntityCrudRepository<Target, TargetID, TargetRelations>
+    >;
+  },
 ): InclusionResolver<Entity, Target> {
   const relationMeta = resolveBelongsToMetadata(meta);
 
-  return async function fetchIncludedModels(
+  return async function fetchBelongsToModel(
     entities: Entity[],
     inclusion: InclusionFilter,
     options?: Options,
-  ): Promise<((Target & TargetRelations) | undefined)[]> {
+  ): Promise<((Target & object) | undefined)[]> {
     if (!entities.length) return [];
 
+    // Source ids are grouped by their target polymorphic types
+    // Each type search for target instances and then merge together in a merge-sort-like manner
+
     const sourceKey = relationMeta.keyFrom;
-    const sourceIds = entities.map(e => (e as AnyObject)[sourceKey]);
     const targetKey = relationMeta.keyTo as StringKeyOf<Target>;
-    const dedupedSourceIds = deduplicate(sourceIds);
+    const targetDiscriminator: keyof Entity | undefined =
+      relationMeta.polymorphic
+        ? (relationMeta.polymorphic.discriminator as keyof Entity)
+        : undefined;
 
     const scope =
       typeof inclusion === 'string' ? {} : (inclusion.scope as Filter<Target>);
 
-    const targetRepo = await getTargetRepo();
-    const targetsFound = await findByForeignKeys(
-      targetRepo,
-      targetKey,
-      dedupedSourceIds.filter(e => e),
-      scope,
-      options,
-    );
+    // sourceIds in {targetType -> sourceId}
+    const sourceIdsCategorized: {
+      [concreteItemType: string]: Target[StringKeyOf<Target>][];
+    } = {};
+    if (targetDiscriminator) {
+      entities.forEach((value, index, allEntites) => {
+        const concreteType = String(value[targetDiscriminator]);
+        if (!getTargetRepoDict[concreteType]) {
+          throw new InvalidPolymorphismError(concreteType, targetDiscriminator);
+        }
+        if (!sourceIdsCategorized[concreteType]) {
+          sourceIdsCategorized[concreteType] = [];
+        }
+        sourceIdsCategorized[concreteType].push(
+          (value as AnyObject)[sourceKey],
+        );
+      });
+    } else {
+      const concreteType = relationMeta.target().name;
+      if (!getTargetRepoDict[concreteType]) {
+        throw new InvalidPolymorphismError(concreteType);
+      }
+      entities.forEach((value, index, allEntites) => {
+        if (!sourceIdsCategorized[concreteType]) {
+          sourceIdsCategorized[concreteType] = [];
+        }
+        sourceIdsCategorized[concreteType].push(
+          (value as AnyObject)[sourceKey],
+        );
+      });
+    }
 
-    return flattenTargetsOfOneToOneRelation(sourceIds, targetsFound, targetKey);
+    // Ensure targetKey is included otherwise flatten function cannot work
+    const changedTargetKeyField = includeFieldIfNot(scope?.fields, targetKey);
+    let needToRemoveTargetKeyFieldLater = false;
+    if (changedTargetKeyField !== false) {
+      scope.fields = changedTargetKeyField;
+      needToRemoveTargetKeyFieldLater = true;
+    }
+    // Each sourceIds array with same target type extract target instances
+    const targetCategorized: {
+      [concreteItemType: string]: ((Target & TargetRelations) | undefined)[];
+    } = {};
+    for (const k of Object.keys(sourceIdsCategorized)) {
+      const targetRepo = await getTargetRepoDict[k]();
+      const targetsFound = await findByForeignKeys(
+        targetRepo,
+        targetKey,
+        deduplicate(sourceIdsCategorized[k]).filter(e => e),
+        scope,
+        options,
+      );
+      targetCategorized[k] = flattenTargetsOfOneToOneRelation(
+        sourceIdsCategorized[k],
+        targetsFound,
+        targetKey,
+      );
+
+      // Remove targetKey if should be excluded but included above
+      if (needToRemoveTargetKeyFieldLater) {
+        targetCategorized[k] = targetCategorized[k].map(e => {
+          if (e) {
+            delete e[targetKey];
+          }
+          return e;
+        });
+      }
+    }
+
+    // Merge
+    // Why the order is correct:
+    // e.g. target model 1 = a, target model 2 = b
+    // all entities: [S(a-1), S(a-2), S(b-3), S(a-4), S(b-5)]
+    // a-result: [a-1, a-2, a-4]
+    // b-result: [b-3, b-4]
+    // merged:
+    // entities[1]->a => targets: [a-1 from a-result.shift()]
+    // entities[2]->a => targets: [a-1, a-2 from a-result.shift()]
+    // entities[3]->b => targets: [a-1, a-2, b-3 from b-result.shift()]
+    // entities[4]->a => targets: [a-1, a-2, b-3, a-4 from a-result.shift()]
+    // entities[5]->b => targets: [a-1, a-2, b-3, a-4, b-5 from b-result.shift()]
+    if (targetDiscriminator) {
+      const allTargets: ((Target & TargetRelations) | undefined)[] = [];
+      entities.forEach((value, index, allEntites) => {
+        allTargets.push(
+          targetCategorized[String(value[targetDiscriminator])].shift(),
+        );
+      });
+      return allTargets;
+    } else {
+      return targetCategorized[relationMeta.target().name];
+    }
   };
 }

--- a/packages/repository/src/relations/belongs-to/belongs-to.repository.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.repository.ts
@@ -4,11 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Getter} from '@loopback/core';
+import {cloneDeep} from 'lodash';
+import {EntityNotFoundError, TypeResolver} from '../../';
 import {DataObject, Options} from '../../common-types';
-import {EntityNotFoundError} from '../../errors';
 import {Entity} from '../../model';
 import {constrainFilter, EntityCrudRepository} from '../../repositories';
-
 /**
  * CRUD operations for a target repository of a BelongsTo relation
  */
@@ -16,10 +16,16 @@ export interface BelongsToRepository<Target extends Entity> {
   /**
    * Gets the target model instance
    * @param options
+   * options.polymorphicType - a string or a string array of polymorphic type names
+   * to specify which repositories should are expected to be searched
+   * It is highly recommended to contain this param especially for
+   * datasources using deplicated ids across tables
    * @returns A promise resolved with the target object or rejected
    * with an EntityNotFoundError when target model instance was not found.
    */
-  get(options?: Options): Promise<Target>;
+  get(
+    options?: Options & {polymorphicType?: string | string[]},
+  ): Promise<Target>;
 }
 
 export class DefaultBelongsToRepository<
@@ -30,26 +36,80 @@ export class DefaultBelongsToRepository<
 {
   /**
    * Constructor of DefaultBelongsToEntityCrudRepository
-   * @param getTargetRepository - the getter of the related target model repository instance
+   * @param getTargetRepository - either a dictionary of target model type - target repository instance
+   * or a single target repository instance
+   * e.g. if the target is of a non-polymorphic type "Student", put the studentRepositoryGetterInstance
+   * if the target is of a polymorphic type "Person" which can be either a "Student" or a "Teacher"
+   * then put "{Student: studentRepositoryGetterInstance, Teacher: teacherRepositoryGetterInstance}"
    * @param constraint - the key value pair representing foreign key name to constrain
    * the target repository instance
+   * @param targetResolver - () => Target to resolve the target class
+   * e.g. if the target is of type "Student", then put "() => Student"
    */
-  constructor(
-    public getTargetRepository: Getter<TargetRepository>,
-    public constraint: DataObject<TargetEntity>,
-  ) {}
 
-  async get(options?: Options): Promise<TargetEntity> {
-    const targetRepo = await this.getTargetRepository();
-    const result = await targetRepo.find(
-      constrainFilter(undefined, this.constraint),
-      options,
-    );
-    if (!result.length) {
-      // We don't have a direct access to the foreign key value here :(
-      const id = 'constraint ' + JSON.stringify(this.constraint);
-      throw new EntityNotFoundError(targetRepo.entityClass, id);
+  constructor(
+    public getTargetRepository:
+      | Getter<TargetRepository>
+      | {
+          [repoType: string]: Getter<TargetRepository>;
+        },
+    public constraint: DataObject<TargetEntity>,
+    public targetResolver: TypeResolver<Entity, typeof Entity>,
+  ) {
+    if (typeof getTargetRepository === 'function') {
+      this.getTargetRepositoryDict = {
+        [targetResolver().name]:
+          getTargetRepository as Getter<TargetRepository>,
+      };
+    } else {
+      this.getTargetRepositoryDict = getTargetRepository as {
+        [repoType: string]: Getter<TargetRepository>;
+      };
     }
-    return result[0];
+  }
+
+  public getTargetRepositoryDict: {
+    [repoType: string]: Getter<TargetRepository>;
+  };
+
+  async get(
+    options?: Options & {polymorphicType?: string | string[]},
+  ): Promise<TargetEntity> {
+    let polymorphicTypes = options?.polymorphicType;
+    let allKeys: string[];
+    if (Object.keys(this.getTargetRepositoryDict).length <= 1) {
+      allKeys = Object.keys(this.getTargetRepositoryDict);
+    } else if (!polymorphicTypes || polymorphicTypes.length === 0) {
+      console.warn(
+        'It is highly recommended to specify the polymorphicTypes param when using polymorphic types.',
+      );
+      allKeys = Object.keys(this.getTargetRepositoryDict);
+    } else {
+      if (typeof polymorphicTypes === 'string') {
+        polymorphicTypes = [polymorphicTypes];
+      }
+      allKeys = [];
+      new Set(polymorphicTypes!).forEach(element => {
+        if (Object.keys(this.getTargetRepositoryDict).includes(element)) {
+          allKeys.push(element);
+        }
+      });
+    }
+    let result: TargetEntity[] = [];
+    for (const key of allKeys) {
+      const targetRepository = await this.getTargetRepositoryDict[key]();
+      result = result.concat(
+        await targetRepository.find(
+          constrainFilter(undefined, this.constraint),
+          Object.assign(cloneDeep(options ?? {}), {polymorphicType: key}),
+        ),
+      );
+      if (result.length >= 1) {
+        return result[0];
+      }
+    }
+    // We don't have a direct access to the foreign key value here :(
+    const id = 'constraint ' + JSON.stringify(this.constraint);
+    throw new EntityNotFoundError(this.targetResolver().name, id);
   }
 }

--- a/packages/repository/src/relations/has-many/has-many-through.repository.ts
+++ b/packages/repository/src/relations/has-many/has-many-through.repository.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {cloneDeep} from 'lodash';
 import {
   constrainDataObject,
   constrainFilter,
@@ -14,7 +15,10 @@ import {
   EntityCrudRepository,
   Filter,
   Getter,
+  InvalidPolymorphismError,
   Options,
+  StringKeyOf,
+  TypeResolver,
   Where,
 } from '../..';
 
@@ -33,6 +37,8 @@ export interface HasManyThroughRepository<
    * Create a target model instance
    * @param targetModelData - The target model data
    * @param options - Options for the operation
+   * options.polymorphicType a string or a string array of polymorphic type names
+   * specify of which concrete model the created instance should be
    * @returns A promise which resolves to the newly created target model instance
    */
   create(
@@ -40,33 +46,43 @@ export interface HasManyThroughRepository<
     options?: Options & {
       throughData?: DataObject<Through>;
       throughOptions?: Options;
-    },
+    } & {polymorphicType?: string},
   ): Promise<Target>;
 
   /**
    * Find target model instance(s)
    * @param filter - A filter object for where, order, limit, etc.
    * @param options - Options for the operation
+   * options.throughOptions.discriminator - target discriminator field on through
+   * options.polymorphicType a string or a string array of polymorphic type names
+   * to specify which repositories should are expected to be searched
+   * It is highly recommended to contain this param especially for
+   * datasources using deplicated ids across tables
    * @returns A promise which resolves with the found target instance(s)
    */
   find(
     filter?: Filter<Target>,
     options?: Options & {
-      throughOptions?: Options;
-    },
+      throughOptions?: Options & {discriminator?: string};
+    } & {polymorphicType?: string | string[]},
   ): Promise<Target[]>;
 
   /**
    * Delete multiple target model instances
    * @param where - Instances within the where scope are deleted
    * @param options
+   * options.throughOptions.discriminator - target discriminator field on through
+   * options.polymorphicType a string or a string array of polymorphic type names
+   * to specify which repositories should are expected to be searched
+   * It is highly recommended to contain this param especially for
+   * datasources using deplicated ids across tables
    * @returns A promise which resolves the deleted target model instances
    */
   delete(
     where?: Where<Target>,
     options?: Options & {
-      throughOptions?: Options;
-    },
+      throughOptions?: Options & {discriminator?: string};
+    } & {polymorphicType?: string | string[]},
   ): Promise<Count>;
 
   /**
@@ -74,14 +90,18 @@ export interface HasManyThroughRepository<
    * @param dataObject - The fields and their new values to patch
    * @param where - Instances within the where scope are patched
    * @param options
+   * options.throughOptions.discriminator - target discriminator field on through
+   * options.isPolymorphic - whether dataObject is a dictionary
    * @returns A promise which resolves the patched target model instances
    */
   patch(
-    dataObject: DataObject<Target>,
+    dataObject:
+      | DataObject<Target>
+      | {[polymorphicType: string]: DataObject<Target>},
     where?: Where<Target>,
     options?: Options & {
-      throughOptions?: Options;
-    },
+      throughOptions?: Options & {discriminator?: string};
+    } & {isPolymorphic?: boolean},
   ): Promise<Count>;
 
   /**
@@ -140,7 +160,11 @@ export class DefaultHasManyThroughRepository<
 > implements HasManyThroughRepository<TargetEntity, TargetID, ThroughEntity>
 {
   constructor(
-    public getTargetRepository: Getter<TargetRepository>,
+    public getTargetRepository:
+      | Getter<TargetRepository>
+      | {
+          [repoType: string]: Getter<TargetRepository>;
+        },
     public getThroughRepository: Getter<ThroughRepository>,
     public getTargetConstraintFromThroughModels: (
       throughInstances: ThroughEntity[],
@@ -151,16 +175,52 @@ export class DefaultHasManyThroughRepository<
     public getThroughConstraintFromTarget: (
       targetID: TargetID[],
     ) => DataObject<ThroughEntity>,
-  ) {}
+    public targetResolver: TypeResolver<Entity, typeof Entity>,
+    public throughResolver: TypeResolver<Entity, typeof Entity>,
+  ) {
+    if (typeof getTargetRepository === 'function') {
+      this.getTargetRepositoryDict = {
+        [targetResolver().name]:
+          getTargetRepository as Getter<TargetRepository>,
+      };
+    } else {
+      this.getTargetRepositoryDict = getTargetRepository as {
+        [repoType: string]: Getter<TargetRepository>;
+      };
+    }
+  }
+
+  public getTargetRepositoryDict: {
+    [repoType: string]: Getter<TargetRepository>;
+  };
 
   async create(
     targetModelData: DataObject<TargetEntity>,
     options?: Options & {
       throughData?: DataObject<ThroughEntity>;
       throughOptions?: Options;
-    },
+    } & {polymorphicType?: string},
   ): Promise<TargetEntity> {
-    const targetRepository = await this.getTargetRepository();
+    let targetPolymorphicTypeName = options?.polymorphicType;
+    if (targetPolymorphicTypeName) {
+      if (!this.getTargetRepositoryDict[targetPolymorphicTypeName]) {
+        throw new InvalidPolymorphismError(targetPolymorphicTypeName);
+      }
+    } else {
+      if (Object.keys(this.getTargetRepositoryDict).length > 1) {
+        console.warn(
+          'It is highly recommended to specify the polymorphicTypes param when using polymorphic types.',
+        );
+      }
+      targetPolymorphicTypeName = this.targetResolver().name;
+      if (!this.getTargetRepositoryDict[targetPolymorphicTypeName]) {
+        throw new InvalidPolymorphismError(targetPolymorphicTypeName);
+      }
+    }
+
+    const targetRepository = await this.getTargetRepositoryDict[
+      targetPolymorphicTypeName
+    ]();
     const targetInstance = await targetRepository.create(
       targetModelData,
       options,
@@ -172,91 +232,298 @@ export class DefaultHasManyThroughRepository<
   async find(
     filter?: Filter<TargetEntity>,
     options?: Options & {
-      throughOptions?: Options;
-    },
+      throughOptions?: Options & {discriminator?: string};
+    } & {polymorphicType?: string | string[]},
   ): Promise<TargetEntity[]> {
-    const targetRepository = await this.getTargetRepository();
-    const throughRepository = await this.getThroughRepository();
+    const targetDiscriminatorOnThrough = options?.throughOptions?.discriminator;
+    let targetPolymorphicTypes = options?.polymorphicType;
+    let allKeys: string[];
+    if (Object.keys(this.getTargetRepositoryDict).length <= 1) {
+      allKeys = Object.keys(this.getTargetRepositoryDict);
+    } else {
+      if (!targetDiscriminatorOnThrough) {
+        console.warn(
+          'It is highly recommended to specify the targetDiscriminatorOnThrough param when using polymorphic types.',
+        );
+      }
+      if (!targetPolymorphicTypes || targetPolymorphicTypes.length === 0) {
+        console.warn(
+          'It is highly recommended to specify the polymorphicTypes param when using polymorphic types.',
+        );
+        allKeys = Object.keys(this.getTargetRepositoryDict);
+      } else {
+        if (typeof targetPolymorphicTypes === 'string') {
+          targetPolymorphicTypes = [targetPolymorphicTypes];
+        }
+        allKeys = [];
+        new Set(targetPolymorphicTypes!).forEach(element => {
+          if (Object.keys(this.getTargetRepositoryDict).includes(element)) {
+            allKeys.push(element);
+          }
+        });
+      }
+    }
+
     const sourceConstraint = this.getThroughConstraintFromSource();
-    const throughInstances = await throughRepository.find(
-      constrainFilter(undefined, sourceConstraint),
-      options?.throughOptions,
-    );
-    const targetConstraint =
-      this.getTargetConstraintFromThroughModels(throughInstances);
-    return targetRepository.find(
-      constrainFilter(filter, targetConstraint),
-      options,
-    );
+
+    const throughCategorized: {[concreteType: string]: (ThroughEntity & {})[]} =
+      {};
+    const throughRepository = await this.getThroughRepository();
+    (
+      await throughRepository.find(
+        constrainFilter(undefined, sourceConstraint),
+        options?.throughOptions,
+      )
+    ).forEach(element => {
+      let concreteTargetType;
+      if (!targetDiscriminatorOnThrough) {
+        concreteTargetType = this.targetResolver().name;
+      } else {
+        concreteTargetType = String(
+          element[targetDiscriminatorOnThrough as StringKeyOf<ThroughEntity>],
+        );
+      }
+      if (!allKeys.includes(concreteTargetType)) {
+        return;
+      }
+      if (!this.getTargetRepositoryDict[concreteTargetType]) {
+        throw new InvalidPolymorphismError(
+          concreteTargetType,
+          targetDiscriminatorOnThrough,
+        );
+      }
+      if (!throughCategorized[concreteTargetType]) {
+        throughCategorized[concreteTargetType] = [];
+      }
+      throughCategorized[concreteTargetType].push(element);
+    });
+
+    let allTargets: TargetEntity[] = [];
+    for (const key of Object.keys(throughCategorized)) {
+      const targetRepository = await this.getTargetRepositoryDict[key]();
+      const targetConstraint = this.getTargetConstraintFromThroughModels(
+        throughCategorized[key],
+      );
+      allTargets = allTargets.concat(
+        await targetRepository.find(
+          constrainFilter(filter, targetConstraint),
+          Object.assign(cloneDeep(options ?? {}), {polymorphicType: key}),
+        ),
+      );
+    }
+
+    return allTargets;
   }
 
   async delete(
     where?: Where<TargetEntity>,
     options?: Options & {
-      throughOptions?: Options;
-    },
+      throughOptions?: Options & {discriminator?: string};
+    } & {polymorphicType?: string | string[]},
   ): Promise<Count> {
-    const targetRepository = await this.getTargetRepository();
-    const throughRepository = await this.getThroughRepository();
-    const sourceConstraint = this.getThroughConstraintFromSource();
-    const throughInstances = await throughRepository.find(
-      constrainFilter(undefined, sourceConstraint),
-      options?.throughOptions,
-    );
-    if (where) {
-      // only delete related through models
-      // TODO(Agnes): this performance can be improved by only fetching related data
-      // TODO: add target ids to the `where` constraint
-      const targets = await targetRepository.find({where});
-      const targetIds = this.getTargetIds(targets);
-      if (targetIds.length > 0) {
-        const targetConstraint = this.getThroughConstraintFromTarget(targetIds);
-        const constraints = {...targetConstraint, ...sourceConstraint};
-        await throughRepository.deleteAll(
-          constrainDataObject({}, constraints as DataObject<ThroughEntity>),
-          options?.throughOptions,
+    const targetDiscriminatorOnThrough = options?.throughOptions?.discriminator;
+    let targetPolymorphicTypes = options?.polymorphicType;
+    let allKeys: string[];
+    if (Object.keys(this.getTargetRepositoryDict).length <= 1) {
+      allKeys = Object.keys(this.getTargetRepositoryDict);
+    } else {
+      if (!targetDiscriminatorOnThrough) {
+        console.warn(
+          'It is highly recommended to specify the targetDiscriminatorOnThrough param when using polymorphic types.',
         );
       }
-    } else {
-      // otherwise, delete through models that relate to the sourceId
-      const targetFkValues = this.getTargetKeys(throughInstances);
-      // delete through instances that have the targets that are going to be deleted
-      const throughFkConstraint =
-        this.getThroughConstraintFromTarget(targetFkValues);
-      await throughRepository.deleteAll(
-        constrainWhereOr({}, [sourceConstraint, throughFkConstraint]),
-      );
+      if (!targetPolymorphicTypes || targetPolymorphicTypes.length === 0) {
+        console.warn(
+          'It is highly recommended to specify the polymorphicTypes param when using polymorphic types.',
+        );
+        allKeys = Object.keys(this.getTargetRepositoryDict);
+      } else {
+        if (typeof targetPolymorphicTypes === 'string') {
+          targetPolymorphicTypes = [targetPolymorphicTypes];
+        }
+        allKeys = [];
+        new Set(targetPolymorphicTypes!).forEach(element => {
+          if (Object.keys(this.getTargetRepositoryDict).includes(element)) {
+            allKeys.push(element);
+          }
+        });
+      }
     }
-    // delete target(s)
-    const targetConstraint =
-      this.getTargetConstraintFromThroughModels(throughInstances);
-    return targetRepository.deleteAll(
-      constrainWhere(where, targetConstraint as Where<TargetEntity>),
-      options,
-    );
+
+    const sourceConstraint = this.getThroughConstraintFromSource();
+    let totalCount = 0;
+    const throughCategorized: {[concreteType: string]: (ThroughEntity & {})[]} =
+      {};
+    const throughRepository = await this.getThroughRepository();
+    (
+      await throughRepository.find(
+        constrainFilter(undefined, sourceConstraint),
+        options?.throughOptions,
+      )
+    ).forEach(element => {
+      let concreteTargetType;
+      if (!targetDiscriminatorOnThrough) {
+        concreteTargetType = this.targetResolver().name;
+      } else {
+        concreteTargetType = String(
+          element[targetDiscriminatorOnThrough as StringKeyOf<ThroughEntity>],
+        );
+      }
+      if (!allKeys.includes(concreteTargetType)) {
+        return;
+      }
+      if (!this.getTargetRepositoryDict[concreteTargetType]) {
+        throw new InvalidPolymorphismError(
+          concreteTargetType,
+          targetDiscriminatorOnThrough,
+        );
+      }
+      if (!throughCategorized[concreteTargetType]) {
+        throughCategorized[concreteTargetType] = [];
+      }
+      throughCategorized[concreteTargetType].push(element);
+    });
+
+    for (const targetKey of Object.keys(throughCategorized)) {
+      const targetRepository = await this.getTargetRepositoryDict[targetKey]();
+      if (where) {
+        // only delete related through models
+        // TODO(Agnes): this performance can be improved by only fetching related data
+        // TODO: add target ids to the `where` constraint
+        const targets = await targetRepository.find({where});
+        const targetIds = this.getTargetIds(targets);
+        if (targetIds.length > 0) {
+          const targetConstraint =
+            this.getThroughConstraintFromTarget(targetIds);
+          const constraints = {...targetConstraint, ...sourceConstraint};
+          await throughRepository.deleteAll(
+            constrainDataObject({}, constraints as DataObject<ThroughEntity>),
+            options?.throughOptions,
+          );
+        }
+      } else {
+        // otherwise, delete through models that relate to the sourceId
+        const targetFkValues = this.getTargetKeys(
+          throughCategorized[targetKey],
+        );
+        // delete through instances that have the targets that are going to be deleted
+        const throughFkConstraint =
+          this.getThroughConstraintFromTarget(targetFkValues);
+        await throughRepository.deleteAll(
+          constrainWhereOr({}, [sourceConstraint, throughFkConstraint]),
+        );
+      }
+      // delete target(s)
+      const targetConstraint = this.getTargetConstraintFromThroughModels(
+        throughCategorized[targetKey],
+      );
+      totalCount +=
+        (
+          await targetRepository.deleteAll(
+            constrainWhere(where, targetConstraint as Where<TargetEntity>),
+            options,
+          )
+        )?.count ?? 0;
+    }
+    return {count: totalCount};
   }
+
   // only allows patch target instances for now
   async patch(
-    dataObject: DataObject<TargetEntity>,
+    dataObject:
+      | DataObject<TargetEntity>
+      | {[polymorphicType: string]: DataObject<TargetEntity>},
     where?: Where<TargetEntity>,
     options?: Options & {
-      throughOptions?: Options;
-    },
+      throughOptions?: Options & {discriminator?: string};
+    } & {isPolymorphic?: boolean},
   ): Promise<Count> {
-    const targetRepository = await this.getTargetRepository();
-    const throughRepository = await this.getThroughRepository();
+    const targetDiscriminatorOnThrough = options?.throughOptions?.discriminator;
+    const isMultipleTypes = options?.isPolymorphic;
+    let allKeys: string[];
+    if (!targetDiscriminatorOnThrough) {
+      if (Object.keys(this.getTargetRepositoryDict).length > 1) {
+        console.warn(
+          'It is highly recommended to specify the targetDiscriminatorOnThrough param when using polymorphic types.',
+        );
+      }
+    }
+    if (!isMultipleTypes) {
+      if (Object.keys(this.getTargetRepositoryDict).length > 1) {
+        console.warn(
+          'It is highly recommended to specify the isMultipleTypes param and pass in a dictionary of dataobjects when using polymorphic types.',
+        );
+      }
+      allKeys = Object.keys(this.getTargetRepositoryDict);
+    } else {
+      allKeys = [];
+      new Set(Object.keys(dataObject)).forEach(element => {
+        if (Object.keys(this.getTargetRepositoryDict).includes(element)) {
+          allKeys.push(element);
+        }
+      });
+    }
+
     const sourceConstraint = this.getThroughConstraintFromSource();
-    const throughInstances = await throughRepository.find(
-      constrainFilter(undefined, sourceConstraint),
-      options?.throughOptions,
-    );
-    const targetConstraint =
-      this.getTargetConstraintFromThroughModels(throughInstances);
-    return targetRepository.updateAll(
-      constrainDataObject(dataObject, targetConstraint),
-      constrainWhere(where, targetConstraint as Where<TargetEntity>),
-      options,
-    );
+
+    const throughCategorized: {[concreteType: string]: (ThroughEntity & {})[]} =
+      {};
+    const throughRepository = await this.getThroughRepository();
+    (
+      await throughRepository.find(
+        constrainFilter(undefined, sourceConstraint),
+        options?.throughOptions,
+      )
+    ).forEach(element => {
+      let concreteTargetType;
+      if (!targetDiscriminatorOnThrough) {
+        concreteTargetType = this.targetResolver().name;
+      } else {
+        concreteTargetType = String(
+          element[targetDiscriminatorOnThrough as StringKeyOf<ThroughEntity>],
+        );
+      }
+      if (!allKeys.includes(concreteTargetType)) {
+        return;
+      }
+      if (!this.getTargetRepositoryDict[concreteTargetType]) {
+        throw new InvalidPolymorphismError(
+          concreteTargetType,
+          targetDiscriminatorOnThrough,
+        );
+      }
+      if (!throughCategorized[concreteTargetType]) {
+        throughCategorized[concreteTargetType] = [];
+      }
+      throughCategorized[concreteTargetType].push(element);
+    });
+
+    let updatedCount = 0;
+    for (const key of Object.keys(throughCategorized)) {
+      const targetRepository = await this.getTargetRepositoryDict[key]();
+      const targetConstraint = this.getTargetConstraintFromThroughModels(
+        throughCategorized[key],
+      );
+      updatedCount +=
+        (
+          await targetRepository.updateAll(
+            constrainDataObject(
+              isMultipleTypes
+                ? (
+                    dataObject as {
+                      [polymorphicType: string]: DataObject<TargetEntity>;
+                    }
+                  )[key]
+                : (dataObject as DataObject<TargetEntity>),
+              targetConstraint,
+            ),
+            constrainWhere(where, targetConstraint as Where<TargetEntity>),
+            options,
+          )
+        )?.count ?? 0;
+    }
+
+    return {count: updatedCount};
   }
 
   async link(

--- a/packages/repository/src/relations/has-one/has-one.inclusion-resolver.ts
+++ b/packages/repository/src/relations/has-one/has-one.inclusion-resolver.ts
@@ -4,6 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Filter, InclusionFilter} from '@loopback/filter';
+import {cloneDeep} from 'lodash';
+import {includeFieldIfNot, InvalidPolymorphismError} from '../../';
 import {AnyObject, Options} from '../../common-types';
 import {Entity} from '../../model';
 import {EntityCrudRepository} from '../../repositories';
@@ -22,18 +24,22 @@ import {resolveHasOneMetadata} from './has-one.helpers';
  *
  * Notice: scope field for inclusion is not supported yet.
  *
- * @param meta
- * @param getTargetRepo
+ * @param meta - resolved HasOneMetadata
+ * @param getTargetRepoDict - dictionary of target model type - target repository
+ * i.e where related instances for different types are
  */
+
 export function createHasOneInclusionResolver<
   Target extends Entity,
   TargetID,
   TargetRelations extends object,
 >(
   meta: HasOneDefinition,
-  getTargetRepo: Getter<
-    EntityCrudRepository<Target, TargetID, TargetRelations>
-  >,
+  getTargetRepoDict: {
+    [repoType: string]: Getter<
+      EntityCrudRepository<Target, TargetID, TargetRelations>
+    >;
+  },
 ): InclusionResolver<Entity, Target> {
   const relationMeta = resolveHasOneMetadata(meta);
 
@@ -44,22 +50,110 @@ export function createHasOneInclusionResolver<
   ): Promise<((Target & TargetRelations) | undefined)[]> {
     if (!entities.length) return [];
 
+    // Source ids are grouped by their target polymorphic types
+    // Each type search for target instances and then merge together in a merge-sort-like manner
+
     const sourceKey = relationMeta.keyFrom;
-    const sourceIds = entities.map(e => (e as AnyObject)[sourceKey]);
     const targetKey = relationMeta.keyTo as StringKeyOf<Target>;
+    const targetDiscriminator: keyof Entity | undefined =
+      relationMeta.polymorphic
+        ? (relationMeta.polymorphic.discriminator as keyof Entity)
+        : undefined;
 
     const scope =
       typeof inclusion === 'string' ? {} : (inclusion.scope as Filter<Target>);
 
-    const targetRepo = await getTargetRepo();
-    const targetsFound = await findByForeignKeys(
-      targetRepo,
-      targetKey,
-      sourceIds,
-      scope,
-      options,
-    );
+    // sourceIds in {targetType -> sourceId}
+    const sourceIdsCategorized: {
+      [concreteItemType: string]: Target[StringKeyOf<Target>][];
+    } = {};
+    if (targetDiscriminator) {
+      entities.forEach((value, index, allEntites) => {
+        const concreteType = String(value[targetDiscriminator]);
+        if (!getTargetRepoDict[concreteType]) {
+          throw new InvalidPolymorphismError(concreteType, targetDiscriminator);
+        }
+        if (!sourceIdsCategorized[concreteType]) {
+          sourceIdsCategorized[concreteType] = [];
+        }
+        sourceIdsCategorized[concreteType].push(
+          (value as AnyObject)[sourceKey],
+        );
+      });
+    } else {
+      const concreteType = relationMeta.target().name;
+      if (!getTargetRepoDict[concreteType]) {
+        throw new InvalidPolymorphismError(concreteType);
+      }
+      entities.forEach((value, index, allEntites) => {
+        if (!sourceIdsCategorized[concreteType]) {
+          sourceIdsCategorized[concreteType] = [];
+        }
+        sourceIdsCategorized[concreteType].push(
+          (value as AnyObject)[sourceKey],
+        );
+      });
+    }
 
-    return flattenTargetsOfOneToOneRelation(sourceIds, targetsFound, targetKey);
+    // Ensure targetKey is included otherwise flatten function cannot work
+    const changedTargetKeyField = includeFieldIfNot(scope?.fields, targetKey);
+    let needToRemoveTargetKeyFieldLater = false;
+    if (changedTargetKeyField !== false) {
+      scope.fields = changedTargetKeyField;
+      needToRemoveTargetKeyFieldLater = true;
+    }
+    // Each sourceIds array with same target type extract target instances
+    const targetCategorized: {
+      [concreteItemType: string]: ((Target & TargetRelations) | undefined)[];
+    } = {};
+    for (const k of Object.keys(sourceIdsCategorized)) {
+      const targetRepo = await getTargetRepoDict[k]();
+      const targetsFound = await findByForeignKeys(
+        targetRepo,
+        targetKey,
+        sourceIdsCategorized[k],
+        scope,
+        Object.assign(cloneDeep(options ?? {}), {polymorphicType: k}),
+      );
+      targetCategorized[k] = flattenTargetsOfOneToOneRelation(
+        sourceIdsCategorized[k],
+        targetsFound,
+        targetKey,
+      );
+
+      // Remove targetKey if should be excluded but included above
+      if (needToRemoveTargetKeyFieldLater) {
+        targetCategorized[k] = targetCategorized[k].map(e => {
+          if (e) {
+            delete e[targetKey];
+          }
+          return e;
+        });
+      }
+    }
+
+    // Merge
+    // Why the order is correct:
+    // e.g. target model 1 = a, target model 2 = b
+    // all entities: [S(a-1), S(a-2), S(b-3), S(a-4), S(b-5)]
+    // a-result: [a-1, a-2, a-4]
+    // b-result: [b-3, b-4]
+    // merged:
+    // entities[1]->a => targets: [a-1 from a-result.shift()]
+    // entities[2]->a => targets: [a-1, a-2 from a-result.shift()]
+    // entities[3]->b => targets: [a-1, a-2, b-3 from b-result.shift()]
+    // entities[4]->a => targets: [a-1, a-2, b-3, a-4 from a-result.shift()]
+    // entities[5]->b => targets: [a-1, a-2, b-3, a-4, b-5 from b-result.shift()]
+    if (targetDiscriminator) {
+      const allTargets: ((Target & TargetRelations) | undefined)[] = [];
+      entities.forEach((value, index, allEntites) => {
+        allTargets.push(
+          targetCategorized[String(value[targetDiscriminator])].shift(),
+        );
+      });
+      return allTargets;
+    } else {
+      return targetCategorized[relationMeta.target().name];
+    }
   };
 }

--- a/packages/repository/src/relations/has-one/has-one.repository-factory.ts
+++ b/packages/repository/src/relations/has-one/has-one.repository-factory.ts
@@ -36,10 +36,14 @@ export interface HasOneRepositoryFactory<
  * via a HasOne relation, then, the relational repository returned by the
  * factory function would be constrained by a Customer model instance's id(s).
  *
+ * If the target model is polymorphic, i.e. stored within different repositories,
+ * supply the targetRepositoryGetter with a dictionary in the form of {[typeName: string]: repositoryGetter}
+ *
  * @param relationMetadata - The relation metadata used to describe the
  * relationship and determine how to apply the constraint.
- * @param targetRepositoryGetter - The repository which represents the target model of a
- * relation attached to a datasource.
+ * @param targetRepositoryGetter - The repository or a dictionary of classname - repository,
+ * which represents the target model of a relation attached to a datasource.
+ * For the dictionary, the key is the class name of the concrete class the the polymorphic model.
  * @returns The factory function which accepts a foreign key value to constrain
  * the given target repository
  */
@@ -49,9 +53,21 @@ export function createHasOneRepositoryFactory<
   ForeignKeyType,
 >(
   relationMetadata: HasOneDefinition,
-  targetRepositoryGetter: Getter<EntityCrudRepository<Target, TargetID>>,
+  targetRepositoryGetter:
+    | Getter<EntityCrudRepository<Target, TargetID>>
+    | {
+        [repoType: string]: Getter<EntityCrudRepository<Target, TargetID>>;
+      },
 ): HasOneRepositoryFactory<Target, ForeignKeyType> {
   const meta = resolveHasOneMetadata(relationMetadata);
+  // resolve the repositoryGetter into a dictionary
+  if (typeof targetRepositoryGetter === 'function') {
+    targetRepositoryGetter = {
+      [meta.target().name]: targetRepositoryGetter as Getter<
+        EntityCrudRepository<Target, TargetID>
+      >,
+    };
+  }
   debug('Resolved HasOne relation metadata: %o', meta);
   const result: HasOneRepositoryFactory<Target, ForeignKeyType> = function (
     fkValue: ForeignKeyType,
@@ -62,11 +78,23 @@ export function createHasOneRepositoryFactory<
       Target,
       TargetID,
       EntityCrudRepository<Target, TargetID>
-    >(targetRepositoryGetter, constraint as DataObject<Target>);
+    >(
+      targetRepositoryGetter as {
+        [repoType: string]: Getter<EntityCrudRepository<Target, TargetID>>;
+      },
+      constraint as DataObject<Target>,
+      relationMetadata.target,
+    );
   };
-  result.inclusionResolver = createHasOneInclusionResolver(
+  result.inclusionResolver = createHasOneInclusionResolver<
+    Target,
+    TargetID,
+    object
+  >(
     meta,
-    targetRepositoryGetter,
+    targetRepositoryGetter as {
+      [repoType: string]: Getter<EntityCrudRepository<Target, TargetID>>;
+    },
   );
   return result;
 }

--- a/packages/repository/src/relations/has-one/has-one.repository.ts
+++ b/packages/repository/src/relations/has-one/has-one.repository.ts
@@ -5,8 +5,10 @@
 
 import {Getter} from '@loopback/core';
 import {Filter} from '@loopback/filter';
+import {cloneDeep} from 'lodash';
+import {TypeResolver} from '../../';
 import {Count, DataObject, Options} from '../../common-types';
-import {EntityNotFoundError} from '../../errors';
+import {EntityNotFoundError, InvalidPolymorphismError} from '../../errors';
 import {Entity} from '../../model';
 import {
   constrainDataObject,
@@ -23,39 +25,58 @@ export interface HasOneRepository<Target extends Entity> {
    * Create a target model instance
    * @param targetModelData - The target model data
    * @param options - Options for the operation
+   * options.polymorphicType - If polymorphic target model,
+   * specify of which concrete model the created instance should be
    * @returns A promise which resolves to the newly created target model instance
    */
   create(
     targetModelData: DataObject<Target>,
-    options?: Options,
+    options?: Options & {polymorphicType?: string},
   ): Promise<Target>;
 
   /**
    * Find the only target model instance that belongs to the declaring model.
    * @param filter - Query filter without a Where condition
    * @param options - Options for the operations
+   * options.polymorphicType - a string or a string array of polymorphic type names
+   * to specify which repositories should are expected to be searched
+   * It is highly recommended to contain this param especially for
+   * datasources using deplicated ids across tables
    * @returns A promise resolved with the target object or rejected
    * with an EntityNotFoundError when target model instance was not found.
    */
   get(
     filter?: Pick<Filter<Target>, Exclude<keyof Filter<Target>, 'where'>>,
-    options?: Options,
+    options?: Options & {polymorphicType?: string | string[]},
   ): Promise<Target>;
 
   /**
    * Delete the related target model instance
    * @param options
+   * options.polymorphicType - a string or a string array of polymorphic type names
+   * to specify which repositories should are expected to be searched
+   * It is highly recommended to contain this param especially for
+   * datasources using deplicated ids across tables
    * @returns A promise which resolves the deleted target model instances
    */
-  delete(options?: Options): Promise<Count>;
+  delete(
+    options?: Options & {polymorphicType?: string | string[]},
+  ): Promise<Count>;
 
   /**
    * Patch the  related target model instance
    * @param dataObject - The target model fields and their new values to patch
+   * If the target models are of different types, this should be a dictionary
    * @param options
+   * options.isPolymorphic - whether dataObject is a dictionary
    * @returns A promise which resolves the patched target model instances
    */
-  patch(dataObject: DataObject<Target>, options?: Options): Promise<Count>;
+  patch(
+    dataObject:
+      | DataObject<Target>
+      | {[polymorphicType: string]: DataObject<Target>},
+    options?: Options & {isPolymorphic?: boolean},
+  ): Promise<Count>;
 }
 
 export class DefaultHasOneRepository<
@@ -66,20 +87,65 @@ export class DefaultHasOneRepository<
 {
   /**
    * Constructor of DefaultHasOneEntityCrudRepository
-   * @param getTargetRepository - the getter of the related target model repository instance
+   * @param getTargetRepository  - either a dictionary of target model type - target repository instance
+   * or a single target repository instance
+   * e.g. if the target is of a non-polymorphic type "Student", put the studentRepositoryGetterInstance
+   * if the target is of a polymorphic type "Person" which can be either a "Student" or a "Teacher"
+   * then put "{Student: studentRepositoryGetterInstance, Teacher: teacherRepositoryGetterInstance}"
    * @param constraint - the key value pair representing foreign key name to constrain
    * the target repository instance
+   * @param targetResolver - () => Target to resolve the target class
+   * e.g. if the target is of type "Student", then put "() => Student"
    */
+
   constructor(
-    public getTargetRepository: Getter<TargetRepository>,
+    public getTargetRepository:
+      | Getter<TargetRepository>
+      | {
+          [repoType: string]: Getter<TargetRepository>;
+        },
     public constraint: DataObject<TargetEntity>,
-  ) {}
+    public targetResolver: TypeResolver<Entity, typeof Entity>,
+  ) {
+    if (typeof getTargetRepository === 'function') {
+      this.getTargetRepositoryDict = {
+        [targetResolver().name]:
+          getTargetRepository as Getter<TargetRepository>,
+      };
+    } else {
+      this.getTargetRepositoryDict = getTargetRepository as {
+        [repoType: string]: Getter<TargetRepository>;
+      };
+    }
+  }
+
+  public getTargetRepositoryDict: {
+    [repoType: string]: Getter<TargetRepository>;
+  };
 
   async create(
     targetModelData: DataObject<TargetEntity>,
-    options?: Options,
+    options?: Options & {polymorphicType?: string},
   ): Promise<TargetEntity> {
-    const targetRepository = await this.getTargetRepository();
+    let polymorphicTypeName = options?.polymorphicType;
+    if (polymorphicTypeName) {
+      if (!this.getTargetRepositoryDict[polymorphicTypeName]) {
+        throw new InvalidPolymorphismError(polymorphicTypeName);
+      }
+    } else {
+      if (Object.keys(this.getTargetRepositoryDict).length > 1) {
+        console.warn(
+          'It is highly recommended to specify the polymorphicType param when using polymorphic types.',
+        );
+      }
+      polymorphicTypeName = this.targetResolver().name;
+      if (!this.getTargetRepositoryDict[polymorphicTypeName]) {
+        throw new InvalidPolymorphismError(polymorphicTypeName);
+      }
+    }
+    const targetRepository = await this.getTargetRepositoryDict[
+      polymorphicTypeName
+    ]();
     return targetRepository.create(
       constrainDataObject(targetModelData, this.constraint),
       options,
@@ -91,37 +157,124 @@ export class DefaultHasOneRepository<
       Filter<TargetEntity>,
       Exclude<keyof Filter<TargetEntity>, 'where'>
     >,
-    options?: Options,
+    options?: Options & {polymorphicType?: string | string[]},
   ): Promise<TargetEntity> {
-    const targetRepository = await this.getTargetRepository();
-    const found = await targetRepository.find(
-      Object.assign({limit: 1}, constrainFilter(filter, this.constraint)),
-      options,
-    );
-    if (found.length < 1) {
-      // We don't have a direct access to the foreign key value here :(
-      const id = 'constraint ' + JSON.stringify(this.constraint);
-      throw new EntityNotFoundError(targetRepository.entityClass, id);
+    let polymorphicTypes = options?.polymorphicType;
+    let allKeys: string[];
+    if (Object.keys(this.getTargetRepositoryDict).length <= 1) {
+      allKeys = Object.keys(this.getTargetRepositoryDict);
+    } else if (!polymorphicTypes || polymorphicTypes.length === 0) {
+      console.warn(
+        'It is highly recommended to specify the polymorphicType param when using polymorphic types.',
+      );
+      allKeys = Object.keys(this.getTargetRepositoryDict);
+    } else {
+      if (typeof polymorphicTypes === 'string') {
+        polymorphicTypes = [polymorphicTypes];
+      }
+      allKeys = [];
+      new Set(polymorphicTypes!).forEach(element => {
+        if (Object.keys(this.getTargetRepositoryDict).includes(element)) {
+          allKeys.push(element);
+        }
+      });
     }
-    return found[0];
+    for (const key of allKeys) {
+      const targetRepository = await this.getTargetRepositoryDict[key]();
+      const found = await targetRepository.find(
+        Object.assign({limit: 1}, constrainFilter(filter, this.constraint)),
+        Object.assign(cloneDeep(options ?? {}), {polymorphicType: key}),
+      );
+      if (found.length >= 1) {
+        return found[0];
+      }
+    }
+    // We don't have a direct access to the foreign key value here :(
+    const id = 'constraint ' + JSON.stringify(this.constraint);
+    throw new EntityNotFoundError(this.targetResolver().name, id);
   }
-  async delete(options?: Options): Promise<Count> {
-    const targetRepository = await this.getTargetRepository();
-    return targetRepository.deleteAll(
-      constrainWhere({}, this.constraint),
-      options,
-    );
+
+  async delete(
+    options?: Options & {polymorphicType?: string | string[]},
+  ): Promise<Count> {
+    let polymorphicTypes = options?.polymorphicType;
+    let allKeys: string[];
+    if (Object.keys(this.getTargetRepositoryDict).length <= 1) {
+      allKeys = Object.keys(this.getTargetRepositoryDict);
+    } else if (!polymorphicTypes || polymorphicTypes.length === 0) {
+      console.warn(
+        'It is highly recommended to specify the polymorphicType param when using polymorphic types.',
+      );
+      allKeys = Object.keys(this.getTargetRepositoryDict);
+    } else {
+      if (typeof polymorphicTypes === 'string') {
+        polymorphicTypes = [polymorphicTypes];
+      }
+      allKeys = [];
+      new Set(polymorphicTypes!).forEach(element => {
+        if (Object.keys(this.getTargetRepositoryDict).includes(element)) {
+          allKeys.push(element);
+        }
+      });
+    }
+    let total = 0;
+    for (const key of allKeys) {
+      const targetRepository = await this.getTargetRepositoryDict[key]();
+      total +=
+        (
+          await targetRepository.deleteAll(
+            constrainWhere({}, this.constraint),
+            options,
+          )
+        )?.count ?? 0;
+    }
+    return {count: total};
   }
 
   async patch(
-    dataObject: DataObject<TargetEntity>,
-    options?: Options,
+    dataObject:
+      | DataObject<TargetEntity>
+      | {[polymorphicType: string]: DataObject<TargetEntity>},
+    options?: Options & {isPolymorphic?: boolean},
   ): Promise<Count> {
-    const targetRepository = await this.getTargetRepository();
-    return targetRepository.updateAll(
-      constrainDataObject(dataObject, this.constraint),
-      constrainWhere({}, this.constraint),
-      options,
-    );
+    const isMultipleTypes = options?.isPolymorphic;
+    let allKeys: string[];
+    if (!isMultipleTypes) {
+      if (Object.keys(this.getTargetRepositoryDict).length > 1) {
+        console.warn(
+          'It is highly recommended to specify the isPolymorphic param and pass in a dictionary of dataobjects when using polymorphic types.',
+        );
+      }
+      allKeys = Object.keys(this.getTargetRepositoryDict);
+    } else {
+      allKeys = [];
+      new Set(Object.keys(dataObject)).forEach(element => {
+        if (Object.keys(this.getTargetRepositoryDict).includes(element)) {
+          allKeys.push(element);
+        }
+      });
+    }
+    let total = 0;
+    for (const key of allKeys) {
+      const targetRepository = await this.getTargetRepositoryDict[key]();
+      total +=
+        (
+          await targetRepository.updateAll(
+            constrainDataObject(
+              isMultipleTypes
+                ? (
+                    dataObject as {
+                      [polymorphicType: string]: DataObject<TargetEntity>;
+                    }
+                  )[key]
+                : (dataObject as DataObject<TargetEntity>),
+              this.constraint,
+            ),
+            constrainWhere({}, this.constraint),
+            options,
+          )
+        )?.count ?? 0;
+    }
+    return {count: total};
   }
 }

--- a/packages/repository/src/relations/index.ts
+++ b/packages/repository/src/relations/index.ts
@@ -7,5 +7,6 @@ export * from './belongs-to';
 export * from './has-many';
 export * from './has-one';
 export * from './relation.decorator';
+export * from './relation.filter.solver';
 export * from './relation.helpers';
 export * from './relation.types';

--- a/packages/repository/src/relations/relation.filter.solver.ts
+++ b/packages/repository/src/relations/relation.filter.solver.ts
@@ -1,0 +1,56 @@
+import {Fields} from '@loopback/filter';
+import {cloneDeep} from 'lodash';
+
+export function includeFieldIfNot<MT>(
+  fields: Fields<MT> | undefined,
+  fieldToInclude: Extract<keyof MT, string>,
+): false | Fields<MT> {
+  if (!fields) {
+    return false;
+  } else if (Array.isArray(fields)) {
+    const fieldsCloned: {[P in keyof MT]?: boolean} = fields.reduce(
+      (prev, current) => ({...prev, [current]: true}),
+      {},
+    );
+    if (Object.keys(fieldsCloned).length > 0) {
+      if (fieldsCloned[fieldToInclude] === true) {
+        return false;
+      }
+      fieldsCloned[fieldToInclude] = true;
+      return fieldsCloned;
+    }
+    return false;
+  }
+
+  const fieldsCloned = cloneDeep(fields);
+  if (Object.keys(fieldsCloned).length > 0) {
+    let containsTrue = false;
+    for (const k in fieldsCloned) {
+      if (fieldsCloned[k] === true) {
+        containsTrue = true;
+      }
+    }
+    for (const k in fieldsCloned) {
+      if (k === fieldToInclude) {
+        if (fieldsCloned[k] === true) {
+          return false;
+        } else {
+          if (containsTrue) {
+            fieldsCloned[k] = true;
+          } else {
+            delete fieldsCloned[k];
+          }
+          return fieldsCloned;
+        }
+      }
+    }
+    if (containsTrue) {
+      fieldsCloned[fieldToInclude] = true;
+      return fieldsCloned;
+    } else {
+      return false;
+    }
+  } else {
+    return false;
+  }
+}

--- a/packages/repository/src/relations/relation.helpers.ts
+++ b/packages/repository/src/relations/relation.helpers.ts
@@ -122,7 +122,22 @@ export async function includeRelatedModels<
   options?: Options,
 ): Promise<(T & Relations)[]> {
   entities = cloneDeep(entities);
-  include = cloneDeep(include);
+  if (options?.polymorphicType) {
+    include = include?.filter(inclusionFilter => {
+      if (typeof inclusionFilter === 'string') {
+        return true;
+      } else {
+        if (
+          inclusionFilter.targetType === undefined ||
+          inclusionFilter.targetType === options?.polymorphicType
+        ) {
+          return true;
+        }
+      }
+    });
+  } else {
+    include = cloneDeep(include);
+  }
   const result = entities as (T & Relations)[];
   if (!include) return result;
 

--- a/packages/repository/src/relations/relation.types.ts
+++ b/packages/repository/src/relations/relation.types.ts
@@ -75,6 +75,12 @@ export interface HasManyDefinition extends RelationDefinitionBase {
   keyFrom?: string;
 
   /**
+   * With current architecture design, polymorphic type cannot be supported without through
+   * Consider using Source-hasMany->Through->hasOne->Target(polymorphic) for one-to-many relations
+   */
+  // polymorphic?: boolean | {discriminator: string};
+
+  /**
    * Description of the through model of the hasManyThrough relation.
    *
    * A `hasManyThrough` relation defines a many-to-many connection with another model.
@@ -107,6 +113,19 @@ export interface HasManyDefinition extends RelationDefinitionBase {
      * The foreign key of the target model defined in the through model, e.g. CategoryProductLink#productId
      */
     keyTo?: string;
+
+    /**
+     * The polymorphism of the target model. The discriminator is a key of *through* model.
+     * If the target model is not polymorphic, then the value should be left undefined or false;
+     * If the key on through model indicating the concrete class of the through instance is default
+     * i.e. camelCase(classNameOf(targetModelInstance)) + "Id"
+     * then the discriminator field can be undefined
+     *
+     * With current architecture design, polymorphic type cannot be supported without through
+     * Consider using Source hasMany Through hasOne Target(polymorphic)
+     * or Source hasMany Through belongsTo Target(polymorphic) for one-to-many relations
+     */
+    polymorphic?: boolean | {discriminator: string};
   };
 }
 
@@ -123,6 +142,14 @@ export interface BelongsToDefinition extends RelationDefinitionBase {
    * The primary key of the target model, e.g Customer#id.
    */
   keyTo?: string;
+  /**
+   * The polymorphism of the target model. The discriminator is a key of source model.
+   * If the target model is not polymorphic, then the value should be left undefined or false;
+   * If the key on source model indicating the concrete class of the target instance is default
+   * i.e. camelCase(classNameOf(throughModelInstance)) + "Id"
+   * Then the discriminator field can be undefined
+   */
+  polymorphic?: boolean | {discriminator: string};
 }
 
 export interface HasOneDefinition extends RelationDefinitionBase {
@@ -141,6 +168,14 @@ export interface HasOneDefinition extends RelationDefinitionBase {
    */
   keyTo?: string;
   keyFrom?: string;
+  /**
+   * The polymorphism of the target model. The discriminator is a key of source model.
+   * If the target model is not polymorphic, then the value should be left undefined or false;
+   * If the key on source model indicating the concrete class of the target instance is default
+   * i.e. camelCase(classNameOf(throughModelInstance)) + "Id"
+   * Then the discriminator field can be undefined
+   */
+  polymorphic?: boolean | {discriminator: string};
 }
 
 /**

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -240,11 +240,11 @@ export class DefaultCrudRepository<
     ForeignKeyType,
   >(
     relationName: string,
-    targetRepoGetter: Getter<EntityCrudRepository<Target, TargetID>>,
+    targetRepositoryGetter: Getter<EntityCrudRepository<Target, TargetID>>,
   ): HasManyRepositoryFactory<Target, ForeignKeyType> {
     return this.createHasManyRepositoryFactoryFor(
       relationName,
-      targetRepoGetter,
+      targetRepositoryGetter,
     );
   }
 
@@ -282,12 +282,12 @@ export class DefaultCrudRepository<
     ForeignKeyType,
   >(
     relationName: string,
-    targetRepoGetter: Getter<EntityCrudRepository<Target, TargetID>>,
+    targetRepositoryGetter: Getter<EntityCrudRepository<Target, TargetID>>,
   ): HasManyRepositoryFactory<Target, ForeignKeyType> {
     const meta = this.entityClass.definition.relations[relationName];
     return createHasManyRepositoryFactory<Target, TargetID, ForeignKeyType>(
       meta as HasManyDefinition,
-      targetRepoGetter,
+      targetRepositoryGetter,
     );
   }
 
@@ -329,8 +329,12 @@ export class DefaultCrudRepository<
     ForeignKeyType,
   >(
     relationName: string,
-    targetRepoGetter: Getter<EntityCrudRepository<Target, TargetID>>,
-    throughRepoGetter: Getter<EntityCrudRepository<Through, ThroughID>>,
+    targetRepositoryGetter:
+      | Getter<EntityCrudRepository<Target, TargetID>>
+      | {
+          [repoType: string]: Getter<EntityCrudRepository<Target, TargetID>>;
+        },
+    throughRepositoryGetter: Getter<EntityCrudRepository<Through, ThroughID>>,
   ): HasManyThroughRepositoryFactory<
     Target,
     TargetID,
@@ -344,7 +348,11 @@ export class DefaultCrudRepository<
       Through,
       ThroughID,
       ForeignKeyType
-    >(meta as HasManyDefinition, targetRepoGetter, throughRepoGetter);
+    >(
+      meta as HasManyDefinition,
+      targetRepositoryGetter,
+      throughRepositoryGetter,
+    );
   }
 
   /**
@@ -358,9 +366,16 @@ export class DefaultCrudRepository<
    */
   protected _createBelongsToAccessorFor<Target extends Entity, TargetId>(
     relationName: string,
-    targetRepoGetter: Getter<EntityCrudRepository<Target, TargetId>>,
+    targetRepositoryGetter:
+      | Getter<EntityCrudRepository<Target, TargetId>>
+      | {
+          [repoType: string]: Getter<EntityCrudRepository<Target, TargetId>>;
+        },
   ): BelongsToAccessor<Target, ID> {
-    return this.createBelongsToAccessorFor(relationName, targetRepoGetter);
+    return this.createBelongsToAccessorFor(
+      relationName,
+      targetRepositoryGetter,
+    );
   }
 
   /**
@@ -371,12 +386,16 @@ export class DefaultCrudRepository<
    */
   protected createBelongsToAccessorFor<Target extends Entity, TargetId>(
     relationName: string,
-    targetRepoGetter: Getter<EntityCrudRepository<Target, TargetId>>,
+    targetRepositoryGetter:
+      | Getter<EntityCrudRepository<Target, TargetId>>
+      | {
+          [repoType: string]: Getter<EntityCrudRepository<Target, TargetId>>;
+        },
   ): BelongsToAccessor<Target, ID> {
     const meta = this.entityClass.definition.relations[relationName];
     return createBelongsToAccessor<Target, TargetId, T, ID>(
       meta as BelongsToDefinition,
-      targetRepoGetter,
+      targetRepositoryGetter,
       this,
     );
   }
@@ -394,11 +413,15 @@ export class DefaultCrudRepository<
     ForeignKeyType,
   >(
     relationName: string,
-    targetRepoGetter: Getter<EntityCrudRepository<Target, TargetID>>,
+    targetRepositoryGetter:
+      | Getter<EntityCrudRepository<Target, TargetID>>
+      | {
+          [repoType: string]: Getter<EntityCrudRepository<Target, TargetID>>;
+        },
   ): HasOneRepositoryFactory<Target, ForeignKeyType> {
     return this.createHasOneRepositoryFactoryFor(
       relationName,
-      targetRepoGetter,
+      targetRepositoryGetter,
     );
   }
 
@@ -414,12 +437,16 @@ export class DefaultCrudRepository<
     ForeignKeyType,
   >(
     relationName: string,
-    targetRepoGetter: Getter<EntityCrudRepository<Target, TargetID>>,
+    targetRepositoryGetter:
+      | Getter<EntityCrudRepository<Target, TargetID>>
+      | {
+          [repoType: string]: Getter<EntityCrudRepository<Target, TargetID>>;
+        },
   ): HasOneRepositoryFactory<Target, ForeignKeyType> {
     const meta = this.entityClass.definition.relations[relationName];
     return createHasOneRepositoryFactory<Target, TargetID, ForeignKeyType>(
       meta as HasOneDefinition,
-      targetRepoGetter,
+      targetRepositoryGetter,
     );
   }
 


### PR DESCRIPTION
Addressing the feature parity of polymorphic relations from lb3, and the syntax is similar to lb3. The changes are backward compatible with the previous APIs. hasOne, belongsTo, and hasManyThrough relations are supported, while hasMany relation cannot facilitate this feature without a through model.
packages repository and repository-tests are updated.

related to #2487

Signed-off-by: David Zhang <dwzhangdavid@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈

## API changes:

### defining polymorphic models
define the polymorphic models
```
class Post extends Entity {
id;
}

class Letter extends Post {
}

class Parcel extends Post {
}
```
define the polymorphic property
```
class Delivery extends Entity {
// use belonging can be any subclass of Post, i.e. Letter or Parcel
@hasOne(() => Post, {polymorphic: true})
  post: Post;

postType: string;
}
```
or a customized discriminator
```
class Delivery extends Entity {
// use belonging can be any subclass of Post, i.e. Letter or Parcel
@hasOne(() => Post, {polymorphic: {discriminator: "post_type"}})
  post: Post;

post_type: string;
}
```
### setting up repository
```
export class DeliveryRepository extends DefaultCrudRepository {
  public readonly post: HasOneRepositoryFactory<Post, typeof Delivery.prototype.id>;

  constructor(
    dataSource: juggler.DataSource,
    @repository.getter('LetterRepository')
    protected letterRepositoryGetter: Getter<EntityCrudRepository<Post, typeof Post.prototype.id, PostRelations>>,
    @repository.getter('ParcelRepository')
    protected parcelRepositoryGetter: Getter<EntityCrudRepository<Post, typeof Post.prototype.id, PostRelations>>,
  ) {
    super(Delivery, dataSource);
    this.post = this.createHasOneRepositoryFactoryFor(
      'post',
      // use a dictionary of repoGetters instead of a single repoGetter instance
      {Letter: letterRepositoryGetter, Parcel: parcelRepositoryGetter},
    );
    this.registerInclusionResolver('post', this.post.inclusionResolver);
  }
}
```
### Query with inclusions
```
const result = await deliveryRepo.findById(delivery1.id, {
  include: ['post'],
});
```
### Creation with polymorphic relations
```
deliveryRepo
.post(deliveryId)
.create(letter1Data, {polymorphicType: "Letter"});
```