### PR TITLE
fix(docs): documentation fix typo from sematics

### DIFF
--- a/docs/site/migration/auth/passport.md
+++ b/docs/site/migration/auth/passport.md
@@ -247,7 +247,7 @@ You can configure the authentication endpoints with the following steps:
 - For OAuth2 authorizaton flow, we need authentication endpoints that
   participate to get the user validated with an external system.
 - This essentially means the `@authenticate` decorator is used with different
-  sematics compared to the non-OAuth2 section above.
+  semantics compared to the non-OAuth2 section above.
 - Here the controller methods become small parts of the larger OAuth2 dialog.
 - We ideally create a controller with two endpoints decorated with
   `@authenticate(`{passport-strategy-name}`)`


### PR DESCRIPTION
documentation typo fix from "sematics" to "semantics"

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
