### PR TITLE
fix(docs): documentation fix of for repository generator

### DIFF
--- a/docs/site/Repository-generator.md
+++ b/docs/site/Repository-generator.md
@@ -62,7 +62,7 @@ model already created in their respective directories.
 
 ### Arguments
 
-`<name>` - Optional argument specifyng the respository name to be generated. In
+`<name>` - Optional argument specifying the respository name to be generated. In
 case you select multiple models, the first model will take this argument for its
 repository file name.
 


### PR DESCRIPTION
fix in docs in repository generator from "specifyng" to "specifying"

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
