### PR TITLE
fix(docs): documentation fix in req response cycle

### DIFF
--- a/docs/site/Request-response-cycle.md
+++ b/docs/site/Request-response-cycle.md
@@ -30,7 +30,7 @@ controller method.
 {% include tip.html content="Apart from controller files in the `controllers` directory,
 controllers may be added to the app by [components](https://loopback.io/doc/en/lb4/Components.html)." %}
 
-In the request/response cycle section we will see how implemenation details
+In the request/response cycle section we will see how implementation details
 determine the course of a request to these endpoints - they may or may not
 actually interact with a model.
 


### PR DESCRIPTION
documentation typo fix in from "implemenation" to "implementation"

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
