### PR TITLE
fix: do not cascade exclude list when building json schema

### DIFF
--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -552,6 +552,43 @@ describe('build-schema', () => {
         additionalProperties: false,
       });
     });
+
+    it('property definition does not inherit exclude list from model', () => {
+      @model()
+      class B {
+        @property()
+        id: string;
+      }
+
+      @model()
+      class A {
+        @property()
+        id: string;
+
+        @property()
+        b: B;
+      }
+
+      const aSchema = modelToJsonSchema(A, {
+        exclude: ['id'],
+      });
+      expect(aSchema).to.eql({
+        title: 'AExcluding_id_',
+        type: 'object',
+        description:
+          "(tsType: Omit<A, 'id'>, schemaOptions: { exclude: [ 'id' ] })",
+        properties: {b: {$ref: '#/definitions/B'}},
+        definitions: {
+          B: {
+            title: 'B',
+            type: 'object',
+            properties: {id: {type: 'string'}},
+            additionalProperties: false,
+          },
+        },
+        additionalProperties: false,
+      });
+    });
   });
 
   describe('getNavigationalPropertyForRelation', () => {

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -522,6 +522,8 @@ export function modelToJsonSchema<T extends object>(
     // it should be removed from the `options`
     // when generating the relation or property schemas
     delete propOptions.title;
+    // Do not cascade `exclude` to nested properties.
+    delete propOptions.exclude;
 
     const propSchema = getJsonSchema(referenceType, propOptions);
 


### PR DESCRIPTION
Signed-off-by: Simon Stone <Simon.Stone@docusign.com>

Fixes #8121 

This change stops `modelToJsonSchema` cascading the `exclude` list when building a JSON schema for the specified model. The exclude list is now treated the same as other properties such as `partial`, `includeRelations` and `title`.

Note that the exclude list is typed as a key of the model passed into `modelToJsonSchema`, so it makes sense that the exclude list is only for excluding properties of that model.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
