### PR TITLE
fix(docs): documentation typo fix in filters query and relation

### DIFF
--- a/docs/site/Include-filter.md
+++ b/docs/site/Include-filter.md
@@ -286,7 +286,7 @@ await postRepository.findById('123', {
 
 {% include important.html content="The `limit` filter will be applied on a per parent record basis. So each parent record will include a max of `limit` number of records.
 Previously, we had a bug where `limit` will be applied globally, so not all parent's records will include related objects depending on the `limit` value.
-To keep backward compatability with this, in the weird case it is needed, you can use `totalLimit` instead. For more details [see here](https://github.com/loopbackio/loopback-next/issues/6832)
+To keep backward compatibility with this, in the weird case it is needed, you can use `totalLimit` instead. For more details [see here](https://github.com/loopbackio/loopback-next/issues/6832)
 " %}
 
 #### Access included objects

--- a/packages/filter/src/query.ts
+++ b/packages/filter/src/query.ts
@@ -186,7 +186,7 @@ export interface Inclusion {
   scope?: Filter<AnyObject> & {
     /**
      * Global maximum number of inclusions. This is just to remain backward
-     * compatability. This totalLimit props takes precedence over limit
+     * compatibility. This totalLimit props takes precedence over limit
      * https://github.com/loopbackio/loopback-next/issues/6832
      */
     totalLimit?: number;

--- a/packages/repository/src/relations/relation.helpers.ts
+++ b/packages/repository/src/relations/relation.helpers.ts
@@ -62,7 +62,7 @@ export async function findByForeignKeys<
     useScopeFilterGlobally = true;
   }
 
-  // This code is to keep backward compatability.
+  // This code is to keep backward compatibility.
   // See https://github.com/loopbackio/loopback-next/issues/6832 for more info.
   if (scope?.totalLimit) {
     scope.limit = scope.totalLimit;


### PR DESCRIPTION
fix in docs for typo from "compatability" to "compatibility" in "Include Filter" "Query" and "Relation.helpers" files

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
