### PR TITLE
docs: Fix polymorphic relations documentation

### DIFF
--- a/docs/site/Polymorphic-relations.md
+++ b/docs/site/Polymorphic-relations.md
@@ -1,9 +1,9 @@
 ---
 lang: en
-title: 'hasManyThrough Relation'
+title: 'Polymorphic Relations'
 keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Model Relation
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/HasManyThrough-relation.html
+permalink: /doc/en/lb4/Polymorphic-relation.html
 ---
 
 ## Overview


### PR DESCRIPTION
The title and permalink in the document head was mistakenly set as HasManyThrough relation. Just a minor fix.