### PR TITLE
fix(docs): documentation fix for infered text in repository generator

### DIFF
--- a/docs/site/Repository-generator.md
+++ b/docs/site/Repository-generator.md
@@ -91,7 +91,7 @@ The tool will prompt you for:
 - **Please select the repository base class.** _(repository)_ if the name of a
   valid base class has been supplied from the command line, the prompt is
   skipped, otherwise it will present you a list of repositories. The default
-  repository is infered from the datasource type.
+  repository is inferred from the datasource type.
 
   Any repository in the `src/repository` folder with the file format
   `*.repository.base.ts` will be added to the list too.


### PR DESCRIPTION
fix in docs for typo from "infered" to "inferred"

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
