### PR TITLE
feat(cli): binary support for blob type

### DIFF
--- a/packages/cli/generators/model/property-definition.js
+++ b/packages/cli/generators/model/property-definition.js
@@ -38,6 +38,8 @@ function createPropertyTemplateData(val) {
     }
   } else if (val.type === 'buffer') {
     val.tsType = 'Buffer';
+  } else if (val.type === 'Binary') {
+    val.tsType = 'Buffer';
   }
 
   if (NON_TS_TYPES.includes(val.tsType)) {

--- a/packages/cli/test/unit/discover/import-discovered-model.test.js
+++ b/packages/cli/test/unit/discover/import-discovered-model.test.js
@@ -112,6 +112,27 @@ describe('importDiscoveredModel', () => {
     });
   });
 
+  it('imports Blob properties', () => {
+    const discoveredModel = {
+      name: 'TestModel',
+      properties: {
+        image: {
+          type: 'Binary',
+          required: false,
+          length: null,
+          precision: null,
+          scale: null,
+        },
+      },
+    };
+
+    const modelData = importDiscoveredModel(discoveredModel);
+    expect(modelData.properties).to.have.property('image').deepEqual({
+      type: `'Binary'`,
+      tsType: 'Buffer',
+    });
+  });
+
   it('imports numeric primary key', () => {
     const discoveredModel = {
       name: 'TestModel',


### PR DESCRIPTION
Currently, discovering models that have a field with BLOB type fails the build with an error. 

```
npm run build
> binaryissue@0.0.1 build
> lb-tsc
src/models/amounts.model.ts:69:11 - error TS2304: Cannot find name 'Binary'.
69   image?: Binary;
             ~~~~~~
src/models/amounts.model.ts:69:11 - error TS4031: Public property 'image' of exported class has or is using private name 'Binary'.
69   image?: Binary;
             ~~~~~~
Found 2 errors in the same file, starting at: src/models/amounts.model.ts:69
```

This happens due to the fact that lb4 doesn't handle Binary type. This PR intends to fix this issue and provides support for the BLOB type.

There was [PR](https://github.com/loopbackio/loopback-next/pull/6476) a while ago which was closed without merge. This PR continues that PR and has added a test for the change.

Related GitHub issues & PRs:

Fixes # [6295](https://github.com/loopbackio/loopback-next/issues/6295)
Fixes # [9043](https://github.com/loopbackio/loopback-next/issues/9043)
Fixes # [144](https://github.com/loopbackio/loopback-connector-oracle/issues/144)

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

