### PR TITLE
fix(cli): update --help for relation

### DIFF
--- a/packages/cli/.yo-rc.json
+++ b/packages/cli/.yo-rc.json
@@ -1415,7 +1415,7 @@
         "foreignKeyName": {
           "type": "String",
           "required": false,
-          "description": "Destination model foreign key name",
+          "description": "Destination model foreign key name (optional, provide only when there is a custom foreign key)",
           "name": "foreignKeyName",
           "hide": false
         },

--- a/packages/cli/generators/relation/index.js
+++ b/packages/cli/generators/relation/index.js
@@ -128,7 +128,9 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
     this.option('foreignKeyName', {
       type: String,
       required: false,
-      description: g.f('Destination model foreign key name'),
+      description: g.f(
+        'Destination model foreign key name (optional, provide only when there is a custom foreign key)',
+      ),
     });
 
     this.option('relationName', {

--- a/packages/cli/intl/en/messages.json
+++ b/packages/cli/intl/en/messages.json
@@ -151,7 +151,7 @@
   "bfd42878b3c50994368322098aed9e42": "include Dockerfile and .dockerignore",
   "c1f96ff7ee37bcc6aa150ae5d0dbc3bb": "What is the type of your ID?",
   "c3eece87ffd6970cb83a75715824dce7": "include service-proxy imports and ServiceMixin",
-  "c87a36fbb5183525d0006021aec56a91": "Destination model foreign key name",
+  "c87a36fbb5183525d0006021aec56a91": "Destination model foreign key name (optional, provide only when there is a custom foreign key)",
   "c8d3e70199f75ca1f1d0bd9af1d62d38": "model does not exist.",
   "c92e838c1513ce96008d7bfee201e1e9": "A valid datasource name",
   "ca660806a44ff651cd28cf4a3dddc686": "Do not remember prompt answers",

--- a/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
@@ -1473,7 +1473,7 @@ exports[`cli saves command metadata to .yo-rc.json 1`] = `
         "foreignKeyName": {
           "type": "String",
           "required": false,
-          "description": "Destination model foreign key name",
+          "description": "Destination model foreign key name (optional, provide only when there is a custom foreign key)",
           "name": "foreignKeyName",
           "hide": false
         },


### PR DESCRIPTION
Current --help response for relation has a bit confusing description for foreignKeyName. I've updated the text to be clearer.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
