### PR TITLE
docs(typeorm): update docs describing connection binding in application.ts

### DIFF
--- a/extensions/typeorm/README.md
+++ b/extensions/typeorm/README.md
@@ -66,6 +66,20 @@ using SQlite, you'll need to install `sqlite3`.
 npm install sqlite3
 ```
 
+Then, register `SqliteConnection` connection in `application.ts` file as shown
+below:
+
+```ts
+import {BootMixin} from '@loopback/boot';
+import {RestApplication} from '@loopback/rest';
+import {TypeOrmMixin} from '@loopback/typeorm';
+export class MyApplication extends BootMixin(TypeOrmMixin(RestApplication)) {
+    super(options);
+    this.connection(SqliteConnection);
+    ...
+}
+```
+
 Refer to the
 [TypeORM documentation](https://github.com/typeorm/typeorm#installation) for the
 supported databases and the underlying drivers.


### PR DESCRIPTION
Signed-off-by: bhavyasf <37434313+bhavyasf@users.noreply.github.com>

There needs to be a binding of Connection in `application.ts`  to successfully use `TypeORM` with loopback4 which was missing in LB4 docs.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
