### PR TITLE
fix(cli): extend from DefaultKeyValueRepository in case of kv datasource

### DIFF
--- a/packages/cli/generators/repository/templates/src/repositories/repository-kv-template.ts.ejs
+++ b/packages/cli/generators/repository/templates/src/repositories/repository-kv-template.ts.ejs
@@ -8,8 +8,9 @@ import {<%= modelName %>} from '../models';
 import {<%=repositoryBaseClass %>} from './<%=repositoryBaseFile %>';
 <% } -%>
 
-export class <%= className %>Repository extends <%= repositoryBaseClass %><
-  <%= modelName %>
+<% if (isRepositoryBaseBuiltin) { %>export class <%= className %>Repository extends <%= repositoryTypeClass %><
+  <%} else { %>export class <%= className %>Repository extends <%= repositoryBaseClass %><
+  <% } %><%= modelName %>
 > {
   constructor(
     @inject('datasources.<%= dataSourceName %>') dataSource: <%= dataSourceClassName %>,

--- a/packages/cli/test/integration/generators/repository.integration.js
+++ b/packages/cli/test/integration/generators/repository.integration.js
@@ -491,9 +491,7 @@ describe('lb4 repository', /** @this {Mocha.Suite} */ function () {
           }),
         )
         .withPrompts(basicPrompt)
-        .withArguments(
-          '--model DecoratorDefined --repositoryBaseClass DefaultKeyValueRepository',
-        );
+        .withArguments('--model DecoratorDefined');
       const expectedFile = path.join(
         sandbox.path,
         REPOSITORY_APP_PATH,


### PR DESCRIPTION
If we create a repository for a kv-based datasource, the repository class is supposed to extend DefaultKeyValueRepository but currently, if we run `lb4 repository` and select kv-based DS  & the model, the resulting code is buggy. 

This PR would allow the creation of correct code for kv based repository.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
