### PR TITLE
fix(cli): response type from array to object in belongsTo

### DIFF
--- a/packages/cli/generators/relation/templates/controller-relation-template-belongs-to.ts.ejs
+++ b/packages/cli/generators/relation/templates/controller-relation-template-belongs-to.ts.ejs
@@ -24,7 +24,7 @@ export class <%= controllerClassName %> {
         description: '<%= targetModelClassName %> belonging to <%= sourceModelClassName %>',
         content: {
           'application/json': {
-            schema: {type: 'array', items: getModelSchemaRef(<%= targetModelClassName %>)},
+            schema: getModelSchemaRef(<%= targetModelClassName %>),
           },
         },
       },

--- a/packages/cli/snapshots/integration/generators/relation.belongs-to.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/relation.belongs-to.integration.snapshots.js
@@ -89,7 +89,7 @@ export class OrderCustomerController {
         description: 'Customer belonging to Order',
         content: {
           'application/json': {
-            schema: {type: 'array', items: getModelSchemaRef(Customer)},
+            schema: getModelSchemaRef(Customer),
           },
         },
       },
@@ -138,7 +138,7 @@ export class OrderCustomerController {
         description: 'Customer belonging to Order',
         content: {
           'application/json': {
-            schema: {type: 'array', items: getModelSchemaRef(Customer)},
+            schema: getModelSchemaRef(Customer),
           },
         },
       },


### PR DESCRIPTION
Signed-off-by: Muhammad Aaqil <aaqilniz@yahoo.com>

In case of a belongsTo relation, the openAPI docs show `array` in the responses for the route: 
`/sourceModel/:{targetId}/targetModel`. (e.g: /orders/1/customer. 

The target instance will always be a single record in case of belongsTo relation. Hence the type should be object. This PR changes the type in the response (in openAPI docs) from `array` to `object`.

There is one thing though, the actual response of the API is actually an object - not an array.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
