### PR TITLE
revert: update dependency eslint-plugin-mocha to ^10.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "eslint": "^8.14.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-eslint-plugin": "^4.1.0",
-        "eslint-plugin-mocha": "^10.0.4",
+        "eslint-plugin-mocha": "^10.0.3",
         "eslint-plugin-prettier": "^4.0.0",
         "fs-extra": "^10.1.0",
         "husky": "^7.0.4",
@@ -4124,13 +4124,13 @@
       }
     },
     "node_modules/eslint-plugin-mocha": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.4.tgz",
-      "integrity": "sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.3.tgz",
+      "integrity": "sha512-9mM7PZGxfejpjey+MrG0Cu3Lc8MyA5E2s7eUCdHXgS4SY/H9zLuwa7wVAjnEaoDjbBilA+0bPEB+iMO7lBUPcg==",
       "dev": true,
       "dependencies": {
         "eslint-utils": "^3.0.0",
-        "ramda": "^0.28.0"
+        "ramda": "^0.27.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -8633,14 +8633,10 @@
       }
     },
     "node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
+      "dev": true
     },
     "node_modules/read": {
       "version": "1.0.7",
@@ -13840,13 +13836,13 @@
       }
     },
     "eslint-plugin-mocha": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.4.tgz",
-      "integrity": "sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.3.tgz",
+      "integrity": "sha512-9mM7PZGxfejpjey+MrG0Cu3Lc8MyA5E2s7eUCdHXgS4SY/H9zLuwa7wVAjnEaoDjbBilA+0bPEB+iMO7lBUPcg==",
       "dev": true,
       "requires": {
         "eslint-utils": "^3.0.0",
-        "ramda": "^0.28.0"
+        "ramda": "^0.27.1"
       }
     },
     "eslint-plugin-prettier": {
@@ -17244,9 +17240,9 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
       "dev": true
     },
     "read": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint": "^8.14.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-eslint-plugin": "^4.1.0",
-    "eslint-plugin-mocha": "^10.0.4",
+    "eslint-plugin-mocha": "^10.0.3",
     "eslint-plugin-prettier": "^4.0.0",
     "fs-extra": "^10.1.0",
     "husky": "^7.0.4",

--- a/packages/eslint-config/package-lock.json
+++ b/packages/eslint-config/package-lock.json
@@ -13,7 +13,7 @@
 				"@typescript-eslint/parser": "^5.21.0",
 				"eslint-config-prettier": "^8.5.0",
 				"eslint-plugin-eslint-plugin": "^4.1.0",
-				"eslint-plugin-mocha": "^10.0.4"
+				"eslint-plugin-mocha": "^10.0.3"
 			},
 			"engines": {
 				"node": "12 || 14 || 16 || 17"
@@ -576,12 +576,12 @@
 			}
 		},
 		"node_modules/eslint-plugin-mocha": {
-			"version": "10.0.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.4.tgz",
-			"integrity": "sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.3.tgz",
+			"integrity": "sha512-9mM7PZGxfejpjey+MrG0Cu3Lc8MyA5E2s7eUCdHXgS4SY/H9zLuwa7wVAjnEaoDjbBilA+0bPEB+iMO7lBUPcg==",
 			"dependencies": {
 				"eslint-utils": "^3.0.0",
-				"ramda": "^0.28.0"
+				"ramda": "^0.27.1"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -1182,13 +1182,9 @@
 			]
 		},
 		"node_modules/ramda": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-			"integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ramda"
-			}
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+			"integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
 		},
 		"node_modules/regexpp": {
 			"version": "3.2.0",
@@ -1840,12 +1836,12 @@
 			}
 		},
 		"eslint-plugin-mocha": {
-			"version": "10.0.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.4.tgz",
-			"integrity": "sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.3.tgz",
+			"integrity": "sha512-9mM7PZGxfejpjey+MrG0Cu3Lc8MyA5E2s7eUCdHXgS4SY/H9zLuwa7wVAjnEaoDjbBilA+0bPEB+iMO7lBUPcg==",
 			"requires": {
 				"eslint-utils": "^3.0.0",
-				"ramda": "^0.28.0"
+				"ramda": "^0.27.1"
 			}
 		},
 		"eslint-scope": {
@@ -2278,9 +2274,9 @@
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
 		},
 		"ramda": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-			"integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+			"integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
 		},
 		"regexpp": {
 			"version": "3.2.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -25,6 +25,6 @@
     "@typescript-eslint/parser": "^5.21.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-eslint-plugin": "^4.1.0",
-    "eslint-plugin-mocha": "^10.0.4"
+    "eslint-plugin-mocha": "^10.0.3"
   }
 }


### PR DESCRIPTION
This reverts commit c7557d0a1439d097c3af58f7b41a57628f7967d7.

Reason: https://github.com/lo1tuma/eslint-plugin-mocha/issues/322

If the lint is run with Node v17 or greater, it fails