### PR TITLE
Updated authentication docs to reflect breaking changes

### DIFF
--- a/docs/site/Authentication-component-options.md
+++ b/docs/site/Authentication-component-options.md
@@ -31,7 +31,7 @@ simply configure the authentication component with `defaultMetadata` as follows:
 ```ts
 app
   .configure(AuthenticationBindings.COMPONENT)
-  .to({defaultMetadata: {strategy: 'xyz'}});
+  .to({defaultMetadata: [{strategy: 'xyz'}]});
 ```
 
 If multiple strategies are used for a given method, we can configure the


### PR DESCRIPTION
Authentication metadata decorator was changed to be able set more than one authentication strategy.
https://github.com/loopbackio/loopback-next/commit/ae6c0e68a58a2b574fd534242e599aa2a96fc855

However, the example in docs was not updated and currenty it is not working.

See also #5735

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
