### PR TITLE
fix(docs): fix in docs of crafting loopback for typo

### DIFF
--- a/docs/site/DEVELOPING.md
+++ b/docs/site/DEVELOPING.md
@@ -679,12 +679,12 @@ to preserve backward compatibility.
 However, we do recognize that often a breaking change is the most sensible thing
 to do. When that time comes:
 
-- Describe incompatibilites for release notes
+- Describe incompatibilities for release notes
 - Look for more breaking changes to include in the release: search for comments
   containing `TODO(semver-major)` and `@deprecated`.
 - Update list of supported versions
 
-### Describe incompatibilites for release notes
+### Describe incompatibilities for release notes
 
 In the pull request introducing the breaking change, provide a descriptive
 [footer](#footer-optional) explaining the breaking change to our users. This


### PR DESCRIPTION
fix in docs of crafting loopback for typo from incompatibilites to incompatibilities

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
