### PR TITLE
feat!: update dependency typeorm to ^0.3.x

### DIFF
--- a/extensions/typeorm/package-lock.json
+++ b/extensions/typeorm/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"debug": "^4.3.4",
 				"tslib": "^2.4.0",
-				"typeorm": "^0.2.45"
+				"typeorm": "^0.3.6"
 			},
 			"devDependencies": {
 				"@types/debug": "^4.1.7",
@@ -866,11 +866,6 @@
 			"integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
 			"dev": true
 		},
-		"node_modules/@types/zen-observable": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
-			"integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
-		},
 		"node_modules/abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1188,6 +1183,18 @@
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 			"devOptional": true
 		},
+		"node_modules/date-fns": {
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+			"integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+			"engines": {
+				"node": ">=0.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/date-fns"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1230,11 +1237,11 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-			"integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+			"integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/emoji-regex": {
@@ -2232,35 +2239,41 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/typeorm": {
-			"version": "0.2.45",
-			"resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.45.tgz",
-			"integrity": "sha512-c0rCO8VMJ3ER7JQ73xfk0zDnVv0WDjpsP6Q1m6CVKul7DB9iVdWLRjPzc8v2eaeBuomsbZ2+gTaYr8k1gm3bYA==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.6.tgz",
+			"integrity": "sha512-DRqgfqcelMiGgWSMbBmVoJNFN2nPNA3EeY2gC324ndr2DZoGRTb9ILtp2oGVGnlA+cu5zgQ6it5oqKFNkte7Aw==",
 			"dependencies": {
 				"@sqltools/formatter": "^1.2.2",
 				"app-root-path": "^3.0.0",
 				"buffer": "^6.0.3",
 				"chalk": "^4.1.0",
 				"cli-highlight": "^2.1.11",
-				"debug": "^4.3.1",
-				"dotenv": "^8.2.0",
-				"glob": "^7.1.6",
-				"js-yaml": "^4.0.0",
+				"date-fns": "^2.28.0",
+				"debug": "^4.3.3",
+				"dotenv": "^16.0.0",
+				"glob": "^7.2.0",
+				"js-yaml": "^4.1.0",
 				"mkdirp": "^1.0.4",
 				"reflect-metadata": "^0.1.13",
 				"sha.js": "^2.4.11",
-				"tslib": "^2.1.0",
+				"tslib": "^2.3.1",
 				"uuid": "^8.3.2",
 				"xml2js": "^0.4.23",
-				"yargs": "^17.0.1",
-				"zen-observable-ts": "^1.0.0"
+				"yargs": "^17.3.1"
 			},
 			"bin": {
-				"typeorm": "cli.js"
+				"typeorm": "cli.js",
+				"typeorm-ts-node-commonjs": "cli-ts-node-commonjs.js",
+				"typeorm-ts-node-esm": "cli-ts-node-esm.js"
+			},
+			"engines": {
+				"node": ">= 12.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/typeorm"
 			},
 			"peerDependencies": {
+				"@google-cloud/spanner": "^5.18.0",
 				"@sap/hana-client": "^2.11.14",
 				"better-sqlite3": "^7.1.2",
 				"hdb-pool": "^0.1.6",
@@ -2272,12 +2285,16 @@
 				"pg": "^8.5.1",
 				"pg-native": "^3.0.0",
 				"pg-query-stream": "^4.0.0",
-				"redis": "^3.1.1",
+				"redis": "^3.1.1 || ^4.0.0",
 				"sql.js": "^1.4.0",
 				"sqlite3": "^5.0.2",
+				"ts-node": "^10.7.0",
 				"typeorm-aurora-data-api-driver": "^2.0.0"
 			},
 			"peerDependenciesMeta": {
+				"@google-cloud/spanner": {
+					"optional": true
+				},
 				"@sap/hana-client": {
 					"optional": true
 				},
@@ -2318,6 +2335,9 @@
 					"optional": true
 				},
 				"sqlite3": {
+					"optional": true
+				},
+				"ts-node": {
 					"optional": true
 				},
 				"typeorm-aurora-data-api-driver": {
@@ -2478,20 +2498,6 @@
 			"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/zen-observable": {
-			"version": "0.8.15",
-			"resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-			"integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-		},
-		"node_modules/zen-observable-ts": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
-			"integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
-			"dependencies": {
-				"@types/zen-observable": "0.8.3",
-				"zen-observable": "0.8.15"
 			}
 		}
 	},
@@ -8459,11 +8465,6 @@
 			"integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
 			"dev": true
 		},
-		"@types/zen-observable": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
-			"integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
-		},
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -8697,6 +8698,11 @@
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 			"devOptional": true
 		},
+		"date-fns": {
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+			"integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+		},
 		"debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -8725,9 +8731,9 @@
 			"devOptional": true
 		},
 		"dotenv": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-			"integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+			"integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -9493,27 +9499,27 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"typeorm": {
-			"version": "0.2.45",
-			"resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.45.tgz",
-			"integrity": "sha512-c0rCO8VMJ3ER7JQ73xfk0zDnVv0WDjpsP6Q1m6CVKul7DB9iVdWLRjPzc8v2eaeBuomsbZ2+gTaYr8k1gm3bYA==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.6.tgz",
+			"integrity": "sha512-DRqgfqcelMiGgWSMbBmVoJNFN2nPNA3EeY2gC324ndr2DZoGRTb9ILtp2oGVGnlA+cu5zgQ6it5oqKFNkte7Aw==",
 			"requires": {
 				"@sqltools/formatter": "^1.2.2",
 				"app-root-path": "^3.0.0",
 				"buffer": "^6.0.3",
 				"chalk": "^4.1.0",
 				"cli-highlight": "^2.1.11",
-				"debug": "^4.3.1",
-				"dotenv": "^8.2.0",
-				"glob": "^7.1.6",
-				"js-yaml": "^4.0.0",
+				"date-fns": "^2.28.0",
+				"debug": "^4.3.3",
+				"dotenv": "^16.0.0",
+				"glob": "^7.2.0",
+				"js-yaml": "^4.1.0",
 				"mkdirp": "^1.0.4",
 				"reflect-metadata": "^0.1.13",
 				"sha.js": "^2.4.11",
-				"tslib": "^2.1.0",
+				"tslib": "^2.3.1",
 				"uuid": "^8.3.2",
 				"xml2js": "^0.4.23",
-				"yargs": "^17.0.1",
-				"zen-observable-ts": "^1.0.0"
+				"yargs": "^17.3.1"
 			}
 		},
 		"unique-filename": {
@@ -9640,20 +9646,6 @@
 			"version": "21.0.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
 			"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
-		},
-		"zen-observable": {
-			"version": "0.8.15",
-			"resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-			"integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-		},
-		"zen-observable-ts": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
-			"integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
-			"requires": {
-				"@types/zen-observable": "0.8.3",
-				"zen-observable": "0.8.15"
-			}
 		}
 	}
 }

--- a/extensions/typeorm/package.json
+++ b/extensions/typeorm/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "debug": "^4.3.4",
     "tslib": "^2.4.0",
-    "typeorm": "^0.2.45"
+    "typeorm": "^0.3.6"
   },
   "devDependencies": {
     "@loopback/boot": "^4.1.2",

--- a/extensions/typeorm/src/__tests__/fixtures/controllers/book.controller.ts
+++ b/extensions/typeorm/src/__tests__/fixtures/controllers/book.controller.ts
@@ -51,9 +51,7 @@ export class BookController {
       },
     },
   })
-  async findById(
-    @param.path.string('id') id: string,
-  ): Promise<Book | undefined> {
-    return this.bookRepo.findOne(id);
+  async findById(@param.path.number('id') id: number): Promise<Book | null> {
+    return this.bookRepo.findOne({where: {id}});
   }
 }


### PR DESCRIPTION
It will be released shortly. The methods used for the connection are obsolete but they offer support until version 0.4, so it will be marked as a breaking change to change them later