### PR TITLE
fix(docs): fix document typo from moreved to removed

### DIFF
--- a/docs/site/tutorials/core/3-context-in-action.md
+++ b/docs/site/tutorials/core/3-context-in-action.md
@@ -134,7 +134,7 @@ For details, see [Configure the scope](../../Binding.md#configure-the-scope).
 
 ## Watching artifacts
 
-The context view gives us control when a binding is being added or moreved. This
+The context view gives us control when a binding is being added or removed. This
 also allows the support of dynamic extension points. For the
 [greeting-app example](https://github.com/loopbackio/loopback-next/tree/master/examples/greeting-app),
 after the application has started, more greeters can be added, and there is no


### PR DESCRIPTION
fix document typo from moreved to removed

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
