### PR TITLE
fix(docs): update build documentation for spelling mistake

### DIFF
--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -79,7 +79,7 @@ Now you run the scripts, such as:
     }
     ```
 
-  - Set options explicity for the script
+  - Set options explicitly for the script
 
     ```sh
     lb-tsc -p tsconfig.json --target es2017 --outDir dist


### PR DESCRIPTION
update build documentation for spelling mistake explicity to explicitly

Signed-off-by: Vaibhav Kumar <vaibhav.kumar@sourcefuse.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
