### PR TITLE
docs: Add documentation on how to add debug in your own code #8315

### DIFF
--- a/docs/site/Setting-debug-strings.md
+++ b/docs/site/Setting-debug-strings.md
@@ -84,7 +84,7 @@ For example:
 
 `loopback:cli:model-generator`
 
-The debug string `model-generator` is specified in the source file
+The debug string `model-generator` is specified in the source file 
 [`generators/model/index.js`](https://github.com/loopbackio/loopback-next/blob/master/packages/cli/generators/model/index.js)
 of the `@loopback/cli` module.
 
@@ -363,3 +363,34 @@ of the `@loopback/cli` module.
     </tr>
   </tbody>
 </table>
+
+## Adding debugs
+
+As seen before, LoopBack has built-in debug strings to help with debugging.
+
+LoopBack uses the `debug` package internally. Even if there's no mandate for
+LoopBack users to use the same library, you can use this package in your
+application to help with debugging.
+
+To do so, you can define your own debug strings like demonstrated in this
+example:
+
+```ts
+// Import from debug
+import debugFactory from 'debug';
+
+// Define your custom debug string
+const debug = debugFactory('example:debug:factory');
+
+// Use it in your code
+debug('Oops there was an error!');
+```
+
+To debug parts of your app with this custom debug string, you can run:
+
+```sh
+DEBUG=example:debug:factory npm start
+```
+
+> Refer to the [debug](https://www.npmjs.com/package/debug) documentation for
+> more information.


### PR DESCRIPTION
Add missing documentation on how to add debug in your own code.
Related to discussion: https://github.com/loopbackio/loopback-next/discussions/8315

Also fixed documentation, missing space in sentence
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
