### PR TITLE
feat(cli): add option to mark id field as not required in discover command

### DIFF
--- a/docs/site/Discovering-models.md
+++ b/docs/site/Discovering-models.md
@@ -47,6 +47,9 @@ placed. Default is `src/models`
 `--schema`: Specify the schema which the datasource will find the models to
 discover
 
+`--optionalId`: Specify if the Id property of generated models will be marked as
+not required
+
 ### Interactive Prompts
 
 Based on the option, the tool may prompt you for:

--- a/packages/cli/.yo-rc.json
+++ b/packages/cli/.yo-rc.json
@@ -1270,6 +1270,13 @@
           "description": "Specify the directory into which the `model.model.ts` files will be placed",
           "name": "outDir",
           "hide": false
+        },
+        "optionalId": {
+          "type": "Boolean",
+          "description": "Boolean to mark id property as optional field",
+          "default": false,
+          "name": "optionalId",
+          "hide": false
         }
       },
       "arguments": [

--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -50,6 +50,12 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
       ),
       default: undefined,
     });
+
+    this.option('optionalId', {
+      type: Boolean,
+      description: g.f('Boolean to mark id property as optional field'),
+      default: false,
+    });
   }
 
   _setupGenerator() {
@@ -288,6 +294,18 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
         ),
       );
       debug(`Discovered: ${modelInfo.name}`);
+    }
+
+    if (this.options.optionalId) {
+      // Find id property
+      const idProperty = Object.entries(
+        this.artifactInfo.modelDefinitions[0].properties,
+      ).find(x => x[1].id === 1)[0];
+
+      // Mark as not required
+      this.artifactInfo.modelDefinitions[0].properties[
+        idProperty
+      ].required = false;
     }
   }
 

--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -283,29 +283,26 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
     for (let i = 0; i < this.discoveringModels.length; i++) {
       const modelInfo = this.discoveringModels[i];
       debug(`Discovering: ${modelInfo.name}...`);
-      this.artifactInfo.modelDefinitions.push(
-        await modelMaker.discoverSingleModel(
-          this.artifactInfo.dataSource,
-          modelInfo.name,
-          {
-            schema: modelInfo.owner,
-            disableCamelCase: this.artifactInfo.disableCamelCase,
-          },
-        ),
+      const modelDefinition = await modelMaker.discoverSingleModel(
+        this.artifactInfo.dataSource,
+        modelInfo.name,
+        {
+          schema: modelInfo.owner,
+          disableCamelCase: this.artifactInfo.disableCamelCase,
+        },
       );
+      if (this.options.optionalId) {
+        // Find id properties (can be multiple ids if using composite key)
+        const idProperties = Object.values(modelDefinition.properties).filter(
+          property => property.id,
+        );
+        // Mark as not required
+        idProperties.forEach(property => {
+          property.required = false;
+        });
+      }
+      this.artifactInfo.modelDefinitions.push(modelDefinition);
       debug(`Discovered: ${modelInfo.name}`);
-    }
-
-    if (this.options.optionalId) {
-      // Find id property
-      const idProperty = Object.entries(
-        this.artifactInfo.modelDefinitions[0].properties,
-      ).find(x => x[1].id === 1)[0];
-
-      // Mark as not required
-      this.artifactInfo.modelDefinitions[0].properties[
-        idProperty
-      ].required = false;
     }
   }
 

--- a/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
@@ -1328,6 +1328,13 @@ exports[`cli saves command metadata to .yo-rc.json 1`] = `
           "description": "Specify the directory into which the \`model.model.ts\` files will be placed",
           "name": "outDir",
           "hide": false
+        },
+        "optionalId": {
+          "type": "Boolean",
+          "description": "Boolean to mark id property as optional field",
+          "default": false,
+          "name": "optionalId",
+          "hide": false
         }
       },
       "arguments": [

--- a/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
@@ -7,6 +7,58 @@
 
 'use strict';
 
+exports[`lb4 discover integration model discovery does not mark id property as required based on optionalId option 1`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Test extends Entity {
+  @property({
+    type: 'date',
+  })
+  dateTest?: string;
+
+  @property({
+    type: 'number',
+  })
+  numberTest?: number;
+
+  @property({
+    type: 'string',
+  })
+  stringTest?: string;
+
+  @property({
+    type: 'boolean',
+  })
+  booleanText?: boolean;
+
+  @property({
+    type: 'number',
+    scale: 0,
+    id: 1,
+  })
+  id?: number;
+
+  // Define well-known properties here
+
+  // Indexer property to allow additional data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [prop: string]: any;
+
+  constructor(data?: Partial<Test>) {
+    super(data);
+  }
+}
+
+export interface TestRelations {
+  // describe navigational properties here
+}
+
+export type TestWithRelations = Test & TestRelations;
+
+`;
+
+
 exports[`lb4 discover integration model discovery generates all models without prompts using --all --dataSource 1`] = `
 import {Entity, model, property} from '@loopback/repository';
 

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -50,6 +50,10 @@ const disableCamelCaseOptions = {
 const missingDataSourceOptions = {
   dataSource: 'foo',
 };
+const optionalIdOptions = {
+  ...baseOptions,
+  optionalId: true,
+};
 
 // Expected File Name
 const defaultExpectedTestModel = path.join(
@@ -154,6 +158,20 @@ describe('lb4 discover integration', () => {
           )
           .withOptions(missingDataSourceOptions),
       ).to.be.rejectedWith(/Cannot find datasource/);
+    });
+
+    it('does not mark id property as required based on optionalId option', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withOptions(optionalIdOptions);
+
+      assert.file(defaultExpectedTestModel);
+      expectFileToMatchSnapshot(defaultExpectedTestModel);
     });
   });
 });


### PR DESCRIPTION
Added a new parameter in the discover command `optionalId'. It defaults to false and if set to true, it does not mark `id` of generated models as required.

Fixes #8572 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

