### PR TITLE
docs: update standard for foreign key name in belongs to relation

### DIFF
--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -93,7 +93,7 @@ name or the relation name, you'll need to specify some fields through the
 relation decorator.
 
 The standard naming convention for the foreign key property in the source model
-is `relation name` + `Id` (for example, Order.customerId).
+is `target name` + `Id` (for example, Order.customerId).
 
 {% include code-caption.html content="/src/models/order.model.ts" %}
 


### PR DESCRIPTION
Signed-off-by: Muhammad Aaqil <aaqilniz@yahoo.com>

The way the default foreign key for a belongsTo relation is being generated [here](https://github.com/loopbackio/loopback-next/blob/6c73ca1037659315f17184c0325f64efe9398e98/packages/cli/generators/relation/index.js#L542) is different than mentioned in the docs. I have changed the docs according to the code.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
