### PR TITLE
fix: remove repeated import from controller for same table relation for hasManyThrough

### DIFF
--- a/packages/cli/generators/relation/templates/controller-relation-template-has-many-through.ts.ejs
+++ b/packages/cli/generators/relation/templates/controller-relation-template-has-many-through.ts.ejs
@@ -15,8 +15,8 @@ import {
   post,
   requestBody,
 } from '@loopback/rest';
-import {
-<%= sourceModelClassName %>,
+import {<%if (sourceModelClassName != targetModelClassName) { %>
+<%= sourceModelClassName %>,<% } %>
 <%= throughModelClassName %>,
 <%= targetModelClassName %>,
 } from '../models';

--- a/packages/cli/snapshots/integration/generators/relation.has-many-through.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/relation.has-many-through.integration.snapshots.js
@@ -636,3 +636,203 @@ export class DoctorRepository extends DefaultCrudRepository<
 }
 
 `;
+
+
+exports[`lb4 relation HasManyThrough generates model relation with same table answers {"relationType":"hasManyThrough","sourceModel":"User","destinationModel":"User","throughModel":"Friend"} controller file has been created with hasManyThrough relation with same table 1`] = `
+import {
+  Count,
+  CountSchema,
+  Filter,
+  repository,
+  Where,
+} from '@loopback/repository';
+  import {
+  del,
+  get,
+  getModelSchemaRef,
+  getWhereSchemaFor,
+  param,
+  patch,
+  post,
+  requestBody,
+} from '@loopback/rest';
+import {
+Friend,
+User,
+} from '../models';
+import {UserRepository} from '../repositories';
+
+export class UserUserController {
+  constructor(
+    @repository(UserRepository) protected userRepository: UserRepository,
+  ) { }
+
+  @get('/users/{id}/users', {
+    responses: {
+      '200': {
+        description: 'Array of User has many User through Friend',
+        content: {
+          'application/json': {
+            schema: {type: 'array', items: getModelSchemaRef(User)},
+          },
+        },
+      },
+    },
+  })
+  async find(
+    @param.path.number('id') id: number,
+    @param.query.object('filter') filter?: Filter<User>,
+  ): Promise<User[]> {
+    return this.userRepository.users(id).find(filter);
+  }
+
+  @post('/users/{id}/users', {
+    responses: {
+      '200': {
+        description: 'create a User model instance',
+        content: {'application/json': {schema: getModelSchemaRef(User)}},
+      },
+    },
+  })
+  async create(
+    @param.path.number('id') id: typeof User.prototype.id,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(User, {
+            title: 'NewUserInUser',
+            exclude: ['id'],
+          }),
+        },
+      },
+    }) user: Omit<User, 'id'>,
+  ): Promise<User> {
+    return this.userRepository.users(id).create(user);
+  }
+
+  @patch('/users/{id}/users', {
+    responses: {
+      '200': {
+        description: 'User.User PATCH success count',
+        content: {'application/json': {schema: CountSchema}},
+      },
+    },
+  })
+  async patch(
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(User, {partial: true}),
+        },
+      },
+    })
+    user: Partial<User>,
+    @param.query.object('where', getWhereSchemaFor(User)) where?: Where<User>,
+  ): Promise<Count> {
+    return this.userRepository.users(id).patch(user, where);
+  }
+
+  @del('/users/{id}/users', {
+    responses: {
+      '200': {
+        description: 'User.User DELETE success count',
+        content: {'application/json': {schema: CountSchema}},
+      },
+    },
+  })
+  async delete(
+    @param.path.number('id') id: number,
+    @param.query.object('where', getWhereSchemaFor(User)) where?: Where<User>,
+  ): Promise<Count> {
+    return this.userRepository.users(id).delete(where);
+  }
+}
+
+`;
+
+
+exports[`lb4 relation HasManyThrough generates model relation with same table answers {"relationType":"hasManyThrough","sourceModel":"User","destinationModel":"User","throughModel":"Friend"} has correct default foreign keys 1`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Friend extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'number',
+  })
+  userId?: number;
+
+  @property({
+    type: 'number',
+  })
+  friendId?: number;
+
+  constructor(data?: Partial<Friend>) {
+    super(data);
+  }
+}
+
+`;
+
+
+exports[`lb4 relation HasManyThrough generates model relation with same table answers {"relationType":"hasManyThrough","sourceModel":"User","destinationModel":"User","throughModel":"Friend"} has correct imports and relation name users 1`] = `
+import {Entity, model, property, hasMany} from '@loopback/repository';
+import {Friend} from './friend.model';
+
+@model()
+export class User extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  email?: string;
+
+  @hasMany(() => User, {through: {model: () => Friend}})
+  users: User[];
+
+  constructor(data?: Partial<User>) {
+    super(data);
+  }
+}
+
+`;
+
+
+exports[`lb4 relation HasManyThrough generates model relation with same table answers {"relationType":"hasManyThrough","sourceModel":"User","destinationModel":"User","throughModel":"Friend"} has correct imports and relation name users 2`] = `
+import {inject, Getter} from '@loopback/core';
+import {DefaultCrudRepository, repository, HasManyThroughRepositoryFactory} from '@loopback/repository';
+import {DbDataSource} from '../datasources';
+import {User, Friend} from '../models';
+import {FriendRepository} from './friend.repository';
+
+export class UserRepository extends DefaultCrudRepository<
+  User,
+  typeof User.prototype.id
+> {
+
+  public readonly users: HasManyThroughRepositoryFactory<User, typeof User.prototype.id,
+          Friend,
+          typeof User.prototype.id
+        >;
+
+  constructor(@inject('datasources.db') dataSource: DbDataSource, @repository.getter('FriendRepository') protected friendRepositoryGetter: Getter<FriendRepository>, @repository.getter('UserRepository') protected userRepositoryGetter: Getter<UserRepository>,) {
+    super(User, dataSource);
+    this.users = this.createHasManyThroughRepositoryFactoryFor('users', userRepositoryGetter, friendRepositoryGetter,);
+    this.registerInclusionResolver('users', this.users.inclusionResolver);
+  }
+}
+
+`;

--- a/packages/cli/test/fixtures/relation/controllers/user-user.controller.ts
+++ b/packages/cli/test/fixtures/relation/controllers/user-user.controller.ts
@@ -1,0 +1,1 @@
+export class UserUserController {}

--- a/packages/cli/test/fixtures/relation/index.js
+++ b/packages/cli/test/fixtures/relation/index.js
@@ -162,6 +162,26 @@ const SourceEntries = {
     file: 'employee.controller.ts',
     content: readSourceFile('./controllers/employee.controller.ts'),
   },
+  UserModel: {
+    path: MODEL_APP_PATH,
+    file: 'user.model.ts',
+    content: readSourceFile('./models/user.model.ts'),
+  },
+  FriendModel: {
+    path: MODEL_APP_PATH,
+    file: 'friend.model.ts',
+    content: readSourceFile('./models/friend.model.ts'),
+  },
+  UserRepository: {
+    path: REPOSITORY_APP_PATH,
+    file: 'user.repository.ts',
+    content: readSourceFile('./repositories/user.repository.ts'),
+  },
+  FriendRepository: {
+    path: REPOSITORY_APP_PATH,
+    file: 'friend.repository.ts',
+    content: readSourceFile('./repositories/friend.repository.ts'),
+  },
 };
 exports.SourceEntries = SourceEntries;
 
@@ -226,6 +246,10 @@ exports.SANDBOX_FILES = [
   SourceEntries.DoctorPatientController,
   SourceEntries.EmployeeModel,
   SourceEntries.EmployeeController,
+  SourceEntries.UserModel,
+  SourceEntries.FriendModel,
+  SourceEntries.UserRepository,
+  SourceEntries.FriendRepository,
 ];
 
 exports.SANDBOX_FILES2 = [

--- a/packages/cli/test/fixtures/relation/models/friend.model.ts
+++ b/packages/cli/test/fixtures/relation/models/friend.model.ts
@@ -1,0 +1,25 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Friend extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'number',
+  })
+  userId?: number;
+
+  @property({
+    type: 'number',
+  })
+  friendId?: number;
+
+  constructor(data?: Partial<Friend>) {
+    super(data);
+  }
+}

--- a/packages/cli/test/fixtures/relation/models/user.model.ts
+++ b/packages/cli/test/fixtures/relation/models/user.model.ts
@@ -1,0 +1,20 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class User extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  email?: string;
+
+  constructor(data?: Partial<User>) {
+    super(data);
+  }
+}

--- a/packages/cli/test/fixtures/relation/repositories/friend.repository.ts
+++ b/packages/cli/test/fixtures/relation/repositories/friend.repository.ts
@@ -1,0 +1,13 @@
+import {inject} from '@loopback/core';
+import {DefaultCrudRepository} from '@loopback/repository';
+import {DbDataSource} from '../datasources';
+import {Friend} from '../models';
+
+export class FriendRepository extends DefaultCrudRepository<
+  Friend,
+  typeof Friend.prototype.id
+> {
+  constructor(@inject('datasources.db') dataSource: DbDataSource) {
+    super(Friend, dataSource);
+  }
+}

--- a/packages/cli/test/fixtures/relation/repositories/user.repository.ts
+++ b/packages/cli/test/fixtures/relation/repositories/user.repository.ts
@@ -1,0 +1,13 @@
+import {inject} from '@loopback/core';
+import {DefaultCrudRepository} from '@loopback/repository';
+import {DbDataSource} from '../datasources';
+import {User} from '../models';
+
+export class UserRepository extends DefaultCrudRepository<
+  User,
+  typeof User.prototype.id
+> {
+  constructor(@inject('datasources.db') dataSource: DbDataSource) {
+    super(User, dataSource);
+  }
+}

--- a/packages/cli/test/integration/generators/relation.has-many-through.integration.js
+++ b/packages/cli/test/integration/generators/relation.has-many-through.integration.js
@@ -23,8 +23,14 @@ const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 const sourceFileName = 'doctor.model.ts';
 const throughFileName = 'appointment.model.ts';
-const controllerFileName = 'doctor-patient.controller.ts';
 const repositoryFileName = 'doctor.repository.ts';
+const controllerFileName = 'doctor-patient.controller.ts';
+
+const throughFileNameForSameTable = 'friend.model.ts';
+const sourceFileNameForSameTable = 'user.model.ts';
+const repositoryFileNameForSameTable = 'user.repository.ts';
+const controllerFileNameForSameTable = 'user-user.controller.ts';
+
 // speed up tests by avoiding reading docs
 const options = {
   sourceModelPrimaryKey: 'id',
@@ -316,6 +322,76 @@ describe('lb4 relation HasManyThrough', /** @this {Mocha.Suite} */ function () {
           expectFileToMatchSnapshot(sourceFilePath);
         },
       );
+    }
+  });
+
+  context('generates model relation with same table', () => {
+    const promptArray = [
+      {
+        relationType: 'hasManyThrough',
+        sourceModel: 'User',
+        destinationModel: 'User',
+        throughModel: 'Friend',
+      },
+    ];
+
+    promptArray.forEach(function (multiItemPrompt, i) {
+      describe('answers ' + JSON.stringify(multiItemPrompt), () => {
+        suite(multiItemPrompt, i);
+      });
+    });
+
+    function suite(multiItemPrompt, i) {
+      before(async function runGeneratorWithAnswers() {
+        await sandbox.reset();
+        await testUtils
+          .executeGenerator(generator)
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withPrompts(multiItemPrompt);
+      });
+
+      it('has correct imports and relation name users', async () => {
+        const sourceFilePath = path.join(
+          sandbox.path,
+          MODEL_APP_PATH,
+          sourceFileNameForSameTable,
+        );
+        const sourceRepoFilePath = path.join(
+          sandbox.path,
+          REPOSITORY_APP_PATH,
+          repositoryFileNameForSameTable,
+        );
+
+        assert.file(sourceFilePath);
+        assert.file(sourceRepoFilePath);
+        expectFileToMatchSnapshot(sourceFilePath);
+        expectFileToMatchSnapshot(sourceRepoFilePath);
+      });
+
+      it('has correct default foreign keys', async () => {
+        const throughFilePath = path.join(
+          sandbox.path,
+          MODEL_APP_PATH,
+          throughFileNameForSameTable,
+        );
+
+        assert.file(throughFilePath);
+        expectFileToMatchSnapshot(throughFilePath);
+      });
+
+      it('controller file has been created with hasManyThrough relation with same table', async () => {
+        const filePath = path.join(
+          sandbox.path,
+          CONTROLLER_PATH,
+          controllerFileNameForSameTable,
+        );
+        assert.file(filePath);
+        expectFileToMatchSnapshot(filePath);
+      });
     }
   });
 });


### PR DESCRIPTION
Running `lb4 relation` for hasManyThrough relation having same source & target models results in buggy controller code. (duplicate import of models due to source & target being identical). This PR fixes that.
## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
