### PR TITLE
feat: 🎸 added models option in lb4 discover cli command

### DIFF
--- a/docs/site/Discovering-models.md
+++ b/docs/site/Discovering-models.md
@@ -47,6 +47,8 @@ placed. Default is `src/models`
 `--schema`: Specify the schema which the datasource will find the models to
 discover
 
+`--models`: generate the specific model
+
 ### Interactive Prompts
 
 Based on the option, the tool may prompt you for:

--- a/packages/cli/.yo-rc.json
+++ b/packages/cli/.yo-rc.json
@@ -1270,6 +1270,12 @@
           "description": "Specify the directory into which the `model.model.ts` files will be placed",
           "name": "outDir",
           "hide": false
+        },
+        "models": {
+          "type": "String",
+          "description": "Discover specific models without prompting users to select ex:--models=tale1,table2",
+          "name": "models",
+          "hide": false
         }
       },
       "arguments": [

--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -50,6 +50,13 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
       ),
       default: undefined,
     });
+    this.option('models', {
+      type: String,
+      description: g.f(
+        'Discover specific models without prompting users to select ex:--models=tale1,table2',
+      ),
+      default: undefined,
+    });
   }
 
   _setupGenerator() {
@@ -170,6 +177,16 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
     /* istanbul ignore next */
     if (this.options.all) {
       this.discoveringModels = this.modelChoices;
+    }
+
+    if (this.options.models) {
+      const answers = {discoveringModels: this.options.models.split(',')};
+      debug(`Models chosen: ${JSON.stringify(answers)}`);
+      this.discoveringModels = [];
+      answers.discoveringModels.forEach(m => {
+        this.discoveringModels.push(this.modelChoices.find(c => c.name === m));
+      });
+      return;
     }
 
     const prompts = [

--- a/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
@@ -1328,6 +1328,12 @@ exports[`cli saves command metadata to .yo-rc.json 1`] = `
           "description": "Specify the directory into which the \`model.model.ts\` files will be placed",
           "name": "outDir",
           "hide": false
+        },
+        "models": {
+          "type": "String",
+          "description": "Discover specific models without prompting users to select ex:--models=tale1,table2",
+          "name": "models",
+          "hide": false
         }
       },
       "arguments": [

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -50,6 +50,12 @@ const disableCamelCaseOptions = {
 const missingDataSourceOptions = {
   dataSource: 'foo',
 };
+const specificmodelsOptions = {
+  models: 'Test',
+  dataSource: 'mem',
+  views: false,
+  disableCamelCase: true,
+};
 
 // Expected File Name
 const defaultExpectedTestModel = path.join(
@@ -154,6 +160,20 @@ describe('lb4 discover integration', () => {
           )
           .withOptions(missingDataSourceOptions),
       ).to.be.rejectedWith(/Cannot find datasource/);
+    });
+
+    it('generates specific models without prompts using --models', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withOptions(specificmodelsOptions);
+
+      basicModelFileChecks(defaultExpectedTestModel, defaultExpectedIndexFile);
+      assert.file(defaultExpectedTestModel);
     });
   });
 });


### PR DESCRIPTION
added --models option inside lb4 discover command to generate specific
models

BREAKING CHANGE: 🧨 no

✅ Closes: #7104

Signed-off-by: Punit Diwan <punitdiwan@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #7104 

-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
