### PR TITLE
[WIP] @loopback/boot handle ECMA scripts

### DIFF
--- a/packages/boot/src/__tests__/unit/booters/base-artifact.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/base-artifact.booter.unit.ts
@@ -15,7 +15,8 @@ describe('base-artifact booter unit tests', () => {
   };
 
   describe('configure()', () => {
-    it(`sets 'dirs' / 'extensions' properties as an array if a string`, async () => {
+    it(`sets 'dirs' / 'extensions' properties as an array if a string`,
+    async () => {
       const booterInst = givenBaseBooter({
         dirs: 'test',
         extensions: '.test.js',

--- a/packages/boot/src/__tests__/unit/booters/base-artifact.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/base-artifact.booter.unit.ts
@@ -15,8 +15,7 @@ describe('base-artifact booter unit tests', () => {
   };
 
   describe('configure()', () => {
-    it(`sets 'dirs' / 'extensions' properties as an array if a string`,
-    async () => {
+    it(`sets 'dirs' / 'extensions' properties as an array if a string`, async () => {
       const booterInst = givenBaseBooter({
         dirs: 'test',
         extensions: '.test.js',

--- a/packages/boot/src/__tests__/unit/booters/booter-utils.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/booter-utils.unit.ts
@@ -57,7 +57,7 @@ describe('booter-utils unit tests', () => {
     });
   });
 
-  describe('loadClassesFromFiles()', () => {
+  describe('loadClassesFromFiles()', async () => {
     it('returns an array of classes from a file', async () => {
       // Copying a test file to sandbox that contains a function and 2 classes
       await sandbox.copyFile(
@@ -66,7 +66,7 @@ describe('booter-utils unit tests', () => {
       const files = [resolve(sandbox.path, 'multiple.artifact.js')];
       const NUM_CLASSES = 2; // Number of classes in above file
 
-      const classes = loadClassesFromFiles(files, sandbox.path);
+      const classes = await loadClassesFromFiles(files, sandbox.path);
       expect(classes).to.have.lengthOf(NUM_CLASSES);
       expect(classes[0]).to.be.a.Function();
       expect(classes[1]).to.be.a.Function();
@@ -78,14 +78,14 @@ describe('booter-utils unit tests', () => {
       );
       const files = [resolve(sandbox.path, 'empty.artifact.js')];
 
-      const classes = loadClassesFromFiles(files, sandbox.path);
+      const classes = await loadClassesFromFiles(files, sandbox.path);
       expect(classes).to.be.an.Array();
       expect(classes).to.be.empty();
     });
 
     it('throws an error given a non-existent file', async () => {
       const files = [resolve(sandbox.path, 'fake.artifact.js')];
-      expect(() => loadClassesFromFiles(files, sandbox.path)).to.throw(
+      await expect(loadClassesFromFiles(files, sandbox.path)).to.be.rejectedWith(
         /Cannot find module/,
       );
     });

--- a/packages/boot/src/__tests__/unit/booters/booter-utils.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/booter-utils.unit.ts
@@ -57,7 +57,7 @@ describe('booter-utils unit tests', () => {
     });
   });
 
-  describe('loadClassesFromFiles()', async () => {
+  describe('loadClassesFromFiles()', () => {
     it('returns an array of classes from a file', async () => {
       // Copying a test file to sandbox that contains a function and 2 classes
       await sandbox.copyFile(
@@ -85,9 +85,9 @@ describe('booter-utils unit tests', () => {
 
     it('throws an error given a non-existent file', async () => {
       const files = [resolve(sandbox.path, 'fake.artifact.js')];
-      await expect(loadClassesFromFiles(files, sandbox.path)).to.be.rejectedWith(
-        /Cannot find module/,
-      );
+      await expect(
+        loadClassesFromFiles(files, sandbox.path),
+      ).to.be.rejectedWith(/Cannot find module/);
     });
   });
 });

--- a/packages/boot/src/booters/base-artifact.booter.ts
+++ b/packages/boot/src/booters/base-artifact.booter.ts
@@ -137,6 +137,6 @@ export class BaseArtifactBooter implements Booter {
    * and then process the artifact classes as appropriate.
    */
   async load() {
-    this.classes = loadClassesFromFiles(this.discovered, this.projectRoot);
+    this.classes = await loadClassesFromFiles(this.discovered, this.projectRoot);
   }
 }

--- a/packages/boot/src/booters/base-artifact.booter.ts
+++ b/packages/boot/src/booters/base-artifact.booter.ts
@@ -137,6 +137,9 @@ export class BaseArtifactBooter implements Booter {
    * and then process the artifact classes as appropriate.
    */
   async load() {
-    this.classes = await loadClassesFromFiles(this.discovered, this.projectRoot);
+    this.classes = await loadClassesFromFiles(
+      this.discovered,
+      this.projectRoot,
+    );
   }
 }

--- a/packages/boot/src/booters/booter-utils.ts
+++ b/packages/boot/src/booters/booter-utils.ts
@@ -46,7 +46,7 @@ export function isClass(target: any): target is Constructor<any> {
  *
  * @param files - An array of string of absolute file paths
  * @param projectRootDir - The project root directory
- * @returns An array of Class constructors from a file
+ * @returns A promise of an array of Class constructors from a file
  */
 export async function loadClassesFromFiles(
   files: string[],
@@ -57,8 +57,8 @@ export async function loadClassesFromFiles(
     debug('Loading artifact file %j', path.relative(projectRootDir, file));
     // This is to avoid that compilation transform the import into a require...
     const moduleObj = await Function(
-      `return import("${pathToFileURL(file).toString()}");`
-      )();
+      `return import("${pathToFileURL(file).toString()}");`,
+    )();
     for (const k in moduleObj) {
       const exported = moduleObj[k];
       if (isClass(exported)) {

--- a/packages/boot/src/booters/booter-utils.ts
+++ b/packages/boot/src/booters/booter-utils.ts
@@ -55,10 +55,11 @@ export async function loadClassesFromFiles(
   const classes: Constructor<{}>[] = [];
   for (const file of files) {
     debug('Loading artifact file %j', path.relative(projectRootDir, file));
-    // This is to avoid that compilation transform the import into a require...
+    // To avoid that compilation transform the import into a require...
     const moduleObj = await Function(
-      `return import("${pathToFileURL(file).toString()}");`,
-    )();
+      'file',
+      `return import(file);`,
+    )(pathToFileURL(file).toString());
     for (const k in moduleObj) {
       const exported = moduleObj[k];
       if (isClass(exported)) {


### PR DESCRIPTION
<!--
Make boot loader works when client projects are build as module (ECMA scripts)

See also [#23](https://github.com/loopbackio/loopback-next/discussions/8753)
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [n/a] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [n/a] Affected artifact templates in `packages/cli` were updated
- [n/a] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈

EDIT:
Only one integration test is typeorm does not path. I really do not understand why.
Could someone help with this ?