### PR TITLE
fix(docs): documentation fix for creater text in polymorphic relation

### DIFF
--- a/docs/site/Polymorphic-relation.md
+++ b/docs/site/Polymorphic-relation.md
@@ -62,7 +62,7 @@ deliverable_type: string;
 
 The only difference on the repository class is that instead of having a single
 repository getter, a dictionary of subclass repository getters is passed into
-the repository factory creater.
+the repository factory creator.
 
 ```javascript
 export class DeliveryRepository extends DefaultCrudRepository {


### PR DESCRIPTION
fix in docs for typo from "creater" to "creator"

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
