### PR TITLE
fix: validation error on empty optional request body

### DIFF
--- a/packages/rest/src/validation/request-body.validator.ts
+++ b/packages/rest/src/validation/request-body.validator.ts
@@ -56,6 +56,7 @@ export async function validateRequestBody(
     );
     throw err;
   }
+  if (!required && !body.value) return;
 
   const schema = body.schema;
   /* istanbul ignore if */


### PR DESCRIPTION
Signed-off-by: Jakub Mifek <jakub.mifek@lutherx.com>

Fix for request body validation. In previous versions of loopback (we have skipped some), it was possible to define optional request body (which is acceptable by openapi). However, after update on the latest version, we experienced an issue with incoming request validation.

The body can be defined as optional and the parser correctly parses the body as undefined, however, the body is then passed to AJV for validation purposes together with schema of the expected object. Since undefined is not an object, the validator returns an error. This is, because, the required property for request bodies is not included in the schema of the body - but in the schema of the operation.

This single line of code checks whether the body is required and if it's not and incoming body is undefined, it skips the validation process.

I have run npm test and it succeeded with one exception - greeting page. I was unable to locate the issue and fix it sadly - probably something with my version of puppeteer. That being said, this test should have nothing to do with the changes proposed.

## Checklist

- [X] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [X] `npm test` passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated # skipped due to the simplicity of the change
- [X] Documentation in [/docs/site](../tree/master/docs/site) was updated # skipped due to the simplicity of the change
- [X] Affected artifact templates in `packages/cli` were updated # skipped due to the simplicity of the change
- [X] Affected example projects in `examples/*` were updated # skipped due to the simplicity of the change
