### PR TITLE
enable lb4 relation recognize registerInclusionResolver passed in --config

### DIFF
--- a/packages/cli/generators/relation/index.js
+++ b/packages/cli/generators/relation/index.js
@@ -730,6 +730,8 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
 
   async promptRegisterInclusionResolver() {
     if (this.shouldExit()) return false;
+    this.artifactInfo.registerInclusionResolver =
+      this.options.registerInclusionResolver;
     const props = await this.prompt([
       {
         type: 'confirm',
@@ -739,6 +741,7 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
           chalk.yellow(this.artifactInfo.sourceModel),
           chalk.yellow(this.artifactInfo.destinationModel),
         ),
+        when: this.artifactInfo.registerInclusionResolver === undefined,
         default: true,
       },
     ]);

--- a/packages/cli/snapshots/integration/generators/relation.belongs-to.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/relation.belongs-to.integration.snapshots.js
@@ -85,6 +85,61 @@ export class EmployeeRepository extends DefaultCrudRepository<
 `;
 
 
+exports[`lb4 relation checks generated repository with registerInclusionResolver set to true in --config generated repository file should have inclusion resolver registered 1`] = `
+import {DefaultCrudRepository, BelongsToAccessor, repository} from '@loopback/repository';
+import {Order, Customer} from '../models';
+import {DbDataSource} from '../datasources';
+import {inject, Getter} from '@loopback/core';
+import {CustomerRepository} from './customer.repository';
+
+export class OrderRepository extends DefaultCrudRepository<
+  Order,
+  typeof Order.prototype.id
+> {
+  public readonly myCustomer: BelongsToAccessor<
+    Customer,
+    typeof Order.prototype.id
+  >;
+
+  public readonly custom_name: BelongsToAccessor<Customer, typeof Order.prototype.id>;
+
+  constructor(@inject('datasources.db') dataSource: DbDataSource, @repository.getter('CustomerRepository') protected customerRepositoryGetter: Getter<CustomerRepository>,) {
+    super(Order, dataSource);
+    this.custom_name = this.createBelongsToAccessorFor('custom_name', customerRepositoryGetter,);
+    this.registerInclusionResolver('custom_name', this.custom_name.inclusionResolver);
+  }
+}
+
+`;
+
+
+exports[`lb4 relation checks generated repository with registerInclusionResolver set to false in --config generated repository file should not have inclusion resolver registered 1`] = `
+import {DefaultCrudRepository, BelongsToAccessor, repository} from '@loopback/repository';
+import {Order, Customer} from '../models';
+import {DbDataSource} from '../datasources';
+import {inject, Getter} from '@loopback/core';
+import {CustomerRepository} from './customer.repository';
+
+export class OrderRepository extends DefaultCrudRepository<
+  Order,
+  typeof Order.prototype.id
+> {
+  public readonly myCustomer: BelongsToAccessor<
+    Customer,
+    typeof Order.prototype.id
+  >;
+
+  public readonly custom_name: BelongsToAccessor<Customer, typeof Order.prototype.id>;
+
+  constructor(@inject('datasources.db') dataSource: DbDataSource, @repository.getter('CustomerRepository') protected customerRepositoryGetter: Getter<CustomerRepository>,) {
+    super(Order, dataSource);
+    this.custom_name = this.createBelongsToAccessorFor('custom_name', customerRepositoryGetter,);
+  }
+}
+
+`;
+
+
 exports[`lb4 relation checks if the controller file created  answers {"relationType":"belongsTo","sourceModel":"Order","destinationModel":"Customer","relationName":"my_customer"} checks controller content with belongsTo relation 1`] = `
 import {
   repository,

--- a/packages/cli/test/integration/generators/relation.belongs-to.integration.js
+++ b/packages/cli/test/integration/generators/relation.belongs-to.integration.js
@@ -437,4 +437,64 @@ describe('lb4 relation', /** @this {Mocha.Suite} */ function () {
       );
     }
   });
+
+  context(
+    'checks generated repository with registerInclusionResolver set to false in --config',
+    () => {
+      before(async function runGeneratorWithAnswers() {
+        await sandbox.reset();
+        await testUtils
+          .executeGenerator(generator)
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments([
+            '--config',
+            `{"relationType":"belongsTo","sourceModel":"Order","destinationModel":"Customer","relationName":"custom_name","registerInclusionResolver":false}`,
+          ]);
+      });
+
+      it('generated repository file should not have inclusion resolver registered', async () => {
+        const sourceFilePath = path.join(
+          sandbox.path,
+          REPOSITORY_APP_PATH,
+          repositoryFileName,
+        );
+        assert.file(sourceFilePath);
+        expectFileToMatchSnapshot(sourceFilePath);
+      });
+    },
+  );
+
+  context(
+    'checks generated repository with registerInclusionResolver set to true in --config',
+    () => {
+      before(async function runGeneratorWithAnswers() {
+        await sandbox.reset();
+        await testUtils
+          .executeGenerator(generator)
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments([
+            '--config',
+            `{"relationType":"belongsTo","sourceModel":"Order","destinationModel":"Customer","relationName":"custom_name","registerInclusionResolver":true}`,
+          ]);
+      });
+
+      it('generated repository file should have inclusion resolver registered', async () => {
+        const sourceFilePath = path.join(
+          sandbox.path,
+          REPOSITORY_APP_PATH,
+          repositoryFileName,
+        );
+        assert.file(sourceFilePath);
+        expectFileToMatchSnapshot(sourceFilePath);
+      });
+    },
+  );
 });


### PR DESCRIPTION
lb4 relation with --config fails to recognize `registerInclusionResolver` and asks even if it is provided in the --config. This PR fixes that.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
