### PR TITLE
fix: security spec is removed when using @response decorator

### DIFF
--- a/packages/openapi-v3/src/__tests__/unit/decorators/response.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/response.decorator.unit.ts
@@ -147,6 +147,7 @@ describe('@oas.response decorator', () => {
         actualSpec.components?.schemas?.SuccessModel,
       ).to.not.be.undefined();
     });
+
     it('supports multiple @oas.response decorators with an array of models', () => {
       class MyController {
         @get('/greet')

--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -377,7 +377,7 @@ function resolveControllerSpec(constructor: Function): ControllerSpec {
     }
 
     debug(`  adding ${endpointName}`, operationSpec);
-    spec.paths[path][verb] = operationSpec;
+    spec.paths[path][verb] = {...endpoint.spec, ...operationSpec};
 
     debug(`  inferring schema object for method %s`, op);
     const opMetadata = MetadataInspector.getDesignTypeForMethod(


### PR DESCRIPTION
Signed-off-by: Francisco Buceta <frbuceta@gmail.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
