### PR TITLE
fix(docs): documentation typo update for recevies

### DIFF
--- a/docs/site/tutorials/core/3-context-in-action.md
+++ b/docs/site/tutorials/core/3-context-in-action.md
@@ -92,7 +92,7 @@ Artifacts can be services, repositories, configuration, etc.
 
    Since plain functions do not accept injections, you can create a wrapper
    class that has the ability to accept injection. For example, you can create a
-   provider class that recevies injection of a HTTP request.
+   provider class that receives injection of a HTTP request.
 
 5. As an alias to another binding
 


### PR DESCRIPTION
documentation typo update for recevies to receives

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
