### PR TITLE
feat(cli): enumerate relations in openapispec relation object

### DIFF
--- a/packages/repository-json-schema/src/__tests__/unit/filter-json-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/filter-json-schema.unit.ts
@@ -260,6 +260,19 @@ describe('getFilterJsonSchemaFor', () => {
       .to.equal('Customer.IncludeFilter');
   });
 
+  it('enumerates relations under relation object', () => {
+    expect(customerFilterSchema.properties)
+      .to.have.propertyByPath(
+        'include',
+        'items',
+        'anyOf',
+        '0',
+        'properties',
+        'relation',
+        'enum',
+      )
+      .containDeep(['orders']);
+  });
   it('returns "include.items.title" when no options were provided', () => {
     expect(customerFilterSchema.properties)
       .to.have.propertyByPath('include', 'items', 'anyOf', '0', 'title')

--- a/packages/repository-json-schema/src/filter-json-schema.ts
+++ b/packages/repository-json-schema/src/filter-json-schema.ts
@@ -153,7 +153,7 @@ export function getFilterJsonSchemaFor(
             type: 'object',
             properties: {
               // TODO(bajtos) restrict values to relations defined by "model"
-              relation: {type: 'string'},
+              relation: {type: 'string', enum: Object.keys(modelRelations)},
               // TODO(bajtos) describe the filter for the relation target model
               scope: getScopeFilterJsonSchemaFor(modelCtor, options),
             },


### PR DESCRIPTION
This PR will restrict the relations in openapi spec by using enum.

Signed-off-by: Muhammad Aaqil <aaqilniz@yahoo.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

