### PR TITLE
fix(docs): documentation fix in service static files

### DIFF
--- a/docs/site/Serving-static-files.md
+++ b/docs/site/Serving-static-files.md
@@ -43,7 +43,7 @@ export class TodoListApplication extends BootMixin(
 ```
 
 You can call `app.static()` multiple times to configure the app to serve static
-assets from different drectories.
+assets from different directories.
 
 ```ts
 app.static('/files', path.join(__dirname, 'files'));


### PR DESCRIPTION
documentation typo fix in from "drectories" to "directories"

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
