### PR TITLE
fix(docs): documentation fix in req response cycle

### DIFF
--- a/docs/site/Request-response-cycle.md
+++ b/docs/site/Request-response-cycle.md
@@ -116,7 +116,7 @@ route for invocation.
 ##### 2. ParseParams
 
 [ParseParams](https://loopback.io/doc/en/lb4/apidocs.rest.parseparamsprovider.html)
-parses LoopBack-relevant request paremeters from the request body, URL segment,
+parses LoopBack-relevant request parameters from the request body, URL segment,
 and query parameters.
 
 It is also responsible for validating the property types of the request body, as
@@ -127,7 +127,7 @@ HTTP 422 error.
 
 [InvokeMethod](https://loopback.io/doc/en/lb4/apidocs.rest.invokemethodprovider.html)
 is responsible for calling the endpoint handler, passing in the route found by
-`FindRoute` and the paremeters found by `ParseParams`.
+`FindRoute` and the parameters found by `ParseParams`.
 
 For non-controller endpoints, control is passed on to the respective handlers at
 this stage, which may then handle the response sending process themselves. For


### PR DESCRIPTION
documentation typo fix in from "paremeter" to "parameter"

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
