### PR TITLE
fix(cli): pass treatCHAR1AsString, treatBIT1AsBit & treatTINYINT1AsTinyInt flags to loopback-connector-mysql

### DIFF
--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -292,6 +292,27 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
     for (let i = 0; i < this.discoveringModels.length; i++) {
       const modelInfo = this.discoveringModels[i];
       debug(`Discovering: ${modelInfo.name}...`);
+      let treatCHAR1AsString = false;
+      let treatBIT1AsBit = true;
+      let treatTINYINT1AsTinyInt = true;
+      // when options are passed to discover command as --config, the treatTINYINT1AsTinyInt comes as a string
+      if (typeof this.options.treatCHAR1AsString === 'string') {
+        treatCHAR1AsString = this.options.treatCHAR1AsString === 'true';
+      } else if (typeof this.options.treatCHAR1AsString === 'boolean') {
+        treatCHAR1AsString = this.options.treatCHAR1AsString;
+      }
+      // when options are passed to discover command as --config, the treatBIT1AsBit comes as a string
+      if (typeof this.options.treatBIT1AsBit === 'string') {
+        treatBIT1AsBit = this.options.treatBIT1AsBit === 'true';
+      } else if (typeof this.options.treatBIT1AsBit === 'boolean') {
+        treatBIT1AsBit = this.options.treatBIT1AsBit;
+      }
+      // when options are passed to discover command as --config, the treatTINYINT1AsTinyInt comes as a string
+      if (typeof this.options.treatTINYINT1AsTinyInt === 'string') {
+        treatTINYINT1AsTinyInt = this.options.treatTINYINT1AsTinyInt === 'true';
+      } else if (typeof this.options.treatTINYINT1AsTinyInt === 'boolean') {
+        treatTINYINT1AsTinyInt = this.options.treatTINYINT1AsTinyInt;
+      }
       const modelDefinition = await modelMaker.discoverSingleModel(
         this.artifactInfo.dataSource,
         modelInfo.name,
@@ -299,6 +320,9 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
           schema: modelInfo.owner,
           disableCamelCase: this.artifactInfo.disableCamelCase,
           associations: this.options.relations,
+          treatCHAR1AsString,
+          treatBIT1AsBit,
+          treatTINYINT1AsTinyInt,
         },
       );
       if (this.options.optionalId) {

--- a/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
@@ -37,7 +37,64 @@ export class Test extends Entity {
     scale: 0,
     id: 1,
   })
-  id?: number;
+  id: number;
+
+  // Define well-known properties here
+
+  // Indexer property to allow additional data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [prop: string]: any;
+
+  constructor(data?: Partial<Test>) {
+    super(data);
+  }
+}
+
+export interface TestRelations {
+  // describe navigational properties here
+}
+
+export type TestWithRelations = Test & TestRelations;
+
+`;
+
+exports[`lb4 discover integration model discovery treatTINYINT1AsTinyInt set to false to treat tinyint(1) as boolean 1`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Test extends Entity {
+  @property({
+    type: 'date',
+  })
+  dateTest?: string;
+
+  @property({
+    type: 'number',
+  })
+  numberTest?: number;
+
+  @property({
+    type: 'string',
+  })
+  stringTest?: string;
+
+  @property({
+    type: 'boolean',
+  })
+  booleanText?: boolean;
+
+  @property({
+    type: 'number',
+    scale: 0,
+    id: 1,
+  })
+  id: number;
+
+  @property({
+    type: 'boolean',
+    scale: 0,
+  })
+  isActive?: boolean;
 
   // Define well-known properties here
 

--- a/packages/cli/snapshots/integration/generators/model.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/model.integration.snapshots.js
@@ -34,11 +34,15 @@ export class Test extends Entity {
 
   @property({
     type: 'number',
-    required: true,
     scale: 0,
     id: 1,
   })
-  id: number;
+  id?: number;
+
+  @property({
+    type: 'boolean',
+  })
+  isActive?: boolean;
 
 
   constructor(data?: Partial<Test>) {

--- a/packages/cli/test/fixtures/discover/mem.datasource.js.txt
+++ b/packages/cli/test/fixtures/discover/mem.datasource.js.txt
@@ -68,11 +68,17 @@ const fullDefinitions = [
       },
       'id': {
         'type': 'Number',
-        'required': true,
         'length': null,
         'precision': null,
         'scale': 0,
         'id': 1,
+      },
+      'isActive': {
+        'type': 'boolean',
+        'required': false,
+        'length': null,
+        'precision': null,
+        'scale': null,
       },
     },
   },

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -54,6 +54,10 @@ const optionalIdOptions = {
   ...baseOptions,
   optionalId: true,
 };
+const treatTINYINT1AsTinyIntOptions = {
+  ...baseOptions,
+  treatTINYINT1AsTinyInt: false,
+};
 
 // Expected File Name
 const defaultExpectedTestModel = path.join(
@@ -169,6 +173,20 @@ describe('lb4 discover integration', () => {
           }),
         )
         .withOptions(optionalIdOptions);
+
+      assert.file(defaultExpectedTestModel);
+      expectFileToMatchSnapshot(defaultExpectedTestModel);
+    });
+
+    it('treatTINYINT1AsTinyInt set to false to treat tinyint(1) as boolean', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withOptions(treatTINYINT1AsTinyIntOptions);
 
       assert.file(defaultExpectedTestModel);
       expectFileToMatchSnapshot(defaultExpectedTestModel);


### PR DESCRIPTION
By default, LoopBack treats `tinyint(1)` as `tinyint` from MySQL. Until a flag `treatTINYINT1AsTinyInt` is set to false. [Link](https://loopback.io/pages/en/lb4/readmes/loopback-connector-mysql.html#mysql-to-loopback-types) to the docs.

Running lb4 discover results in any column with type `tinyint(1)` as `number` rather then `boolean`. There is no way to pass `treatTINYINT1AsTinyInt` flag to the MySQL connector. This PR allows passing `treatCHAR1AsString`, `treatBIT1AsBit`, `treatTINYINT1AsTinyInt` as a flag or a property in JSON string of config. 

```lb4 discover -c '{ "dataSource": "localsource", "schema": "track", "all": true, "disableCamelCase": false, "yes": "undefined", "treatTINYINT1AsTinyInt": true}' -y```

Or

```lb4 discover --dataSource=localsource --schema="track" --all="true" --disableCamelCase="false" --treatTINYINT1AsTinyInt=true```


## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
