### PR TITLE
fix(cli): made changes so update comamnd updates the peerDependencies as well

### DIFF
--- a/packages/cli/lib/version-helper.js
+++ b/packages/cli/lib/version-helper.js
@@ -198,9 +198,9 @@ function updateDependencies(generator) {
       pkg.peerDependencies[d] !== templateDeps[d]
     ) {
       depUpdates.push(
-        `- PeerDependency ${d}: ${pkg.devDependencies[d]} => ${templateDeps[d]}`,
+        `- PeerDependency ${d}: ${pkg.peerDependencies[d]} => ${templateDeps[d]}`,
       );
-      pkg.devDependencies[d] = templateDeps[d];
+      pkg.peerDependencies[d] = templateDeps[d];
     }
   }
   if (depUpdates.length) {


### PR DESCRIPTION

fix #9144

Signed-off-by: Yesha  Mavani <yesha.mavani@sourcefuse.com>


Please provide a high-level description of the changes made by your pull request.
The lb4 update command does not update the peer dependencies 
while showing the list of which all packages it will update, it lists the peer dependencies but while updating it misses those
There was a minor issue due to which it wasn't updating it as it was trying to change the devDependencies again instead of peerDependencies. 

Include references to all related GitHub issues and other pull requests, for example:

Fixes #9144 

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
