### PR TITLE
feat(sequelize): add connection pooling support

### DIFF
--- a/extensions/sequelize/README.md
+++ b/extensions/sequelize/README.md
@@ -248,7 +248,6 @@ Please note, the current implementation does not support the following:
 1. Loopback Migrations (via default `migrate.ts`). Though you're good if using
    external packages like
    [`db-migrate`](https://www.npmjs.com/package/db-migrate).
-2. Connection Pooling is not implemented yet.
 
 Community contribution is welcome.
 

--- a/extensions/sequelize/src/__tests__/unit/sequelize.datasource.unit.ts
+++ b/extensions/sequelize/src/__tests__/unit/sequelize.datasource.unit.ts
@@ -16,4 +16,54 @@ describe('Sequelize DataSource', () => {
       expect(result).which.eql('Specified connector memory is not supported.');
     }
   });
+
+  it('parses pool options for postgresql', async () => {
+    const dataSource = new SequelizeDataSource({
+      name: 'db',
+      connector: 'postgresql',
+      min: 10,
+      max: 20,
+      idleTimeoutMillis: 18000,
+    });
+
+    const poolOptions = dataSource.getPoolOptions();
+
+    expect(poolOptions).to.have.property('min', 10);
+    expect(poolOptions).to.have.property('max', 20);
+    expect(poolOptions).to.have.property('idle', 18000);
+    expect(poolOptions).to.not.have.property('acquire');
+  });
+
+  it('parses pool options for mysql', async () => {
+    const dataSource = new SequelizeDataSource({
+      name: 'db',
+      connector: 'mysql',
+      connectionLimit: 20,
+      acquireTimeout: 10000,
+    });
+
+    const poolOptions = dataSource.getPoolOptions();
+
+    expect(poolOptions).to.have.property('max', 20);
+    expect(poolOptions).to.have.property('acquire', 10000);
+    expect(poolOptions).to.not.have.property('min');
+    expect(poolOptions).to.not.have.property('idle');
+  });
+
+  it('parses pool options for oracle', async () => {
+    const dataSource = new SequelizeDataSource({
+      name: 'db',
+      connector: 'oracle',
+      minConn: 10,
+      maxConn: 20,
+      timeout: 20000,
+    });
+
+    const poolOptions = dataSource.getPoolOptions();
+
+    expect(poolOptions).to.have.property('min', 10);
+    expect(poolOptions).to.have.property('max', 20);
+    expect(poolOptions).to.have.property('idle', 20000);
+    expect(poolOptions).to.not.have.property('acquire');
+  });
 });

--- a/extensions/sequelize/src/sequelize/connector-mapping.ts
+++ b/extensions/sequelize/src/sequelize/connector-mapping.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Dialect as AllSequelizeDialects} from 'sequelize';
+import {Dialect as AllSequelizeDialects, PoolOptions} from 'sequelize';
 
 export type SupportedLoopbackConnectors =
   | 'mysql'
@@ -23,4 +23,56 @@ export const SupportedConnectorMapping: {
   oracle: 'oracle',
   sqlite3: 'sqlite',
   db2: 'db2',
+};
+
+/**
+ * Loopback uses different keys for pool options depending on the connector.
+ */
+export const poolConfigKeys = [
+  // mysql
+  'connectionLimit',
+  'acquireTimeout',
+  // postgresql
+  'min',
+  'max',
+  'idleTimeoutMillis',
+  // oracle
+  'minConn',
+  'maxConn',
+  'timeout',
+] as const;
+export type LoopbackPoolConfigKey = (typeof poolConfigKeys)[number];
+
+export type PoolingEnabledConnector = Exclude<
+  SupportedLoopbackConnectors,
+  'db2' | 'sqlite3'
+>;
+
+export const poolingEnabledConnectors: PoolingEnabledConnector[] = [
+  'mysql',
+  'oracle',
+  'postgresql',
+];
+
+type IConnectionPoolOptions = {
+  [connectorName in PoolingEnabledConnector]?: {
+    [sequelizePoolOption in keyof PoolOptions]: LoopbackPoolConfigKey;
+  };
+};
+
+export const ConnectionPoolOptions: IConnectionPoolOptions = {
+  mysql: {
+    max: 'connectionLimit',
+    acquire: 'acquireTimeout',
+  },
+  postgresql: {
+    min: 'min',
+    max: 'max',
+    idle: 'idleTimeoutMillis',
+  },
+  oracle: {
+    min: 'minConn',
+    max: 'maxConn',
+    idle: 'timeout',
+  },
 };


### PR DESCRIPTION
For mysql, postgresql and oracle dialects.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
