### PR TITLE
fix(docs): documentation typo fix from extention to extension

### DIFF
--- a/docs/site/decorators/Decorators_openapi.md
+++ b/docs/site/decorators/Decorators_openapi.md
@@ -513,7 +513,7 @@ export class SomeController {
 
 #### anyOf, allOf, oneOf, not
 
-The `x-ts-type` extention is also valid as a value in `allOf`, `anyOf`, `oneOf`,
+The `x-ts-type` extension is also valid as a value in `allOf`, `anyOf`, `oneOf`,
 and `not` schema keys.
 
 ```ts
@@ -676,7 +676,7 @@ This decorator lets you easily add response specifications using `Models` from
 `@loopback/repository`. The convenience decorator sets the `content-type` to
 `application/json`, and the response description to the string value in the
 `http-status` module. The models become references through the `x-ts-type`
-schema extention.
+schema extension.
 
 ```ts
 @model()

--- a/docs/site/tutorials/core/11-summary.md
+++ b/docs/site/tutorials/core/11-summary.md
@@ -18,7 +18,7 @@ can be useful for our developers to build a scalable Node.js application.
 - [Observers](7-observation.md) and [interceptors](6-interception.md) allows you
   to add logic as part of the application life cycle events.
 - [Configuration](8-configuration.md) can be added to extension points,
-  extentions and services which enables greater flexibility in your application.
+  extensions and services which enables greater flexibility in your application.
 - [Boot by convention](9-boot-by-convention.md) allows artifacts automatically
   discovered and loaded.
 


### PR DESCRIPTION
documentation typo fix in from "extention" to "extension"

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
