### PR TITLE
fix:  custom-inject-decorator.ts direct link to md

### DIFF
--- a/docs/site/tutorials/core/10-advanced-recipes.md
+++ b/docs/site/tutorials/core/10-advanced-recipes.md
@@ -38,8 +38,8 @@ export function env(name: string) {
 }
 ```
 
-For a complete example, see
-https://github.com/loopbackio/loopback-next/blob/master/examples/context/src/custom-inject-decorator.ts.
+For a complete example, see 
+[custom-inject-decorator.ts](https://github.com/loopbackio/loopback-next/blob/master/examples/context/src/custom-inject-decorator.ts)
 
 ## Class factory to allow parameterized decorations
 


### PR DESCRIPTION
convert direct link of example custom-inject-decorator.ts to MD version

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ X] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
