### PR TITLE
feat(cli): add option to create relations in cli discover command

### DIFF
--- a/docs/site/Discovering-models.md
+++ b/docs/site/Discovering-models.md
@@ -39,6 +39,8 @@ Models can be discovered from a supported datasource by running the
 
 `--views`: Choose whether to discover views. Default is true
 
+`--relations`: Choose whether to create relations. Default is false
+
 `--all`: Skips the model prompt and discovers all of them
 
 `--outDir`: Specify the directory into which the `model.model.ts` files will be

--- a/packages/cli/.yo-rc.json
+++ b/packages/cli/.yo-rc.json
@@ -1251,6 +1251,13 @@
           "name": "views",
           "hide": false
         },
+        "relations": {
+          "type": "Boolean",
+          "description": "Discover and create relations",
+          "default": false,
+          "name": "relations",
+          "hide": false
+        },
         "schema": {
           "type": "String",
           "description": "Schema to discover",

--- a/packages/cli/generators/model/templates/model.ts.ejs
+++ b/packages/cli/generators/model/templates/model.ts.ejs
@@ -1,9 +1,12 @@
 <% if (isModelBaseBuiltin) { -%>
-import {<%= modelBaseClass %>, model, property} from '@loopback/repository';
+import {<%= modelBaseClass %>, model, property<%if (locals.relationImports) {%><% relationImports.forEach((relation) => {-%>, <%= relation %> <%_})-%><%}%>} from '@loopback/repository';
 <% } else { -%>
-import {model, property} from '@loopback/repository';
+import {model, property<%if (locals.relationImports) {%><% relationImports.forEach((relation) => {-%> , <%= relation %> <%_})-%><%}%>} from '@loopback/repository';
 import {<%= modelBaseClass %>} from '.';
 <% } -%>
+<%_ if (locals.relationDestinationImports && locals.relationDestinationImports.length > 0) { -%>
+import {<% relationDestinationImports.forEach((model, index) => {-%><%= model %><%if (index!==relationDestinationImports.length-1) {%>,<% } %> <%_}) -%>} from '.';
+<%_ } -%>
 
 <% if (modelSettings) { -%>
 @model(<%- modelSettings %>)
@@ -12,13 +15,17 @@ import {<%= modelBaseClass %>} from '.';
 <% } -%>
 export class <%= className %> extends <%= modelBaseClass %> {
 <% Object.entries(properties).forEach(([key, val]) => { -%>
+<% if (val.relation) { -%>
+  @<%= val.relation.type %>(() => <%= val.relation.model %>)
+<% } else { -%>
   @property({
   <%_ Object.entries(val).forEach(([propKey, propVal]) => { -%>
-    <%_ if (!['tsType'].includes(propKey)) { -%>
+  <%_ if (!['tsType', 'relation'].includes(propKey)) { -%>
     <%= propKey %>: <%- propVal %>,
-    <%_ } -%>
+  <%_ } -%>
   <%_ }) -%>
   })
+<% } -%>
   <%= key %><%if (!val.required) {%>?<% } %>: <%= val.tsType %>;
 
 <% }) -%>

--- a/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
@@ -1309,6 +1309,13 @@ exports[`cli saves command metadata to .yo-rc.json 1`] = `
           "name": "views",
           "hide": false
         },
+        "relations": {
+          "type": "Boolean",
+          "description": "Discover and create relations",
+          "default": false,
+          "name": "relations",
+          "hide": false
+        },
         "schema": {
           "type": "String",
           "description": "Schema to discover",


### PR DESCRIPTION
Added a new option in `discover` CLI command `relations`. If true, relations are discovered from the datasource and added to models. Relations are discovered by settings `associations` property in `modelMaker.discoverSingleModel ` options to true. Then we map the discovered relations onto the `properties` object and also created arrays for relation and destination model imports. Because discover generator uses model generator's `model.ts.ejs` template file. we have updated this template file to include relation imports and property relations.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated


