### PR TITLE
Fixes in CLI using -c config feature. 

### DIFF
--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -86,6 +86,13 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
       utils.toClassName(this.artifactInfo.name),
     );
 
+    if (this.options.controllerType) {
+      Object.assign(this.artifactInfo, {
+        controllerType: this.options.controllerType,
+      });
+      return;
+    }
+
     return this.prompt([
       {
         type: 'list',

--- a/packages/cli/generators/datasource/index.js
+++ b/packages/cli/generators/datasource/index.js
@@ -80,6 +80,11 @@ module.exports = class DataSourceGenerator extends ArtifactGenerator {
   promptArtifactName() {
     debug('Prompting for artifact name');
     if (this.shouldExit()) return false;
+
+    if (this.artifactInfo.name) {
+      return;
+    }
+
     const prompts = [
       {
         type: 'input',

--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -109,6 +109,20 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
         path.resolve(dsDir, `${utils.toFileName(s)}.datasource.js`),
       ),
     );
+
+    if (this.options.dataSource) {
+      if (
+        this.dataSourceChoices
+          .map(d => d.name)
+          .includes(this.options.dataSource)
+      ) {
+        Object.assign(this.artifactInfo, {
+          dataSource: this.dataSourceChoices.find(
+            d => d.name === this.options.dataSource,
+          ),
+        });
+      }
+    }
     debug(`Done importing datasources`);
   }
 

--- a/packages/cli/generators/example/index.js
+++ b/packages/cli/generators/example/index.js
@@ -84,6 +84,10 @@ module.exports = class extends BaseGenerator {
     return super._setupGenerator();
   }
 
+  setOptions() {
+    return super.setOptions();
+  }
+
   help() {
     const examplesHelp = Object.keys(EXAMPLES)
       .map(name => `  ${name}: ${EXAMPLES[name]}`)

--- a/packages/cli/generators/extension/index.js
+++ b/packages/cli/generators/extension/index.js
@@ -43,6 +43,13 @@ module.exports = class ExtensionGenerator extends ProjectGenerator {
 
   promptComponent() {
     if (this.shouldExit()) return;
+
+    if (this.options.componentName) {
+      Object.assign(this.projectInfo, {
+        componentName: this.options.componentName,
+      });
+    }
+
     const prompts = [
       {
         type: 'input',

--- a/packages/cli/generators/openapi/index.js
+++ b/packages/cli/generators/openapi/index.js
@@ -90,6 +90,10 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
     return super._setupGenerator();
   }
 
+  setOptions() {
+    return super.setOptions();
+  }
+
   checkLoopBackProject() {
     return super.checkLoopBackProject();
   }

--- a/packages/cli/generators/repository/index.js
+++ b/packages/cli/generators/repository/index.js
@@ -426,6 +426,7 @@ module.exports = class RepositoryGenerator extends ArtifactGenerator {
         name: 'repositoryBaseClass',
         message: PROMPT_BASE_REPOSITORY_CLASS,
         choices: availableRepositoryList,
+        when: this.artifactInfo.repositoryBaseClass === undefined,
         default:
           this.artifactInfo.repositoryBaseClass === undefined
             ? availableRepositoryList[0]

--- a/packages/cli/lib/artifact-generator.js
+++ b/packages/cli/lib/artifact-generator.js
@@ -46,6 +46,12 @@ module.exports = class ArtifactGenerator extends BaseGenerator {
   promptArtifactName() {
     debug('Prompting for artifact name');
     if (this.shouldExit()) return false;
+
+    if (this.options.name) {
+      Object.assign(this.artifactInfo, {name: this.options.name});
+      return;
+    }
+
     const prompts = [
       {
         type: 'input',


### PR DESCRIPTION
The arguments that are provided in commands like —datasource=postgres and in the config file are treated as the same. Both of them end in the options object of the generator class. Whenever we want to ask a prompt, we check if, for that argument, there is already a value present in the options object. If there is, we assign that value to the respective property in the artifact info object and skip that prompt.
However, for some of the arguments in multiple generators, this check for a value in the options object was missing. I have added all the missing checks and tested them. They now work with both command-line arguments and config files.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #8072 
Fixes #7404 
Fixes #7362 
Fixes #7361 
Fixed #8089 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated


