### PR TITLE
feat(cli): Support Binary type to handle BLOB type field

### DIFF
--- a/acceptance/extension-logging-fluentd/package-lock.json
+++ b/acceptance/extension-logging-fluentd/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/node": "^14.18.33",
         "testcontainers": "^8.16.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "engines": {
         "node": "14 || 16 || 17 || 18"
@@ -870,9 +870,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/tweetnacl": {
@@ -1629,9 +1629,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "tweetnacl": {

--- a/acceptance/extension-logging-fluentd/package.json
+++ b/acceptance/extension-logging-fluentd/package.json
@@ -38,6 +38,6 @@
     "@loopback/testlab": "^5.0.4",
     "@types/node": "^14.18.33",
     "testcontainers": "^8.16.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   }
 }

--- a/acceptance/repository-cloudant/package-lock.json
+++ b/acceptance/repository-cloudant/package-lock.json
@@ -17,7 +17,7 @@
         "lodash": "^4.17.21",
         "loopback-connector-cloudant": "2.5.0",
         "ms": "2.1.3",
-        "tslib": "^2.4.0",
+        "tslib": "^2.4.1",
         "typescript": "~4.8.4"
       },
       "engines": {
@@ -2065,9 +2065,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/tunnel-agent": {
@@ -3835,9 +3835,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "tunnel-agent": {

--- a/acceptance/repository-cloudant/package.json
+++ b/acceptance/repository-cloudant/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.17.21",
     "loopback-connector-cloudant": "2.5.0",
     "ms": "2.1.3",
-    "tslib": "^2.4.0",
+    "tslib": "^2.4.1",
     "typescript": "~4.8.4"
   }
 }

--- a/acceptance/repository-mongodb/package-lock.json
+++ b/acceptance/repository-mongodb/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/node": "^14.18.33",
         "loopback-connector-mongodb": "^6.2.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "engines": {
         "node": "14 || 16 || 17 || 18"
@@ -789,9 +789,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/util-deprecate": {
@@ -1448,9 +1448,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "util-deprecate": {

--- a/acceptance/repository-mongodb/package.json
+++ b/acceptance/repository-mongodb/package.json
@@ -38,6 +38,6 @@
     "@loopback/testlab": "^5.0.4",
     "@types/node": "^14.18.33",
     "loopback-connector-mongodb": "^6.2.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   }
 }

--- a/acceptance/repository-mysql/package-lock.json
+++ b/acceptance/repository-mysql/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/node": "^14.18.33",
         "loopback-connector-mysql": "^6.1.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "engines": {
         "node": "14 || 16 || 17 || 18"
@@ -720,9 +720,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/util-deprecate": {
@@ -1343,9 +1343,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "util-deprecate": {

--- a/acceptance/repository-mysql/package.json
+++ b/acceptance/repository-mysql/package.json
@@ -38,6 +38,6 @@
     "@loopback/testlab": "^5.0.4",
     "@types/node": "^14.18.33",
     "loopback-connector-mysql": "^6.1.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   }
 }

--- a/acceptance/repository-postgresql/package-lock.json
+++ b/acceptance/repository-postgresql/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/node": "^14.18.33",
         "loopback-connector-postgresql": "^5.5.2",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "engines": {
         "node": "14 || 16 || 17 || 18"
@@ -897,9 +897,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/util-deprecate": {
@@ -1655,9 +1655,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "util-deprecate": {

--- a/acceptance/repository-postgresql/package.json
+++ b/acceptance/repository-postgresql/package.json
@@ -38,6 +38,6 @@
     "@loopback/testlab": "^5.0.4",
     "@types/node": "^14.18.33",
     "loopback-connector-postgresql": "^5.5.2",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   }
 }

--- a/benchmark/package-lock.json
+++ b/benchmark/package-lock.json
@@ -18,7 +18,7 @@
         "byline": "^5.0.0",
         "debug": "^4.3.4",
         "path-to-regexp": "^6.2.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/autocannon": "^7.9.0",
@@ -1317,9 +1317,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -2384,9 +2384,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "uuid": {
       "version": "8.3.2",

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -51,7 +51,7 @@
     "byline": "^5.0.0",
     "debug": "^4.3.4",
     "path-to-regexp": "^6.2.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/bodyparsers/rest-msgpack/package-lock.json
+++ b/bodyparsers/rest-msgpack/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "msgpack5": "^6.0.2",
-        "tslib": "^2.4.0",
+        "tslib": "^2.4.1",
         "type-is": "^1.6.18"
       },
       "devDependencies": {
@@ -2333,9 +2333,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -4366,9 +4366,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/bodyparsers/rest-msgpack/package.json
+++ b/bodyparsers/rest-msgpack/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "msgpack5": "^6.0.2",
-    "tslib": "^2.4.0",
+    "tslib": "^2.4.1",
     "type-is": "^1.6.18"
   },
   "devDependencies": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^10.1.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "engines": {
         "node": "14 || 16 || 17 || 18"
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/universalify": {
       "version": "2.0.0",
@@ -85,9 +85,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "universalify": {
       "version": "2.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "fs-extra": "^10.1.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4"

--- a/examples/binding-resolution/package-lock.json
+++ b/examples/binding-resolution/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -1097,9 +1097,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -1977,9 +1977,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/binding-resolution/package.json
+++ b/examples/binding-resolution/package.json
@@ -49,7 +49,7 @@
     "@loopback/rest": "^12.0.4",
     "@loopback/rest-explorer": "^5.0.4",
     "debug": "^4.3.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/context/package-lock.json
+++ b/examples/context/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.4",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33",
@@ -1056,9 +1056,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -1901,9 +1901,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/context/package.json
+++ b/examples/context/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@loopback/context": "^5.0.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/express-composition/package-lock.json
+++ b/examples/express-composition/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.18.2",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.14",
@@ -1701,9 +1701,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3093,9 +3093,9 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -54,7 +54,7 @@
     "@loopback/rest-explorer": "^5.0.4",
     "@loopback/service-proxy": "^5.0.4",
     "express": "^4.18.2",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/file-transfer/package-lock.json
+++ b/examples/file-transfer/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "multer": "^1.4.4",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/express-serve-static-core": "^4.17.31",
@@ -1345,9 +1345,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2471,9 +2471,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/file-transfer/package.json
+++ b/examples/file-transfer/package.json
@@ -51,7 +51,7 @@
     "@loopback/rest": "^12.0.4",
     "@loopback/rest-explorer": "^5.0.4",
     "multer": "^1.4.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/graphql/package-lock.json
+++ b/examples/graphql/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "class-transformer": "^0.5.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/multer": "^1.4.7",
@@ -1169,9 +1169,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2120,9 +2120,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -55,7 +55,7 @@
     "@loopback/repository": "^5.0.4",
     "@loopback/rest": "^12.0.4",
     "class-transformer": "^0.5.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/greeter-extension/package-lock.json
+++ b/examples/greeter-extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "4.1.7",
@@ -1066,9 +1066,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -1918,9 +1918,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -50,7 +50,7 @@
     "@loopback/core": "^4.0.4",
     "chalk": "^4.1.2",
     "debug": "^4.3.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/greeting-app/package-lock.json
+++ b/examples/greeting-app/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "4.1.7",
@@ -1066,9 +1066,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -1918,9 +1918,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/greeting-app/package.json
+++ b/examples/greeting-app/package.json
@@ -54,7 +54,7 @@
     "@loopback/rest": "^12.0.4",
     "chalk": "^4.1.2",
     "debug": "^4.3.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/hello-world/package-lock.json
+++ b/examples/hello-world/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.4",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33",
@@ -1056,9 +1056,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -1901,9 +1901,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@loopback/core": "^4.0.4",
     "@loopback/rest": "^12.0.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/lb3-application/package-lock.json
+++ b/examples/lb3-application/package-lock.json
@@ -16,7 +16,7 @@
         "helmet": "^4.6.0",
         "loopback": "^3.28.0",
         "loopback-boot": "^3.3.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.187",
@@ -3722,9 +3722,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -6856,9 +6856,9 @@
       "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/examples/lb3-application/package.json
+++ b/examples/lb3-application/package.json
@@ -60,7 +60,7 @@
     "helmet": "^4.6.0",
     "loopback": "^3.28.0",
     "loopback-boot": "^3.3.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/log-extension/package-lock.json
+++ b/examples/log-extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -1066,9 +1066,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -1918,9 +1918,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -49,7 +49,7 @@
     "@loopback/rest": "^12.0.4",
     "chalk": "^4.1.2",
     "debug": "^4.3.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/metrics-prometheus/package-lock.json
+++ b/examples/metrics-prometheus/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.10.4",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33",
@@ -1056,9 +1056,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -1901,9 +1901,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/metrics-prometheus/package.json
+++ b/examples/metrics-prometheus/package.json
@@ -51,7 +51,7 @@
     "@loopback/core": "^4.0.4",
     "@loopback/metrics": "^0.11.4",
     "@loopback/rest": "^12.0.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/multi-tenancy/package-lock.json
+++ b/examples/multi-tenancy/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "debug": "^4.3.4",
         "jsonwebtoken": "^8.5.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -1223,9 +1223,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2206,9 +2206,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/multi-tenancy/package.json
+++ b/examples/multi-tenancy/package.json
@@ -62,7 +62,7 @@
     "@loopback/service-proxy": "^5.0.4",
     "debug": "^4.3.4",
     "jsonwebtoken": "^8.5.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/passport-login/package-lock.json
+++ b/examples/passport-login/package-lock.json
@@ -35,7 +35,7 @@
         "passport-oauth2": "^1.6.1",
         "passport-twitter": "1.0.4",
         "path": "^0.12.7",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.14",
@@ -2537,9 +2537,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4707,9 +4707,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/passport-login/package.json
+++ b/examples/passport-login/package.json
@@ -84,7 +84,7 @@
     "passport-oauth2": "^1.6.1",
     "passport-twitter": "1.0.4",
     "path": "^0.12.7",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/references-many/package-lock.json
+++ b/examples/references-many/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "loopback-connector-rest": "^4.0.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.187",
@@ -1834,9 +1834,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -3306,9 +3306,9 @@
       "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/examples/references-many/package.json
+++ b/examples/references-many/package.json
@@ -60,7 +60,7 @@
     "@loopback/rest-explorer": "^5.0.4",
     "@loopback/service-proxy": "^5.0.4",
     "loopback-connector-rest": "^4.0.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/rest-crud/package-lock.json
+++ b/examples/rest-crud/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "loopback-connector-rest": "^4.0.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.187",
@@ -1834,9 +1834,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -3306,9 +3306,9 @@
       "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/examples/rest-crud/package.json
+++ b/examples/rest-crud/package.json
@@ -57,7 +57,7 @@
     "@loopback/rest-crud": "^0.15.3",
     "@loopback/rest-explorer": "^5.0.4",
     "loopback-connector-rest": "^4.0.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/rpc-server/package-lock.json
+++ b/examples/rpc-server/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.18.2",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.14",
@@ -1701,9 +1701,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3093,9 +3093,9 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@loopback/core": "^4.0.4",
     "express": "^4.18.2",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/soap-calculator/package-lock.json
+++ b/examples/soap-calculator/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "loopback-connector-soap": "^6.0.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.0",
@@ -2376,9 +2376,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -4357,9 +4357,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -52,7 +52,7 @@
     "@loopback/rest-explorer": "^5.0.4",
     "@loopback/service-proxy": "^5.0.4",
     "loopback-connector-soap": "^6.0.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/socketio/package-lock.json
+++ b/examples/socketio/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "debug": "^4.3.4",
         "p-event": "^4.2.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -1188,9 +1188,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2166,9 +2166,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/socketio/package.json
+++ b/examples/socketio/package.json
@@ -58,7 +58,7 @@
     "@loopback/socketio": "^0.6.4",
     "debug": "^4.3.4",
     "p-event": "^4.2.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/todo-jwt/package-lock.json
+++ b/examples/todo-jwt/package-lock.json
@@ -12,7 +12,7 @@
         "@types/bcryptjs": "^2.4.2",
         "bcryptjs": "^2.4.3",
         "loopback-connector-rest": "^4.0.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.187",
@@ -1846,9 +1846,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -3328,9 +3328,9 @@
       "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/examples/todo-jwt/package.json
+++ b/examples/todo-jwt/package.json
@@ -65,7 +65,7 @@
     "@types/bcryptjs": "^2.4.2",
     "bcryptjs": "^2.4.3",
     "loopback-connector-rest": "^4.0.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/todo-list/package-lock.json
+++ b/examples/todo-list/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "loopback-connector-rest": "^4.0.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.187",
@@ -1834,9 +1834,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -3306,9 +3306,9 @@
       "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -60,7 +60,7 @@
     "@loopback/rest-explorer": "^5.0.4",
     "@loopback/service-proxy": "^5.0.4",
     "loopback-connector-rest": "^4.0.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/todo/package-lock.json
+++ b/examples/todo/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "loopback-connector-rest": "^4.0.1",
         "morgan": "^1.10.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.187",
@@ -1902,9 +1902,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -3441,9 +3441,9 @@
       "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -59,7 +59,7 @@
     "@loopback/service-proxy": "^5.0.4",
     "loopback-connector-rest": "^4.0.1",
     "morgan": "^1.10.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/validation-app/package-lock.json
+++ b/examples/validation-app/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "strong-error-handler": "^4.0.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33",
@@ -1569,9 +1569,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2833,9 +2833,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/validation-app/package.json
+++ b/examples/validation-app/package.json
@@ -57,7 +57,7 @@
     "@loopback/rest-explorer": "^5.0.4",
     "@loopback/service-proxy": "^5.0.4",
     "strong-error-handler": "^4.0.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -21,7 +21,7 @@
         "process": "^0.11.10",
         "puppeteer": "^19.2.0",
         "typescript": "~4.8.4",
-        "util": "^0.12.4",
+        "util": "^0.12.5",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0"
       },

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33",
@@ -3170,9 +3170,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5931,9 +5931,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -53,7 +53,7 @@
     "process": "^0.11.10",
     "puppeteer": "^19.2.0",
     "typescript": "~4.8.4",
-    "util": "^0.12.4",
+    "util": "^0.12.5",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
   }

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@loopback/core": "^4.0.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/extensions/apiconnect/package-lock.json
+++ b/extensions/apiconnect/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.10.4",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33"
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -4199,9 +4199,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/extensions/apiconnect/package.json
+++ b/extensions/apiconnect/package.json
@@ -43,7 +43,7 @@
     "@loopback/rest": "^12.0.4"
   },
   "dependencies": {
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/extensions/authentication-passport/package-lock.json
+++ b/extensions/authentication-passport/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "passport": "^0.6.0",
-        "tslib": "^2.4.0",
+        "tslib": "^2.4.1",
         "util-promisifyall": "^1.0.6"
       },
       "devDependencies": {
@@ -2658,9 +2658,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -4957,9 +4957,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/extensions/authentication-passport/package.json
+++ b/extensions/authentication-passport/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@loopback/security": "^0.8.4",
     "passport": "^0.6.0",
-    "tslib": "^2.4.0",
+    "tslib": "^2.4.1",
     "util-promisifyall": "^1.0.6"
   },
   "devDependencies": {

--- a/extensions/cron/package-lock.json
+++ b/extensions/cron/package-lock.json
@@ -13,7 +13,7 @@
         "@types/debug": "^4.1.7",
         "cron": "^2.1.0",
         "debug": "^4.3.4",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33"
@@ -209,9 +209,9 @@
       "peer": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/uuid": {
       "version": "9.0.0",
@@ -381,9 +381,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "uuid": {
       "version": "9.0.0",

--- a/extensions/cron/package.json
+++ b/extensions/cron/package.json
@@ -44,7 +44,7 @@
     "@types/debug": "^4.1.7",
     "cron": "^2.1.0",
     "debug": "^4.3.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/extensions/health/package-lock.json
+++ b/extensions/health/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@cloudnative/health": "^2.1.2",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33"
@@ -2235,9 +2235,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -4211,9 +4211,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/extensions/health/package.json
+++ b/extensions/health/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@cloudnative/health": "^2.1.2",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/extensions/logging/package-lock.json
+++ b/extensions/logging/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "fluent-logger": "^3.4.1",
         "morgan": "^1.10.0",
-        "tslib": "^2.4.0",
+        "tslib": "^2.4.1",
         "winston": "^3.8.2",
         "winston-transport": "^4.5.0"
       },
@@ -2486,9 +2486,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -4734,9 +4734,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/extensions/logging/package.json
+++ b/extensions/logging/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "fluent-logger": "^3.4.1",
     "morgan": "^1.10.0",
-    "tslib": "^2.4.0",
+    "tslib": "^2.4.1",
     "winston": "^3.8.2",
     "winston-transport": "^4.5.0"
   },

--- a/extensions/metrics/package-lock.json
+++ b/extensions/metrics/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "prom-client": "^14.1.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.14",
@@ -2188,9 +2188,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -4109,9 +4109,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/extensions/metrics/package.json
+++ b/extensions/metrics/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "prom-client": "^14.1.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/extensions/pooling/package-lock.json
+++ b/extensions/pooling/package-lock.json
@@ -12,7 +12,7 @@
         "@types/generic-pool": "^3.1.11",
         "debug": "^4.3.4",
         "generic-pool": "^3.9.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -196,9 +196,9 @@
       "peer": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/typescript": {
       "version": "4.8.4",
@@ -367,9 +367,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "typescript": {
       "version": "4.8.4",

--- a/extensions/pooling/package.json
+++ b/extensions/pooling/package.json
@@ -42,7 +42,7 @@
     "@types/generic-pool": "^3.1.11",
     "debug": "^4.3.4",
     "generic-pool": "^3.9.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/extensions/typeorm/package-lock.json
+++ b/extensions/typeorm/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
-        "tslib": "^2.4.0",
+        "tslib": "^2.4.1",
         "typeorm": "^0.3.10"
       },
       "devDependencies": {
@@ -3622,9 +3622,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -6971,9 +6971,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/extensions/typeorm/package.json
+++ b/extensions/typeorm/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "tslib": "^2.4.0",
+    "tslib": "^2.4.1",
     "typeorm": "^0.3.10"
   },
   "devDependencies": {

--- a/fixtures/mock-oauth2-provider/package-lock.json
+++ b/fixtures/mock-oauth2-provider/package-lock.json
@@ -20,7 +20,7 @@
         "form-data": "^4.0.0",
         "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.21",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "engines": {
         "node": "14 || 16 || 17 || 18"
@@ -818,9 +818,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -1484,9 +1484,9 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/fixtures/mock-oauth2-provider/package.json
+++ b/fixtures/mock-oauth2-provider/package.json
@@ -46,7 +46,7 @@
     "form-data": "^4.0.0",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/authentication/package-lock.json
+++ b/packages/authentication/package-lock.json
@@ -12,7 +12,7 @@
         "@types/express": "^4.17.14",
         "@types/lodash": "^4.14.187",
         "lodash": "^4.17.21",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33",
@@ -2335,9 +2335,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -4402,9 +4402,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -47,7 +47,7 @@
     "@types/express": "^4.17.14",
     "@types/lodash": "^4.14.187",
     "lodash": "^4.17.21",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/authorization/package-lock.json
+++ b/packages/authorization/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -233,9 +233,9 @@
       "peer": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/uuid": {
       "version": "9.0.0",
@@ -424,9 +424,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "uuid": {
       "version": "9.0.0",

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@loopback/security": "^0.8.4",
     "debug": "^4.3.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/boot/package-lock.json
+++ b/packages/boot/package-lock.json
@@ -13,7 +13,7 @@
         "@types/glob": "^8.0.0",
         "debug": "^4.3.4",
         "glob": "^8.0.3",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33"
@@ -262,9 +262,9 @@
       "peer": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/uuid": {
       "version": "9.0.0",
@@ -486,9 +486,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "uuid": {
       "version": "9.0.0",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -45,7 +45,7 @@
     "@types/glob": "^8.0.0",
     "debug": "^4.3.4",
     "glob": "^8.0.3",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/booter-lb3app/package-lock.json
+++ b/packages/booter-lb3app/package-lock.json
@@ -14,7 +14,7 @@
         "loopback": "^3.28.0",
         "loopback-swagger": "^5.9.0",
         "swagger2openapi": "^7.0.8",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -4967,9 +4967,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -9180,9 +9180,9 @@
       "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/packages/booter-lb3app/package.json
+++ b/packages/booter-lb3app/package.json
@@ -48,7 +48,7 @@
     "loopback": "^3.28.0",
     "loopback-swagger": "^5.9.0",
     "swagger2openapi": "^7.0.8",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/boot": "^5.0.4",

--- a/packages/cli/generators/datasource/index.js
+++ b/packages/cli/generators/datasource/index.js
@@ -63,6 +63,10 @@ module.exports = class DataSourceGenerator extends ArtifactGenerator {
   }
 
   setOptions() {
+    // remove not needed .env property
+    if (this.options.config) {
+      delete this.options?.env;
+    }
     return super.setOptions();
   }
 

--- a/packages/cli/generators/model/property-definition.js
+++ b/packages/cli/generators/model/property-definition.js
@@ -38,6 +38,8 @@ function createPropertyTemplateData(val) {
     }
   } else if (val.type === 'buffer') {
     val.tsType = 'Buffer';
+  } else if (val.type === 'Binary') {
+    val.tsType = 'Buffer';
   }
 
   if (NON_TS_TYPES.includes(val.tsType)) {

--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -196,7 +196,7 @@ module.exports = class BaseGenerator extends Generator {
       return;
     }
     for (const o in opts) {
-      if (this.options[o] == null) {
+      if (!this.options[o]) {
         this.options[o] = opts[o];
       }
     }

--- a/packages/cli/test/unit/discover/import-discovered-model.test.js
+++ b/packages/cli/test/unit/discover/import-discovered-model.test.js
@@ -112,6 +112,27 @@ describe('importDiscoveredModel', () => {
     });
   });
 
+  it('imports Blob properties', () => {
+    const discoveredModel = {
+      name: 'TestModel',
+      properties: {
+        image: {
+          type: 'Binary',
+          required: false,
+          length: null,
+          precision: null,
+          scale: null,
+        },
+      },
+    };
+
+    const modelData = importDiscoveredModel(discoveredModel);
+    expect(modelData.properties).to.have.property('image').deepEqual({
+      type: `'Binary'`,
+      tsType: 'Buffer',
+    });
+  });
+
   it('imports numeric primary key', () => {
     const discoveredModel = {
       name: 'TestModel',

--- a/packages/context/package-lock.json
+++ b/packages/context/package-lock.json
@@ -13,7 +13,7 @@
         "debug": "^4.3.4",
         "hyperid": "^3.0.1",
         "p-event": "^4.2.0",
-        "tslib": "^2.4.0",
+        "tslib": "^2.4.1",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -135,9 +135,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/uuid": {
       "version": "9.0.0",
@@ -242,9 +242,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "uuid": {
       "version": "9.0.0",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -48,7 +48,7 @@
     "debug": "^4.3.4",
     "hyperid": "^3.0.1",
     "p-event": "^4.2.0",
-    "tslib": "^2.4.0",
+    "tslib": "^2.4.1",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -63,9 +63,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     }
   },
   "dependencies": {
@@ -104,9 +104,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@loopback/context": "^5.0.4",
     "debug": "^4.3.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/express/package-lock.json
+++ b/packages/express/package-lock.json
@@ -19,7 +19,7 @@
         "http-errors": "^2.0.0",
         "on-finished": "^2.4.1",
         "toposort": "^2.0.2",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -881,9 +881,9 @@
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -1631,9 +1631,9 @@
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -51,7 +51,7 @@
     "http-errors": "^2.0.0",
     "on-finished": "^2.4.1",
     "toposort": "^2.0.2",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/filter/package-lock.json
+++ b/packages/filter/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33",
@@ -26,9 +26,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/typescript": {
       "version": "4.8.4",
@@ -52,9 +52,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "typescript": {
       "version": "4.8.4",

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -32,7 +32,7 @@
     "!*/__tests__"
   ],
   "dependencies": {
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/http-caching-proxy/package-lock.json
+++ b/packages/http-caching-proxy/package-lock.json
@@ -13,7 +13,7 @@
         "cacache": "^16.1.3",
         "debug": "^4.3.4",
         "rimraf": "^3.0.2",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -599,9 +599,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -1080,9 +1080,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "tunnel": {
       "version": "0.0.6",

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -43,7 +43,7 @@
     "cacache": "^16.1.3",
     "debug": "^4.3.4",
     "rimraf": "^3.0.2",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/http-server/package-lock.json
+++ b/packages/http-server/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "debug": "^4.3.4",
         "stoppable": "^1.1.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     }
   },
   "dependencies": {
@@ -138,9 +138,9 @@
       "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     }
   }
 }

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "debug": "^4.3.4",
     "stoppable": "^1.1.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/metadata/package-lock.json
+++ b/packages/metadata/package-lock.json
@@ -12,7 +12,7 @@
         "debug": "^4.3.4",
         "lodash": "^4.17.21",
         "reflect-metadata": "^0.1.13",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -82,9 +82,9 @@
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     }
   },
   "dependencies": {
@@ -139,9 +139,9 @@
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     }
   }
 }

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -42,7 +42,7 @@
     "debug": "^4.3.4",
     "lodash": "^4.17.21",
     "reflect-metadata": "^0.1.13",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/model-api-builder/package-lock.json
+++ b/packages/model-api-builder/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.4",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33"
@@ -1142,9 +1142,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/upper-case": {
       "version": "2.0.2",
@@ -2137,9 +2137,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "upper-case": {
       "version": "2.0.2",

--- a/packages/model-api-builder/package.json
+++ b/packages/model-api-builder/package.json
@@ -36,7 +36,7 @@
     "@loopback/repository": "^5.0.4"
   },
   "dependencies": {
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/openapi-spec-builder/package-lock.json
+++ b/packages/openapi-spec-builder/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "openapi3-ts": "^2.0.2",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33"
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -63,9 +63,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "openapi3-ts": "^2.0.2",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/openapi-v3/package-lock.json
+++ b/packages/openapi-v3/package-lock.json
@@ -14,7 +14,7 @@
         "json-merge-patch": "^1.0.2",
         "lodash": "^4.17.21",
         "openapi3-ts": "^2.0.2",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -224,9 +224,9 @@
       "peer": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/uuid": {
       "version": "9.0.0",
@@ -415,9 +415,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "uuid": {
       "version": "9.0.0",

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -48,7 +48,7 @@
     "json-merge-patch": "^1.0.2",
     "lodash": "^4.17.21",
     "openapi3-ts": "^2.0.2",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/repository-json-schema/package-lock.json
+++ b/packages/repository-json-schema/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/json-schema": "^7.0.11",
         "debug": "^4.3.4",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -1210,9 +1210,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/upper-case": {
       "version": "2.0.2",
@@ -2260,9 +2260,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "upper-case": {
       "version": "2.0.2",

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@types/json-schema": "^7.0.11",
     "debug": "^4.3.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/repository-tests/package-lock.json
+++ b/packages/repository-tests/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/debug": "^4.1.7",
         "debug": "^4.3.4",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.187",
@@ -1147,9 +1147,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/upper-case": {
       "version": "2.0.2",
@@ -2143,9 +2143,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "upper-case": {
       "version": "2.0.2",

--- a/packages/repository-tests/package.json
+++ b/packages/repository-tests/package.json
@@ -39,7 +39,7 @@
     "@loopback/testlab": "^5.0.4",
     "@types/debug": "^4.1.7",
     "debug": "^4.3.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/repository/package-lock.json
+++ b/packages/repository/package-lock.json
@@ -13,7 +13,7 @@
         "debug": "^4.3.4",
         "lodash": "^4.17.21",
         "loopback-datasource-juggler": "^4.27.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/bson": "^4.0.5",
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/upper-case": {
       "version": "2.0.2",
@@ -2047,9 +2047,9 @@
       "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "upper-case": {
       "version": "2.0.2",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -41,7 +41,7 @@
     "debug": "^4.3.4",
     "lodash": "^4.17.21",
     "loopback-datasource-juggler": "^4.27.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/rest-crud/package-lock.json
+++ b/packages/rest-crud/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -4194,9 +4194,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/packages/rest-crud/package.json
+++ b/packages/rest-crud/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@loopback/model-api-builder": "^4.0.4",
     "debug": "^4.3.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/rest-explorer/package-lock.json
+++ b/packages/rest-explorer/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "ejs": "^3.1.8",
         "swagger-ui-dist": "4.15.2",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/ejs": "^3.1.1",
@@ -2161,9 +2161,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -4056,9 +4056,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "ejs": "^3.1.8",
     "swagger-ui-dist": "4.15.2",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/rest/package-lock.json
+++ b/packages/rest/package-lock.json
@@ -34,7 +34,7 @@
         "path-to-regexp": "^6.2.1",
         "qs": "^6.10.5",
         "strong-error-handler": "^4.0.0",
-        "tslib": "^2.4.0",
+        "tslib": "^2.4.1",
         "type-is": "^1.6.18",
         "validator": "^13.7.0"
       },
@@ -1811,9 +1811,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -3348,9 +3348,9 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -66,7 +66,7 @@
     "path-to-regexp": "^6.2.1",
     "qs": "^6.10.5",
     "strong-error-handler": "^4.0.0",
-    "tslib": "^2.4.0",
+    "tslib": "^2.4.1",
     "type-is": "^1.6.18",
     "validator": "^13.7.0"
   },

--- a/packages/security/package-lock.json
+++ b/packages/security/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -178,9 +178,9 @@
       "peer": true
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/uuid": {
       "version": "9.0.0",
@@ -324,9 +324,9 @@
       "peer": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "uuid": {
       "version": "9.0.0",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/service-proxy/package-lock.json
+++ b/packages/service-proxy/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "loopback-datasource-juggler": "^4.27.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33"
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/upper-case": {
       "version": "2.0.2",
@@ -1894,9 +1894,9 @@
       "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "upper-case": {
       "version": "2.0.2",

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "loopback-datasource-juggler": "^4.27.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/testlab/package-lock.json
+++ b/packages/testlab/package-lock.json
@@ -21,7 +21,7 @@
         "should": "^13.2.3",
         "sinon": "^14.0.1",
         "supertest": "^6.3.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^14.18.33"
@@ -1314,9 +1314,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -2467,9 +2467,9 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-detect": {
       "version": "4.0.8",

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -46,7 +46,7 @@
     "should": "^13.2.3",
     "sinon": "^14.0.1",
     "supertest": "^6.3.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",

--- a/packages/tsdocs/package-lock.json
+++ b/packages/tsdocs/package-lock.json
@@ -14,7 +14,7 @@
         "@microsoft/api-extractor": "^7.33.5",
         "debug": "^4.3.4",
         "fs-extra": "^10.1.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.1"
       },
       "bin": {
         "lb-document-apidocs": "bin/document-apis.js",
@@ -1382,9 +1382,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/type-fest": {
       "version": "0.6.0",
@@ -2635,9 +2635,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "type-fest": {
       "version": "0.6.0",

--- a/packages/tsdocs/package.json
+++ b/packages/tsdocs/package.json
@@ -53,7 +53,7 @@
     "@microsoft/api-extractor": "^7.33.5",
     "debug": "^4.3.4",
     "fs-extra": "^10.1.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.1"
   },
   "devDependencies": {
     "@loopback/build": "^9.0.4",


### PR DESCRIPTION
Currently, discovering models that have a field with BLOB type fails the build with an error. 

```
npm run build
> binaryissue@0.0.1 build
> lb-tsc
src/models/amounts.model.ts:69:11 - error TS2304: Cannot find name 'Binary'.
69   image?: Binary;
             ~~~~~~
src/models/amounts.model.ts:69:11 - error TS4031: Public property 'image' of exported class has or is using private name 'Binary'.
69   image?: Binary;
             ~~~~~~
Found 2 errors in the same file, starting at: src/models/amounts.model.ts:69
```

This happens due to the fact that lb4 doesn't handle Binary type. This PR intends to fix this issue and provides support for the BLOB type.

There was [PR](https://github.com/loopbackio/loopback-next/pull/6476) a while ago which was closed without merge. This PR continues that PR and has added a test for the change.

Related GitHub issues & PRs:

Fixes # [6295](https://github.com/loopbackio/loopback-next/issues/6295)
Fixes # [9043](https://github.com/loopbackio/loopback-next/issues/9043)
Fixes # [144](https://github.com/loopbackio/loopback-connector-oracle/issues/144)

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

