### PR TITLE
Update docs how to set defaultMetadata for methods not decorated with…

### DIFF
--- a/docs/site/Authentication-component-options.md
+++ b/docs/site/Authentication-component-options.md
@@ -31,7 +31,7 @@ simply configure the authentication component with `defaultMetadata` as follows:
 ```ts
 app
   .configure(AuthenticationBindings.COMPONENT)
-  .to({defaultMetadata: {strategy: 'xyz'}});
+  .to({defaultMetadata: [{strategy: 'xyz'}]});
 ```
 
 If multiple strategies are used for a given method, we can configure the


### PR DESCRIPTION
Update Docs: allow defaultMetadata for methods not decorated with [@authenticate]

Fixes #9338

