### PR TITLE
feat(cli): specify models with --models in lb4 discover

### DIFF
--- a/docs/site/Discovering-models.md
+++ b/docs/site/Discovering-models.md
@@ -49,7 +49,10 @@ placed. Default is `src/models`
 `--schema`: Specify the schema which the datasource will find the models to
 discover
 
+**`--models`**: Specify the models to be generated e.g:--models=table1,table2
+
 `--optionalId`: Specify if the Id property of generated models will be marked as
+
 not required
 
 ### Interactive Prompts

--- a/packages/cli/.yo-rc.json
+++ b/packages/cli/.yo-rc.json
@@ -1278,6 +1278,12 @@
           "name": "outDir",
           "hide": false
         },
+        "models": {
+          "type": "String",
+          "description": "Discover specific models without prompting users to select e.g:--models=table1,table2",
+          "name": "models",
+          "hide": false
+        },
         "optionalId": {
           "type": "Boolean",
           "description": "Boolean to mark id property as optional field",

--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -57,6 +57,14 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
       default: undefined,
     });
 
+    this.option('models', {
+      type: String,
+      description: g.f(
+        'Discover specific models without prompting users to select e.g:--models=table1,table2',
+      ),
+      default: undefined,
+    });
+
     this.option('optionalId', {
       type: Boolean,
       description: g.f('Boolean to mark id property as optional field'),
@@ -199,6 +207,16 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
     /* istanbul ignore next */
     if (this.options.all) {
       this.discoveringModels = this.modelChoices;
+    }
+
+    if (this.options.models) {
+      const answers = {discoveringModels: this.options.models.split(',')};
+      debug(`Models specified: ${JSON.stringify(answers)}`);
+      this.discoveringModels = [];
+      answers.discoveringModels.forEach(m => {
+        this.discoveringModels.push(this.modelChoices.find(c => c.name === m));
+      });
+      return;
     }
 
     const prompts = [

--- a/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
@@ -1336,6 +1336,12 @@ exports[`cli saves command metadata to .yo-rc.json 1`] = `
           "name": "outDir",
           "hide": false
         },
+        "models": {
+          "type": "String",
+          "description": "Discover specific models without prompting users to select e.g:--models=table1,table2",
+          "name": "models",
+          "hide": false
+        },
         "optionalId": {
           "type": "Boolean",
           "description": "Boolean to mark id property as optional field",

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -50,6 +50,12 @@ const disableCamelCaseOptions = {
 const missingDataSourceOptions = {
   dataSource: 'foo',
 };
+const specificmodelsOptions = {
+  models: 'Test',
+  dataSource: 'mem',
+  views: false,
+  disableCamelCase: true,
+};
 const optionalIdOptions = {
   ...baseOptions,
   optionalId: true,
@@ -173,5 +179,18 @@ describe('lb4 discover integration', () => {
       assert.file(defaultExpectedTestModel);
       expectFileToMatchSnapshot(defaultExpectedTestModel);
     });
+  });
+  it('generates specific models without prompts using --models', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(sandbox.path, () =>
+        testUtils.givenLBProject(sandbox.path, {
+          additionalFiles: SANDBOX_FILES,
+        }),
+      )
+      .withOptions(specificmodelsOptions);
+
+    basicModelFileChecks(defaultExpectedTestModel, defaultExpectedIndexFile);
+    assert.file(defaultExpectedTestModel);
   });
 });


### PR DESCRIPTION
This PR adds an option to lb4 discover command. --models is an option to pass models that lb4 discover should create without prompt.

The actual PR is [here](https://github.com/loopbackio/loopback-next/pull/8612). This PR is a copy of the same PR. The reason to create another PR is to move things forward and allow merging the changes to the master. The original PR has been active for a while from the PR creator.

Actual credit for the changes goes to the original PR creator.

Signed-off-by: Muhammad Aaqil <aaqilniz@yahoo.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

