### PR TITLE
fix(docs): fix in docs of dynamic models for typo respositories

### DIFF
--- a/docs/site/LB3-vs-LB4-request-response-cycle.md
+++ b/docs/site/LB3-vs-LB4-request-response-cycle.md
@@ -351,7 +351,7 @@ export class ExampleController {
 ```
 
 Similarly, the request and response objects can be injected into services and
-respositories along with other objects from the [context](./Context.md).
+repositories along with other objects from the [context](./Context.md).
 
 It may be tempting to use an Express router (because of familiarity) instead of
 a controller to add custom endpoints to the application, but bear it in mind
@@ -485,6 +485,6 @@ may also be used to access the user submitted data in some cases." %}
 ## Summary
 
 The phase-based middleware chain of LoopBack 3 is replaced by the sequence class
-in LoopBack 4. Controllers, services, and respositories are part of the
+in LoopBack 4. Controllers, services, and repositories are part of the
 request/response cycle in LoopBack 4; they provide interfaces and points of
 access to the request object, the response object, and the model data.

--- a/docs/site/Repository-generator.md
+++ b/docs/site/Repository-generator.md
@@ -62,7 +62,7 @@ model already created in their respective directories.
 
 ### Arguments
 
-`<name>` - Optional argument specifying the respository name to be generated. In
+`<name>` - Optional argument specifying the repository name to be generated. In
 case you select multiple models, the first model will take this argument for its
 repository file name.
 

--- a/docs/site/Request-response-cycle.md
+++ b/docs/site/Request-response-cycle.md
@@ -234,8 +234,8 @@ use them.
 between controllers and the data. They use an underlying datasource and a
 connector to interact with the data.
 
-Controller methods can call corresponding methods in the respository to read
-from or write to the database.
+Controller methods can call corresponding methods in the repository to read from
+or write to the database.
 
 Repositories can be injected in the controller constructor so controller methods
 may use them.

--- a/packages/rest-crud/README.md
+++ b/packages/rest-crud/README.md
@@ -75,7 +75,7 @@ For the examples in the following sections, we are also assuming a model named
 ### Creating a CRUD Controller
 
 Here is how you would use `defineCrudRestController` for exposing the CRUD
-endpoints of an existing model with a respository.
+endpoints of an existing model with a repository.
 
 1. Create a REST CRUD controller class for your model.
 


### PR DESCRIPTION
fix in docs for typo from "respositories" to "repositories"

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
