### PR TITLE
fix(docs): fix in docs of crafting loopback for extensible typo

### DIFF
--- a/docs/site/Crafting-LoopBack-4.md
+++ b/docs/site/Crafting-LoopBack-4.md
@@ -434,8 +434,8 @@ its vast ecosystem.
 Some of the gaps between what Express offers and LoopBack's needs are:
 
 - Lack of extensibility
-  > Express is only extensibile via middleware. It neither exposes a registry
-  > nor provides APIs to manage artifacts such as middleware or routers.
+  > Express is only extensible via middleware. It neither exposes a registry nor
+  > provides APIs to manage artifacts such as middleware or routers.
 - Lack of composability
   > Express is not composable. For example, `app.use()` is the only way to
   > register a middleware. The order of middleware is determined by the order of


### PR DESCRIPTION
fix in docs of crafting loopback for typo "extensibile" to "extensible"

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
