### PR TITLE
CLI command added for "lb4 cache --config"

### DIFF
--- a/docs/site/Cache-generator.md
+++ b/docs/site/Cache-generator.md
@@ -1,0 +1,62 @@
+---
+lang: en
+title: 'Cache generator'
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, CLI
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Cache-generator.html
+---
+
+{% include content/generator-create-app.html lang=page.lang %}
+
+### Synopsis
+
+Add cache to LoopBack4 application using Redis datasource.
+
+```sh
+lb4 [cache] [options]
+```
+
+### Options
+
+`--datasource` : Valid Redis datasource name.
+
+{% include_relative includes/CLI-std-options.md %}
+
+### Interactive Prompts
+
+The tool will prompt you for:
+
+- **Name of the datasource.** If the datasource had been supplied from the
+  command line, the prompt is skipped and the datasource from command-line
+  argument is used.
+
+### Output
+
+Following files are generated as result of this command:
+
+```text
+.
+├── src/
+|   ├── models/
+|   |   └── cache.model.ts
+|   ├── providers/
+|   |   └── cache-strategy.provider.ts
+|   ├── repositories/
+|   |   └── cache.repository.ts
+```
+
+`cache.model.ts` is a model that cache repository uses to read and write data
+into datasource.
+
+`cache-strategy.provider.ts` provides the implementation of caching logic. You
+can modify this file to extend caching capabilities.
+
+`cache.repository.ts` is a repository that connects to Redis datasource and
+reads and writes values from datasource.
+
+The command also modifies `applications.ts` to include `CacheComponent`.
+
+```
+this.component(CacheComponent);
+this.bind(CacheBindings.CACHE_STRATEGY).toProvider(CacheStrategyProvider);
+```

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -879,6 +879,10 @@ children:
       url: Copyright-generator.html
       output: 'web, pdf'
 
+    - title: 'Cache generator'
+      url: Cache-generator.html
+      output: 'web, pdf'
+
   - title: 'Connectors reference'
     url: Connectors-reference.html
     output: 'web'

--- a/packages/cli/.yo-rc.json
+++ b/packages/cli/.yo-rc.json
@@ -1692,6 +1692,77 @@
       },
       "arguments": [],
       "name": "copyright"
+    },
+    "cache": {
+      "options": {
+        "help": {
+          "name": "help",
+          "type": "Boolean",
+          "alias": "h",
+          "description": "Print the generator's options and usage"
+        },
+        "skip-cache": {
+          "name": "skip-cache",
+          "type": "Boolean",
+          "description": "Do not remember prompt answers",
+          "default": false
+        },
+        "skip-install": {
+          "name": "skip-install",
+          "type": "Boolean",
+          "description": "Do not automatically install dependencies",
+          "default": false
+        },
+        "force-install": {
+          "name": "force-install",
+          "type": "Boolean",
+          "description": "Fail on install dependencies error",
+          "default": false
+        },
+        "ask-answered": {
+          "type": "Boolean",
+          "description": "Show prompts for already configured options",
+          "default": false,
+          "name": "ask-answered",
+          "hide": false
+        },
+        "datasource": {
+          "type": "String",
+          "required": false,
+          "description": "A valid redis datasource",
+          "name": "datasource",
+          "hide": false
+        },
+        "config": {
+          "type": "String",
+          "alias": "c",
+          "description": "JSON file name or value to configure options",
+          "name": "config",
+          "hide": false
+        },
+        "yes": {
+          "type": "Boolean",
+          "alias": "y",
+          "description": "Skip all confirmation prompts with default or provided value",
+          "name": "yes",
+          "hide": false
+        },
+        "format": {
+          "type": "Boolean",
+          "description": "Format generated code using npm run lint:fix",
+          "name": "format",
+          "hide": false
+        },
+        "packageManager": {
+          "type": "String",
+          "description": "Change the default package manager",
+          "alias": "pm",
+          "name": "packageManager",
+          "hide": false
+        }
+      },
+      "arguments": [],
+      "name": "cache"
     }
   }
 }

--- a/packages/cli/generators/cache/cache-component.js
+++ b/packages/cli/generators/cache/cache-component.js
@@ -1,0 +1,78 @@
+'use strict';
+const ast = require('ts-morph');
+const path = require('path');
+
+/**
+ * Update `src/application.ts`
+ * @param projectRoot - Project root directory
+ */
+async function updateApplicationTs(projectRoot) {
+  const CACHE_COMPONENT = 'CacheComponent';
+  const CACHE_BINDINGS = 'CacheBindings';
+  const PROVIDER = 'CacheStrategyProvider';
+  const applicationTsFile = path.join(projectRoot, 'src/application.ts');
+
+  // Create an AST project
+  const project = new ast.Project({
+    manipulationSettings: {
+      indentationText: ast.IndentationText.TwoSpaces,
+      insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: false,
+      newLineKind: ast.NewLineKind.LineFeed,
+      quoteKind: ast.QuoteKind.Single,
+    },
+  });
+
+  // import {CacheBindings, CacheComponent} from 'loopback-api-cache';
+  const cacheImportDeclaration = {
+    kind: ast.StructureKind.ImportDeclaration,
+    moduleSpecifier: 'loopback-api-cache',
+    namedImports: [CACHE_BINDINGS, CACHE_COMPONENT],
+  };
+
+  const pFile = project.addSourceFileAtPath(applicationTsFile);
+
+  // Check if `import {CacheBindings, CacheComponent} from 'loopback-api-cache'` exists
+  const cacheImport = pFile.getImportDeclaration('loopback-api-cache');
+
+  if (cacheImport == null) {
+    // Not found
+    pFile.addImportDeclaration(cacheImportDeclaration);
+  } else {
+    // Further check named import for CacheComponent
+    const names = cacheImport.getNamedImports().map(i => i.getName());
+    if (!names.includes(CACHE_COMPONENT)) {
+      cacheImport.addNamedImport(CACHE_COMPONENT);
+    }
+    if (!names.includes(CACHE_BINDINGS)) {
+      cacheImport.addNamedImport(CACHE_BINDINGS);
+    }
+  }
+
+  // import {CacheStrategyProvider} from './providers';
+  const providerImportDeclaration = {
+    kind: ast.StructureKind.ImportDeclaration,
+    moduleSpecifier: './providers',
+    namedImports: [PROVIDER],
+  };
+  const providerImport = pFile.getImportDeclaration('./providers');
+  if (providerImport == null) {
+    // Not found
+    pFile.addImportDeclaration(providerImportDeclaration);
+  }
+
+  // Find the constructor
+  const ctor = pFile.getClasses()[0].getConstructors()[0];
+  const body = ctor.getBodyText();
+
+  // Check if `this.component(CacheComponent)` exists
+  if (!body.includes(`this.component(${CACHE_COMPONENT}`)) {
+    ctor.addStatements(`this.component(${CACHE_COMPONENT});`);
+    ctor.addStatements(
+      `this.bind(${CACHE_BINDINGS}.CACHE_STRATEGY).toProvider(${PROVIDER});`,
+    );
+  }
+
+  await pFile.save();
+}
+
+exports.updateApplicationTs = updateApplicationTs;

--- a/packages/cli/generators/cache/index.js
+++ b/packages/cli/generators/cache/index.js
@@ -178,11 +178,11 @@ module.exports = class CacheGenerator extends BaseGenerator {
   async scaffold() {
     if (this.shouldExit()) return false;
     this._generateModel();
-    await this._updateIndex(MODEL);
+    await this._updateIndex(cacheModel, MODEL);
     this._generateRepository();
-    await this._updateIndex(REPOSITORY);
+    await this._updateIndex(cacheRepository, REPOSITORY);
     this._generateProvider();
-    await this._updateIndex(PROVIDER);
+    await this._updateIndex(cacheProvider, PROVIDER);
 
     await updateApplicationTs(this.destinationPath());
 

--- a/packages/cli/generators/cache/index.js
+++ b/packages/cli/generators/cache/index.js
@@ -1,0 +1,241 @@
+'use strict';
+
+const BaseGenerator = require('../../lib/base-generator');
+const chalk = require('chalk');
+const debug = require('../../lib/debug')('cache-generator');
+const utils = require('../../lib/utils');
+const updateIndex = require('../../lib/update-index');
+const MODEL = 'models';
+const REPOSITORY = 'repositories';
+const PROVIDER = 'providers';
+
+const cacheModel = 'cache.model.ts';
+const cacheRepository = 'cache.repository.ts';
+const cacheProvider = 'cache-strategy.provider.ts';
+
+const {updateApplicationTs} = require('./cache-component');
+
+const g = require('../../lib/globalize');
+
+module.exports = class CacheGenerator extends BaseGenerator {
+  constructor(args, opts) {
+    super(args, opts);
+  }
+
+  _setupGenerator() {
+    this.option('datasource', {
+      type: String,
+      required: false,
+      description: g.f('A valid redis datasource'),
+    });
+
+    return super._setupGenerator();
+  }
+
+  checkLoopBackProject() {
+    return super.checkLoopBackProject();
+  }
+
+  async promptDataSourceName() {
+    if (this.shouldExit()) return false;
+    debug('Prompting for a datasource');
+
+    // grab the datasource from the command line
+    const dsClass = this.options.datasource
+      ? utils.toClassName(this.options.datasource) + 'DataSource'
+      : '';
+
+    debug(`command line datasource is ${dsClass}`);
+
+    const dataSourcesDir = this.destinationPath(
+      `${utils.sourceRootDir}/${utils.datasourcesDir}`,
+    );
+
+    const dataSourceClasses = await utils.getArtifactList(
+      dataSourcesDir,
+      'datasource',
+      true,
+    );
+
+    // List all data sources
+    const dataSourceList = dataSourceClasses.map(ds => ({
+      className: ds,
+    }));
+    debug('datasourceList from %s', dataSourcesDir, dataSourceList);
+
+    // Find redis data sources
+    const redisDataSources = dataSourceList.filter(ds => {
+      debug(`data source inspecting item: ${ds.className}`);
+      const dsObj = utils.getDataSourceConfig(dataSourcesDir, ds.className);
+
+      if (
+        dsObj.connector === 'kv-redis' ||
+        dsObj.connector === 'loopback-connector-kv-redis'
+      ) {
+        ds.usePositionalParams = dsObj.positional;
+        ds.name = dsObj.name;
+        ds.className = utils.toClassName(dsObj.name) + 'DataSource';
+        ds.specPath = dsObj.spec;
+        return true;
+      }
+    });
+
+    debug('Data sources using redis connector', redisDataSources);
+
+    if (redisDataSources.length === 0) {
+      return;
+    }
+
+    const matchedDs = redisDataSources.find(ds => ds.className === dsClass);
+    if (matchedDs) {
+      this.dataSourceInfo = {
+        name: matchedDs.name,
+        className: matchedDs.className,
+      };
+      this.log(
+        g.f('Datasource %s - %s found for Redis'),
+        this.options.datasource,
+        this.dataSourceInfo.className,
+      );
+      return;
+    }
+
+    if (dsClass) return;
+
+    const answers = await this.prompt([
+      {
+        type: 'list',
+        name: 'dataSource',
+        message: g.f('Please select the datasource'),
+        choices: redisDataSources.map(ds => ({
+          name: `${ds.name} - ${ds.className}`,
+          value: ds,
+        })),
+        default: `${redisDataSources[0].name} - ${redisDataSources[0].className}`,
+        validate: utils.validateClassName,
+      },
+    ]);
+
+    debug('Datasource selected', answers);
+    if (answers && answers.dataSource) {
+      this.dataSourceInfo = {
+        name: answers.dataSource.name,
+        className: answers.dataSource.className,
+      };
+      this.log(
+        g.f('Datasource %s - %s selected'),
+        this.dataSourceInfo.name,
+        this.dataSourceInfo.className,
+      );
+    }
+  }
+
+  /** Generates cache.model.ts */
+  _generateModel() {
+    const source = this.templatePath('src/models/cache-model-template.ts.ejs');
+    const dest = this.destinationPath(`src/models/${cacheModel}`);
+    if (debug.enabled) {
+      debug('Copying artifact to: %s', dest);
+    }
+    this.copyTemplatedFiles(source, dest, {});
+  }
+
+  /** Generates cache.repository.ts */
+  _generateRepository() {
+    const source = this.templatePath(
+      'src/repositories/cache-repository-template.ts.ejs',
+    );
+    const dest = this.destinationPath(`src/repositories/${cacheRepository}`);
+    if (debug.enabled) {
+      debug('Copying artifact to: %s', dest);
+    }
+    this.copyTemplatedFiles(source, dest, this.dataSourceInfo);
+  }
+
+  /** Generates cache-strategy.provider.ts */
+  _generateProvider() {
+    const source = this.templatePath(
+      'src/providers/cache-strategy-provider-template.ts.ejs',
+    );
+    const dest = this.destinationPath(`src/providers/${cacheProvider}`);
+    if (debug.enabled) {
+      debug('Copying artifact to: %s', dest);
+    }
+    this.copyTemplatedFiles(source, dest, {});
+  }
+
+  async _updateIndex(file, dir) {
+    if (file != null && dir != null) {
+      const targetDir = this.destinationPath(`src/${dir}`);
+      // Check file being generated to ensure they succeeded
+      const status = this.conflicter.generationStatus[file];
+      if (status !== 'skip' && status !== 'identical') {
+        await updateIndex(targetDir, file, this.fs);
+      }
+    }
+  }
+
+  async scaffold() {
+    if (this.shouldExit()) return false;
+    this._generateModel();
+    await this._updateIndex(MODEL);
+    this._generateRepository();
+    await this._updateIndex(REPOSITORY);
+    this._generateProvider();
+    await this._updateIndex(PROVIDER);
+
+    await updateApplicationTs(this.destinationPath());
+
+    this.log(
+      chalk.blue(
+        g.f(
+          `
+          Please update your sequence to add following lines
+          constructor(
+            ...
+            @inject(CacheBindings.CACHE_CHECK_ACTION) protected checkCache: CacheCheckFn,
+            @inject(CacheBindings.CACHE_SET_ACTION) protected setCache: CacheSetFn,
+            ...
+          ) {}
+
+          async handle(context: RequestContext) {
+            ...
+            const cache = await this.checkCache(request);
+            if (cache) {
+              this.send(response, cache.data);
+              return;
+            }
+            ...
+          }
+          `,
+        ),
+      ),
+    );
+  }
+
+  install() {
+    if (this.shouldExit()) return false;
+    debug('install npm dependencies');
+    const pkgJson = this.packageJson || {};
+    const deps = pkgJson.dependencies || {};
+    const pkgs = [];
+    const pkgVersionRange = deps['loopback-api-cache'];
+    if (!pkgVersionRange) {
+      // No dependency found for loopback-api-cache
+      pkgs.push('loopback-api-cache');
+    }
+
+    if (pkgs.length === 0) return;
+
+    this.pkgManagerInstall(pkgs, {
+      npm: {
+        save: true,
+      },
+    });
+  }
+
+  async end() {
+    await super.end();
+    if (this.shouldExit()) return;
+  }
+};

--- a/packages/cli/generators/cache/templates/src/models/cache-model-template.ts.ejs
+++ b/packages/cli/generators/cache/templates/src/models/cache-model-template.ts.ejs
@@ -1,0 +1,34 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Cache extends Entity {
+  @property({
+    type: 'string',
+    id: true,
+    generated: true,
+  })
+  id: string;
+
+  @property({
+    type: 'any',
+    required: true,
+  })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any;
+
+  @property({
+    type: 'number',
+    required: true,
+  })
+  ttl: number;
+
+  constructor(data?: Partial<Cache>) {
+    super(data);
+  }
+}
+
+export interface CacheRelations {
+  // describe navigational properties here
+}
+
+export type CacheWithRelations = Cache & CacheRelations;

--- a/packages/cli/generators/cache/templates/src/providers/cache-strategy-provider-template.ts.ejs
+++ b/packages/cli/generators/cache/templates/src/providers/cache-strategy-provider-template.ts.ejs
@@ -1,0 +1,41 @@
+import {inject, Provider, ValueOrPromise} from '@loopback/core';
+import {repository} from '@loopback/repository';
+import {CacheBindings, CacheMetadata, CacheStrategy} from 'loopback-api-cache';
+import {Cache} from '../models';
+import {CacheRepository} from '../repositories';
+
+export class CacheStrategyProvider
+  implements Provider<CacheStrategy | undefined>
+{
+  constructor(
+    @inject(CacheBindings.METADATA)
+    private metadata: CacheMetadata,
+    @repository(CacheRepository) protected cacheRepo: CacheRepository,
+  ) {}
+
+  value(): ValueOrPromise<CacheStrategy | undefined> {
+    if (!this.metadata) {
+      return undefined;
+    }
+
+    return {
+      check: (path: string) =>
+        this.cacheRepo.get(path).catch(err => {
+          console.error(err);
+          return undefined;
+        }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      set: async (path: string, result: any) => {
+        const cache = new Cache({
+          id: result.id,
+          data: result,
+          ttl: this.metadata.ttl,
+        });
+        // Defaults to ttl value of 60 seconds
+        this.cacheRepo.set(path, cache, {ttl: 60000}).catch(err => {
+          console.error(err);
+        });
+      },
+    };
+  }
+}

--- a/packages/cli/generators/cache/templates/src/repositories/cache-repository-template.ts.ejs
+++ b/packages/cli/generators/cache/templates/src/repositories/cache-repository-template.ts.ejs
@@ -1,0 +1,10 @@
+import {inject} from '@loopback/core';
+import {DefaultKeyValueRepository} from '@loopback/repository';
+import {<%= className %>} from '../datasources';
+import {Cache} from '../models';
+
+export class CacheRepository extends DefaultKeyValueRepository<Cache> {
+  constructor(@inject('datasources.<%= name %>') dataSource: <%= className %>) {
+    super(Cache, dataSource);
+  }
+}

--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -116,6 +116,7 @@ function setupGenerators() {
     path.join(__dirname, '../generators/copyright'),
     PREFIX + 'copyright',
   );
+  env.register(path.join(__dirname, '../generators/cache'), PREFIX + 'cache');
   return env;
 }
 

--- a/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
@@ -26,6 +26,7 @@ Available commands:
   lb4 update
   lb4 rest-crud
   lb4 copyright
+  lb4 cache
   lb4 install-completion
   lb4 uninstall-completion
 `;
@@ -50,6 +51,7 @@ Available commands:
   lb4 update
   lb4 rest-crud
   lb4 copyright
+  lb4 cache
   lb4 install-completion
   lb4 uninstall-completion
 `;
@@ -1750,6 +1752,77 @@ exports[`cli saves command metadata to .yo-rc.json 1`] = `
       },
       "arguments": [],
       "name": "copyright"
+    },
+    "cache": {
+      "options": {
+        "help": {
+          "name": "help",
+          "type": "Boolean",
+          "alias": "h",
+          "description": "Print the generator's options and usage"
+        },
+        "skip-cache": {
+          "name": "skip-cache",
+          "type": "Boolean",
+          "description": "Do not remember prompt answers",
+          "default": false
+        },
+        "skip-install": {
+          "name": "skip-install",
+          "type": "Boolean",
+          "description": "Do not automatically install dependencies",
+          "default": false
+        },
+        "force-install": {
+          "name": "force-install",
+          "type": "Boolean",
+          "description": "Fail on install dependencies error",
+          "default": false
+        },
+        "ask-answered": {
+          "type": "Boolean",
+          "description": "Show prompts for already configured options",
+          "default": false,
+          "name": "ask-answered",
+          "hide": false
+        },
+        "datasource": {
+          "type": "String",
+          "required": false,
+          "description": "A valid redis datasource",
+          "name": "datasource",
+          "hide": false
+        },
+        "config": {
+          "type": "String",
+          "alias": "c",
+          "description": "JSON file name or value to configure options",
+          "name": "config",
+          "hide": false
+        },
+        "yes": {
+          "type": "Boolean",
+          "alias": "y",
+          "description": "Skip all confirmation prompts with default or provided value",
+          "name": "yes",
+          "hide": false
+        },
+        "format": {
+          "type": "Boolean",
+          "description": "Format generated code using npm run lint:fix",
+          "name": "format",
+          "hide": false
+        },
+        "packageManager": {
+          "type": "String",
+          "description": "Change the default package manager",
+          "alias": "pm",
+          "name": "packageManager",
+          "hide": false
+        }
+      },
+      "arguments": [],
+      "name": "cache"
     }
   }
 }

--- a/packages/cli/snapshots/integration/generators/cache.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/cache.integration.snapshots.js
@@ -1,0 +1,125 @@
+// IMPORTANT
+// This snapshot file is auto-generated, but designed for humans.
+// It should be checked into source control and tracked carefully.
+// Re-generate by setting UPDATE_SNAPSHOTS=1 and running tests.
+// Make sure to inspect the changes in the snapshots below.
+// Do not ignore changes!
+
+'use strict';
+
+exports[`cache-generator basic cache generates all files 1`] = `
+export * from './cache.model';
+
+`;
+
+
+exports[`cache-generator basic cache generates all files 2`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Cache extends Entity {
+  @property({
+    type: 'string',
+    id: true,
+    generated: true,
+  })
+  id: string;
+
+  @property({
+    type: 'any',
+    required: true,
+  })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any;
+
+  @property({
+    type: 'number',
+    required: true,
+  })
+  ttl: number;
+
+  constructor(data?: Partial<Cache>) {
+    super(data);
+  }
+}
+
+export interface CacheRelations {
+  // describe navigational properties here
+}
+
+export type CacheWithRelations = Cache & CacheRelations;
+
+`;
+
+
+exports[`cache-generator basic cache generates all files 3`] = `
+export * from './cache.repository';
+
+`;
+
+
+exports[`cache-generator basic cache generates all files 4`] = `
+import {inject} from '@loopback/core';
+import {DefaultKeyValueRepository} from '@loopback/repository';
+import {} from '../datasources';
+import {Cache} from '../models';
+
+export class CacheRepository extends DefaultKeyValueRepository<Cache> {
+  constructor(@inject('datasources.') dataSource: ) {
+    super(Cache, dataSource);
+  }
+}
+
+`;
+
+
+exports[`cache-generator basic cache generates all files 5`] = `
+export * from './cache-strategy.provider';
+
+`;
+
+
+exports[`cache-generator basic cache generates all files 6`] = `
+import {inject, Provider, ValueOrPromise} from '@loopback/core';
+import {repository} from '@loopback/repository';
+import {CacheBindings, CacheMetadata, CacheStrategy} from 'loopback-api-cache';
+import {Cache} from '../models';
+import {CacheRepository} from '../repositories';
+
+export class CacheStrategyProvider
+  implements Provider<CacheStrategy | undefined>
+{
+  constructor(
+    @inject(CacheBindings.METADATA)
+    private metadata: CacheMetadata,
+    @repository(CacheRepository) protected cacheRepo: CacheRepository,
+  ) {}
+
+  value(): ValueOrPromise<CacheStrategy | undefined> {
+    if (!this.metadata) {
+      return undefined;
+    }
+
+    return {
+      check: (path: string) =>
+        this.cacheRepo.get(path).catch(err => {
+          console.error(err);
+          return undefined;
+        }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      set: async (path: string, result: any) => {
+        const cache = new Cache({
+          id: result.id,
+          data: result,
+          ttl: this.metadata.ttl,
+        });
+        // Defaults to ttl value of 60 seconds
+        this.cacheRepo.set(path, cache, {ttl: 60000}).catch(err => {
+          console.error(err);
+        });
+      },
+    };
+  }
+}
+
+`;

--- a/packages/cli/test/fixtures/cache/application.ts
+++ b/packages/cli/test/fixtures/cache/application.ts
@@ -1,0 +1,26 @@
+import {BootMixin} from '@loopback/boot';
+import {ApplicationConfig} from '@loopback/core';
+import {RepositoryMixin} from '@loopback/repository';
+import path from 'path';
+
+export class CacheApplication extends BootMixin(
+  RepositoryMixin(RestApplication),
+) {
+  constructor(options: ApplicationConfig = {}) {
+    super(options);
+
+    // Set up default home page
+    this.static('/', path.join(__dirname, '../public'));
+
+    this.projectRoot = __dirname;
+    // Customize @loopback/boot Booter Conventions here
+    this.bootOptions = {
+      controllers: {
+        // Customize ControllerBooter Conventions here
+        dirs: ['controllers'],
+        extensions: ['.controller.js'],
+        nested: true,
+      },
+    };
+  }
+}

--- a/packages/cli/test/fixtures/cache/index.js
+++ b/packages/cli/test/fixtures/cache/index.js
@@ -1,0 +1,21 @@
+const DATASOURCE_APP_PATH = 'src/datasources';
+const {getSourceForDataSourceClassWithConfig} = require('../../test-utils');
+const fs = require('fs');
+
+exports.SANDBOX_FILES = [
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'cache.datasource.ts',
+    content: getSourceForDataSourceClassWithConfig('DbkvDataSource', {
+      name: 'cache',
+      connector: 'kv-redis',
+    }),
+  },
+  {
+    path: 'src',
+    file: 'application.ts',
+    content: fs.readFileSync(require.resolve('./application.ts'), {
+      encoding: 'utf-8',
+    }),
+  },
+];

--- a/packages/cli/test/integration/generators/cache.integration.js
+++ b/packages/cli/test/integration/generators/cache.integration.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const path = require('path');
+const {assertFilesToMatchSnapshot} = require('../../snapshots');
+
+const testlab = require('@loopback/testlab');
+const expect = testlab.expect;
+const TestSandbox = testlab.TestSandbox;
+
+const generator = path.join(__dirname, '../../../generators/cache');
+
+// Test Sandbox
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
+const SANDBOX_FILES = require('../../fixtures/cache').SANDBOX_FILES;
+const testUtils = require('../../test-utils');
+
+const props = {
+  dataSource: 'cache',
+};
+
+describe('cache-generator', /** @this {Mocha.Suite} */ function () {
+  before('reset sandbox', () => sandbox.reset());
+
+  it('does not run without package.json', () => {
+    return expect(
+      testUtils
+        .executeGenerator(generator)
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {excludePackageJSON: true}),
+        )
+        .withPrompts(props),
+    ).to.be.rejectedWith(/No package.json found in/);
+  });
+
+  it('does not run without the "@loopback/core" dependency', () => {
+    return expect(
+      testUtils
+        .executeGenerator(generator)
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {excludeLoopbackCore: true}),
+        )
+        .withPrompts(props),
+    ).to.be.rejectedWith(/No `@loopback\/core` package found/);
+  });
+
+  describe('basic cache', () => {
+    it('generates all files', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withPrompts(props);
+
+      assertModel();
+      assertRepository();
+      assertProvider();
+    });
+  });
+});
+
+function assertModel(options) {
+  assertFiles(options, 'src/models/index.ts', 'src/models/cache.model.ts');
+}
+
+function assertRepository(options) {
+  assertFiles(
+    options,
+    'src/repositories/index.ts',
+    'src/repositories/cache.repository.ts',
+  );
+}
+
+function assertProvider(options) {
+  assertFiles(
+    options,
+    'src/providers/index.ts',
+    'src/providers/cache-strategy.provider.ts',
+  );
+}
+
+function assertFiles(options, ...files) {
+  options = {rootPath: sandbox.path, ...options};
+  assertFilesToMatchSnapshot(options, ...files);
+}


### PR DESCRIPTION
lb4 cache command generates the code required to add cache capabilities in a loopback 4 application. The command prompts the user for a valid datasource with kv-redis connector.  It then generates a cache model, repository, and cache-strategy provider. It also updates application.ts to add CacheComponent and bind CacheStrategyProvider. It then prints a message telling the user to add some lines of code to sequence for caching to work. We cannot auto-generate this code, because sequence can vary in different implementations in many applications. So it would be difficult to add code in the right place.


## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

