### PR TITLE
fix(docs): documentation fix in deployment docs

### DIFF
--- a/docs/site/deployment/Deploy-for-GDPR-readiness.md
+++ b/docs/site/deployment/Deploy-for-GDPR-readiness.md
@@ -131,7 +131,7 @@ stored. However, the framework itself does not store actual data.
 
 _Important_: LoopBack 4 is in developer preview. How its application
 configuration data reside and is being used may be subjected to change. More
-information will be provided once the code has stablized.
+information will be provided once the code has stabilized.
 
 ##### Personal data used for online contact with IBM
 


### PR DESCRIPTION
documentation typo fix in from "stablized" to "stabilized"

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
