### PR TITLE
fix: allow application.stop() to release release resources from init()

### DIFF
--- a/packages/core/src/__tests__/unit/application-lifecycle.unit.ts
+++ b/packages/core/src/__tests__/unit/application-lifecycle.unit.ts
@@ -140,6 +140,14 @@ describe('Application life cycle', () => {
       expect(app.state).to.equal('created');
     });
 
+    it('allows application.stop when it is initialized', async () => {
+      const app = new Application();
+      await app.init();
+      expect(app.state).to.equal('initialized');
+      await app.stop();
+      expect(app.state).to.equal('stopped');
+    });
+
     it('await application.stop when it is stopping', async () => {
       const app = new Application();
       await app.start();

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -88,8 +88,8 @@ export class Application extends Context implements LifeCycleObserver {
    *   - !started -> starting -> started
    *   - started -> started (no-op)
    * 2. stop
-   *   - started -> stopping -> stopped
-   *   - !started -> stopped (no-op)
+   *   - (started | initialized) -> stopping -> stopped
+   *   - ! (started || initialized) -> stopped (no-op)
    *
    * Two types of states are expected:
    * - stable, such as `started` and `stopped`
@@ -399,7 +399,7 @@ export class Application extends Context implements LifeCycleObserver {
     if (this._state === 'stopping') return this.awaitState('stopped');
     this.assertNotInProcess('stop');
     // No-op if it's created or stopped
-    if (this._state !== 'started') return;
+    if (this._state !== 'started' && this._state !== 'initialized') return;
     this.setState('stopping');
     if (!this._isShuttingDown) {
       // Explicit stop is called, let's remove signal listeners to avoid


### PR DESCRIPTION
Some applications create resources during `init()` and `stop()` does not
clean up such resources at the moment.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
