### PR TITLE
fix(cli): cli not detecting custom repository

### DIFF
--- a/packages/cli/generators/repository/index.js
+++ b/packages/cli/generators/repository/index.js
@@ -188,7 +188,6 @@ module.exports = class RepositoryGenerator extends ArtifactGenerator {
       type: String,
       required: false,
       description: g.f('A valid repository base class'),
-      default: 'DefaultCrudRepository',
     });
 
     return super._setupGenerator();


### PR DESCRIPTION
Signed-off-by: Yesha  Mavani <yesha.mavani@sourcefuse.com>

<!--
While generating a repository using loopback cli, by default it uses the 'DefaultCrudRepository' as its base instead of providing prompt to user for selecting a base repository.
It wasnt working as expected because a default value was being set in the options and prompt was disabled. So removed the one where a default value was being set. 

Include references to all related GitHub issues and other pull requests, for example:

Fixes #8637 
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
