### PR TITLE
fix(docs): documentation fix of for overridden text

### DIFF
--- a/docs/site/LB3-vs-LB4-request-response-cycle.md
+++ b/docs/site/LB3-vs-LB4-request-response-cycle.md
@@ -475,7 +475,7 @@ async create(book: Book, options?: Options): Promise<Book> {
 }
 ```
 
-Similarly, various other repository methods in LoopBack 4 can be overriden to
+Similarly, various other repository methods in LoopBack 4 can be overridden to
 access the model data in the context of their operation.
 
 {% include tip.html content="

--- a/docs/site/Testing-your-application.md
+++ b/docs/site/Testing-your-application.md
@@ -970,7 +970,7 @@ describe('Product (acceptance)', () => {
     await app.boot();
 
     // change to use the test datasource after the app has been booted so that
-    // it is not overriden
+    // it is not overridden
     app.dataSource(testdb);
     await app.start();
 

--- a/docs/site/decorators/Decorators_openapi.md
+++ b/docs/site/decorators/Decorators_openapi.md
@@ -56,7 +56,7 @@ For example:
   },
 })
 class MyController {
-  // The operation endpoint defined here will be overriden!
+  // The operation endpoint defined here will be overridden!
   @get('/greet')
   greet(@param.query.number('limit') name: string) {}
 }

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -170,7 +170,7 @@ export class DefaultCrudRepository<
 
   /**
    * Creates a legacy persisted model class, attaches it to the datasource and
-   * returns it. This method can be overriden in sub-classes to acess methods
+   * returns it. This method can be overridden in sub-classes to acess methods
    * and properties in the generated model class.
    * @param entityClass - LB4 Entity constructor
    */


### PR DESCRIPTION
fix in docs for typo from "overriden" to "overridden"

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
