### PR TITLE
fix(docs): fix in docs of dynamic models for typo

### DIFF
--- a/docs/site/Dynamic-models-repositories-controllers.md
+++ b/docs/site/Dynamic-models-repositories-controllers.md
@@ -75,8 +75,8 @@ const bookDef = new ModelDefinition({
 
 A LoopBack model class is created by passing a `ModelDefinition` object to
 `@loopback/repository`'s helper function `defineModelClass()`. It expects a base
-model to extend (typically `Model` or `Entity`), folowed by the model definition
-object. In this case it will be `Entity`.
+model to extend (typically `Model` or `Entity`), followed by the model
+definition object. In this case it will be `Entity`.
 
 ```ts
 const BookModel = defineModelClass<typeof Entity, {id: number; title?: string}>(


### PR DESCRIPTION
fix in docs of dynamic models for typo from "folowed" to "followed"

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
