### PR TITLE
feat(cli): model generator can now pick properties from config file

### DIFF
--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -350,6 +350,12 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
   async promptPropertyName() {
     if (this.shouldExit()) return false;
 
+    // If properties are provided from config file
+    if (this.options.properties) {
+      Object.assign(this.artifactInfo.properties, this.options.properties);
+      return;
+    }
+
     this.log(g.f('Enter an empty property name when done'));
     this.log();
 

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -309,4 +309,24 @@ describe('model generator using --config option', () => {
       );
     });
   });
+
+  describe('model generator using --config option with properties', () => {
+    it('creates a model with properties', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
+        .withArguments([
+          '--config',
+          '{"name":"test", "base":"Entity", \
+          "properties": { \
+            "id": {"type": "string", "id": true, "generated": true, "required": true}, \
+            "name": {"type": "string", "required": true, "default": "xyz"}}}',
+          '--yes',
+        ]);
+
+      basicModelFileChecks(expectedModelFile, expectedIndexFile);
+
+      assert.fileContent(expectedModelFile, /id: string;/);
+    });
+  });
 });


### PR DESCRIPTION
You can now provide properties in the model config file in this format.

```sh
{
  "name": "product",
  "base": "Entity",
  "properties": {
    "id": {
      "type": "string",
      "id": true,
      "generated": true,
      "required": true
    },
    "name": {
      "type": "string",
      "required": true,
      "default": "xyz"
    }
  }
}
```

Fixes #7404 


## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
