### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -282,7 +282,7 @@ exports.prependBackslash = httpPath => httpPath.replace(/^\/?/, '/');
 exports.validateUrlSlug = function (name) {
   const backslashIfNeeded = name.charAt(0) === '/' ? '/' : '';
   if (backslashIfNeeded === '/') {
-    name = name.substr(1);
+    name = name.slice(1);
   }
   const separators = ['-', '.', '_', '~', ''];
   const possibleSlugs = separators.map(separator =>

--- a/packages/context/src/binding-key.ts
+++ b/packages/context/src/binding-key.ts
@@ -98,8 +98,8 @@ export class BindingKey<ValueType> {
     }
 
     return BindingKey.create<T>(
-      keyWithPath.substr(0, index).trim(),
-      keyWithPath.substr(index + 1),
+      keyWithPath.slice(0, index).trim(),
+      keyWithPath.slice(index + 1),
     );
   }
 

--- a/packages/metadata/src/reflect.ts
+++ b/packages/metadata/src/reflect.ts
@@ -120,7 +120,7 @@ export class NamespacedReflect {
       for (const key of keys) {
         if (key.indexOf(prefix) === 0) {
           // Only add keys with the namespace prefix
-          metaKeys.push(key.substr(prefix.length));
+          metaKeys.push(key.slice(prefix.length));
         }
       }
     }
@@ -141,7 +141,7 @@ export class NamespacedReflect {
       for (const key of keys) {
         if (key.indexOf(prefix) === 0) {
           // Only add keys with the namespace prefix
-          metaKeys.push(key.substr(prefix.length));
+          metaKeys.push(key.slice(prefix.length));
         }
       }
     }

--- a/packages/rest-explorer/src/rest-explorer.controller.ts
+++ b/packages/rest-explorer/src/rest-explorer.controller.ts
@@ -60,7 +60,7 @@ export class ExplorerController {
     // as a _relative_ URL
     const lastSlash = url.lastIndexOf('/');
     if (lastSlash >= 0) {
-      url = './' + url.substr(lastSlash + 1) + '/';
+      url = './' + url.slice(lastSlash + 1) + '/';
     }
     response.redirect(301, url);
   }


### PR DESCRIPTION
## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.