### PR TITLE
feat: support non-primary reference keys of source and target model for hasManyThrough relation

### DIFF
--- a/docs/site/HasManyThrough-relation.md
+++ b/docs/site/HasManyThrough-relation.md
@@ -172,6 +172,18 @@ model definition's relation metadata.
       <td><code>Patient.pid</code></td>
     </tr>
     <tr>
+      <td><code>customReferenceKeyFrom</code></td>
+      <td>the non-primary key of the source model</td>
+      <td>the non-primary property of the source model</td>
+      <td><code>User.email</code></td>
+    </tr>
+    <tr>
+      <td><code>customReferenceKeyTo</code></td>
+      <td>the non-primary key of the target model</td>
+      <td>the non-primary property of the target model</td>
+      <td><code>User.email</code></td>
+    </tr>
+    <tr>
       <td><code>through.model</code></td>
       <td>the name of the through model</td>
       <td>N/A. The through model name is needed for defining a hasManyThrough relation.</td>
@@ -192,11 +204,32 @@ model definition's relation metadata.
   </tbody>
 </table>
 
-The two foreign keys on through model can only reference the primary keys of
-source and target models. Customization of `keyFrom` and `keyTo` is not
-supported yet. However, custom foreign keys on through model is possible. A
-usage of the decorator with custom foreign keys name for the above example is as
+The two foreign keys on through model can reference the primary keys of source
+and target models. They can also reference non-primary keys with the help of
+`customReferenceKeyFrom` and `customReferenceKeyTo` keys.
+
+A usage of the decorator with custom reference keys for the above example is as
 follows:
+
+{% include code-caption.html content="/src/models/user.model.ts" %}
+
+```ts
+// import statements
+class User extends Entity {
+  // constructor, properties, etc.
+  @hasMany(() => User, {
+    customReferenceKeyFrom: 'email',
+    customReferenceKeyTo: 'email',
+    through: {
+      model: () => Friend1,
+    },
+  })
+  users: User[];
+}
+```
+
+Custom foreign keys on through model is possible. A usage of the decorator with
+custom foreign keys name for the above example is as follows:
 
 {% include code-caption.html content="/src/models/doctor.model.ts" %}
 

--- a/docs/site/Relation-generator.md
+++ b/docs/site/Relation-generator.md
@@ -47,6 +47,12 @@ lb4 relation [options]
   through model. For HasManyThrough relation only.
 - `--targetKeyOnThrough`: Foreign key that references the target model on the
   through model. For HasManyThrough relation only.
+- `--customReferenceKeys`: Confrimation if there is any custom reference key to
+  source or target model. For HasManyThrough relation only.
+- `--customSourceModelKey`: Custom key referencing in the source model. For
+  HasManyThrough relation only.
+- `--customTargetModelKey`: Custom key referencing in the target model. For
+  HasManyThrough relation only.
 - `-c`, `--config`: JSON file name or value to configure options.
 - `-y`, `--yes`: Skip all confirmation prompts with default or provided value.
 - `--format`: Format generated code using `npm run lint:fix`.
@@ -114,6 +120,8 @@ lb4 relation --sourceModel=<sourceModel>
 [--destinationModelPrimaryKey=<destinationModelPrimaryKey>]
 [--destinationModelPrimaryKeyType=<destinationModelPrimaryKeyType>]
 [--sourceKeyOnThrough=<sourceKeyOnThrough>] [--targetKeyOnThrough<targetKeyOnThrough>]
+[--customReferenceKeys=<customReferenceKeys>]
+[--customSourceModelKey=<customSourceModelKey>] [--customTargetModelKey<customTargetModelKey>]
 [--format]
 ```
 
@@ -125,6 +133,15 @@ lb4 relation --sourceModel=<sourceModel>
 
 - `<targetKeyOnThrough>` - Property on the through model that references the
   primary key property of the target model.
+
+- `<customReferenceKeys>` - Confirm if there is any custom reference key to
+  source or target model.
+
+- `<customSourceModelKey>` - Property to that references the key in the source
+  model
+
+- `<customTargetModelKey>` - Property to that references the key in the target
+  model
 
 ### Interactive Prompts
 
@@ -164,6 +181,19 @@ The tool will prompt you for:
   references the target model to define on the through model. For HasManyThrough
   relation only. Default value: `<targetModel>` + `Id` in camelCase, e.g
   `patientId`.
+
+- Confirmation for any custom reference key(s) (`customReferenceKeys`). Prompts
+  to confirm if there is any custom reference keys to be defined referenceing
+  source or target model. For HasManyThrough relation only. The default value is
+  false
+
+- Name of custom reference key in source model (`customSourceModelKey`). Prompts
+  a property name that references non-primary key in source model. Only prompts
+  if `customReferenceKeys` is true.For HasManyThrough relation only.
+
+- Name of custom reference key in target model (`customTargetModelKey`). Prompts
+  a property name that references non-primary key in target model. Only prompts
+  if `customReferenceKeys` is true.For HasManyThrough relation only.
 
 - Name of the relation (`relationName`). Prompts for the Source property name.
   Note: Leave blank to use the default. Default values:

--- a/packages/cli/.yo-rc.json
+++ b/packages/cli/.yo-rc.json
@@ -1366,11 +1366,32 @@
           "name": "sourceModel",
           "hide": false
         },
-        "destinationModel": {
+        "customReferenceKeys": {
           "type": "String",
           "required": false,
-          "description": "Destination model",
-          "name": "destinationModel",
+          "description": "Any Custom Reference Kyes",
+          "name": "customReferenceKeys",
+          "hide": false
+        },
+        "customSourceModelKey": {
+          "type": "String",
+          "required": false,
+          "description": "Custom Source model key",
+          "name": "customSourceModelKey",
+          "hide": false
+        },
+        "customTargetModelKey": {
+          "type": "String",
+          "required": false,
+          "description": "Custom Destination model",
+          "name": "customTargetModelKey",
+          "hide": false
+        },
+        "destinationModelKey": {
+          "type": "String",
+          "required": false,
+          "description": "Destination model key",
+          "name": "destinationModelKey",
           "hide": false
         },
         "throughModel": {

--- a/packages/cli/generators/relation/has-many-through-relation.generator.js
+++ b/packages/cli/generators/relation/has-many-through-relation.generator.js
@@ -101,12 +101,16 @@ module.exports = class HasManyThroughRelationGenerator extends (
     const relationType = 'hasMany';
     const relationName = options.relationName;
     const sourceKey = options.sourceKeyOnThrough;
+    const customSourceModelKey = options.customSourceModelKey;
+    const customTargetModelKey = options.customTargetModelKey;
     const targetKey = options.targetKeyOnThrough;
     const dftSourceKey = options.defaultSourceKeyOnThrough;
     const dftTargetKey = options.defaultTargetKeyOnThrough;
-    const sourceKeyType = options.sourceModelPrimaryKeyType;
-    const targetKeyType = options.destinationModelPrimaryKeyType;
-
+    const sourceKeyType =
+      options.customSourceModelKeyType || options.sourceModelPrimaryKeyType;
+    const targetKeyType =
+      options.customTargetModelKeyType ||
+      options.destinationModelPrimaryKeyType;
     // checks if both target and source key exist in through model
     const project = new relationUtils.AstLoopBackProject();
     const throughFile = relationUtils.addFileToProject(
@@ -145,6 +149,8 @@ module.exports = class HasManyThroughRelationGenerator extends (
       sourceKey,
       isDefaultTargetKey,
       targetKey,
+      customSourceModelKey,
+      customTargetModelKey,
     );
     relationUtils.addProperty(sourceClass, modelProperty);
     let imports;
@@ -200,21 +206,31 @@ module.exports = class HasManyThroughRelationGenerator extends (
     sourceKey,
     isDefaultTargetKey,
     targetKey,
+    customSourceModelKey,
+    customTargetModelKey,
   ) {
     let keyFrom = '';
     let keyTo = '';
+    let customReferenceKeyFrom = '';
+    let customReferenceKeyTo = '';
     if (!isDefaultSourceKey) {
       keyFrom = `, keyFrom: '${sourceKey}'`;
     }
     if (!isDefaultTargetKey) {
       keyTo = `, keyTo: '${targetKey}'`;
     }
+    if (customSourceModelKey) {
+      customReferenceKeyFrom = `customReferenceKeyFrom: '${customSourceModelKey}', `;
+    }
+    if (customTargetModelKey) {
+      customReferenceKeyTo = `customReferenceKeyTo: '${customTargetModelKey}', `;
+    }
 
     const relationDecorator = [
       {
         name: 'hasMany',
         arguments: [
-          `() => ${targetClass}, {through: {model: () => ${throughModel}${keyFrom}${keyTo}}}`,
+          `() => ${targetClass}, {${customReferenceKeyFrom}${customReferenceKeyTo}through: {model: () => ${throughModel}${keyFrom}${keyTo}}}`,
         ],
       },
     ];

--- a/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
@@ -1412,11 +1412,32 @@ exports[`cli saves command metadata to .yo-rc.json 1`] = `
           "name": "sourceModel",
           "hide": false
         },
-        "destinationModel": {
+        "customReferenceKeys": {
           "type": "String",
           "required": false,
-          "description": "Destination model",
-          "name": "destinationModel",
+          "description": "Any Custom Reference Kyes",
+          "name": "customReferenceKeys",
+          "hide": false
+        },
+        "customSourceModelKey": {
+          "type": "String",
+          "required": false,
+          "description": "Custom Source model key",
+          "name": "customSourceModelKey",
+          "hide": false
+        },
+        "customTargetModelKey": {
+          "type": "String",
+          "required": false,
+          "description": "Custom Destination model",
+          "name": "customTargetModelKey",
+          "hide": false
+        },
+        "destinationModelKey": {
+          "type": "String",
+          "required": false,
+          "description": "Destination model key",
+          "name": "destinationModelKey",
           "hide": false
         },
         "throughModel": {

--- a/packages/cli/snapshots/integration/generators/relation.has-many-through.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/relation.has-many-through.integration.snapshots.js
@@ -552,6 +552,178 @@ export class Appointment extends Entity {
 `;
 
 
+exports[`lb4 relation HasManyThrough generates model relation with custom reference keys answers {"relationType":"hasManyThrough","sourceModel":"User","destinationModel":"User","throughModel":"Friend1","customReferenceKeys":true,"customSourceModelKey":"email","customTargetModelKey":"email"} has correct default foreign keys 1`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Friend1 extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  userId?: string;
+
+  @property({
+    type: 'string',
+  })
+  friendId?: string;
+
+  constructor(data?: Partial<Friend1>) {
+    super(data);
+  }
+}
+
+`;
+
+
+exports[`lb4 relation HasManyThrough generates model relation with custom reference keys answers {"relationType":"hasManyThrough","sourceModel":"User","destinationModel":"User","throughModel":"Friend1","customReferenceKeys":true,"customSourceModelKey":"email","customTargetModelKey":"email"} has correct imports and relation name users 1`] = `
+import {Entity, model, property, hasMany} from '@loopback/repository';
+import {Friend1} from './friend1.model';
+
+@model()
+export class User extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  email?: string;
+
+  @hasMany(() => User, {customReferenceKeyFrom: 'email', customReferenceKeyTo: 'email', through: {model: () => Friend1}})
+  users: User[];
+
+  constructor(data?: Partial<User>) {
+    super(data);
+  }
+}
+
+`;
+
+
+exports[`lb4 relation HasManyThrough generates model relation with custom reference keys answers {"relationType":"hasManyThrough","sourceModel":"User","destinationModel":"User","throughModel":"Friend1","customReferenceKeys":true,"customSourceModelKey":"email","customTargetModelKey":"email"} has correct imports and relation name users 2`] = `
+import {inject, Getter} from '@loopback/core';
+import {DefaultCrudRepository, repository, HasManyThroughRepositoryFactory} from '@loopback/repository';
+import {DbDataSource} from '../datasources';
+import {User, Friend1} from '../models';
+import {Friend1Repository} from './friend1.repository';
+
+export class UserRepository extends DefaultCrudRepository<
+  User,
+  typeof User.prototype.id
+> {
+
+  public readonly users: HasManyThroughRepositoryFactory<User, typeof User.prototype.id,
+          Friend1,
+          typeof User.prototype.id
+        >;
+
+  constructor(@inject('datasources.db') dataSource: DbDataSource, @repository.getter('Friend1Repository') protected friend1RepositoryGetter: Getter<Friend1Repository>, @repository.getter('UserRepository') protected userRepositoryGetter: Getter<UserRepository>,) {
+    super(User, dataSource);
+    this.users = this.createHasManyThroughRepositoryFactoryFor('users', userRepositoryGetter, friend1RepositoryGetter,);
+    this.registerInclusionResolver('users', this.users.inclusionResolver);
+  }
+}
+
+`;
+
+
+exports[`lb4 relation HasManyThrough generates model relation with custom reference keys with --config has correct default foreign keys 1`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Friend1 extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  userId?: string;
+
+  @property({
+    type: 'string',
+  })
+  friendId?: string;
+
+  constructor(data?: Partial<Friend1>) {
+    super(data);
+  }
+}
+
+`;
+
+
+exports[`lb4 relation HasManyThrough generates model relation with custom reference keys with --config has correct imports and relation name users 1`] = `
+import {Entity, model, property, hasMany} from '@loopback/repository';
+import {Friend1} from './friend1.model';
+
+@model()
+export class User extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  email?: string;
+
+  @hasMany(() => User, {customReferenceKeyFrom: 'email', customReferenceKeyTo: 'email', through: {model: () => Friend1}})
+  users: User[];
+
+  constructor(data?: Partial<User>) {
+    super(data);
+  }
+}
+
+`;
+
+
+exports[`lb4 relation HasManyThrough generates model relation with custom reference keys with --config has correct imports and relation name users 2`] = `
+import {inject, Getter} from '@loopback/core';
+import {DefaultCrudRepository, repository, HasManyThroughRepositoryFactory} from '@loopback/repository';
+import {DbDataSource} from '../datasources';
+import {User, Friend1} from '../models';
+import {Friend1Repository} from './friend1.repository';
+
+export class UserRepository extends DefaultCrudRepository<
+  User,
+  typeof User.prototype.id
+> {
+
+  public readonly users: HasManyThroughRepositoryFactory<User, typeof User.prototype.id,
+          Friend1,
+          typeof User.prototype.id
+        >;
+
+  constructor(@inject('datasources.db') dataSource: DbDataSource, @repository.getter('Friend1Repository') protected friend1RepositoryGetter: Getter<Friend1Repository>, @repository.getter('UserRepository') protected userRepositoryGetter: Getter<UserRepository>,) {
+    super(User, dataSource);
+    this.users = this.createHasManyThroughRepositoryFactoryFor('users', userRepositoryGetter, friend1RepositoryGetter,);
+    this.registerInclusionResolver('users', this.users.inclusionResolver);
+  }
+}
+
+`;
+
+
 exports[`lb4 relation HasManyThrough generates model relation with custom relation name answers {"relationType":"hasManyThrough","sourceModel":"Doctor","destinationModel":"Patient","throughModel":"Appointment","relationName":"myPatients"} relation name should be myPatients 1`] = `
 import {Entity, model, property, hasMany} from '@loopback/repository';
 import {Patient} from './patient.model';
@@ -697,206 +869,6 @@ export class DoctorRepository extends DefaultCrudRepository<
     super(Doctor, dataSource);
     this.patients = this.createHasManyThroughRepositoryFactoryFor('patients', patientRepositoryGetter, appointmentRepositoryGetter,);
     this.registerInclusionResolver('patients', this.patients.inclusionResolver);
-  }
-}
-
-`;
-
-
-exports[`lb4 relation HasManyThrough generates model relation with same table answers {"relationType":"hasManyThrough","sourceModel":"User","destinationModel":"User","throughModel":"Friend"} controller file has been created with hasManyThrough relation with same table 1`] = `
-import {
-  Count,
-  CountSchema,
-  Filter,
-  repository,
-  Where,
-} from '@loopback/repository';
-  import {
-  del,
-  get,
-  getModelSchemaRef,
-  getWhereSchemaFor,
-  param,
-  patch,
-  post,
-  requestBody,
-} from '@loopback/rest';
-import {
-Friend,
-User,
-} from '../models';
-import {UserRepository} from '../repositories';
-
-export class UserUserController {
-  constructor(
-    @repository(UserRepository) protected userRepository: UserRepository,
-  ) { }
-
-  @get('/users/{id}/users', {
-    responses: {
-      '200': {
-        description: 'Array of User has many User through Friend',
-        content: {
-          'application/json': {
-            schema: {type: 'array', items: getModelSchemaRef(User)},
-          },
-        },
-      },
-    },
-  })
-  async find(
-    @param.path.number('id') id: number,
-    @param.query.object('filter') filter?: Filter<User>,
-  ): Promise<User[]> {
-    return this.userRepository.users(id).find(filter);
-  }
-
-  @post('/users/{id}/users', {
-    responses: {
-      '200': {
-        description: 'create a User model instance',
-        content: {'application/json': {schema: getModelSchemaRef(User)}},
-      },
-    },
-  })
-  async create(
-    @param.path.number('id') id: typeof User.prototype.id,
-    @requestBody({
-      content: {
-        'application/json': {
-          schema: getModelSchemaRef(User, {
-            title: 'NewUserInUser',
-            exclude: ['id'],
-          }),
-        },
-      },
-    }) user: Omit<User, 'id'>,
-  ): Promise<User> {
-    return this.userRepository.users(id).create(user);
-  }
-
-  @patch('/users/{id}/users', {
-    responses: {
-      '200': {
-        description: 'User.User PATCH success count',
-        content: {'application/json': {schema: CountSchema}},
-      },
-    },
-  })
-  async patch(
-    @param.path.number('id') id: number,
-    @requestBody({
-      content: {
-        'application/json': {
-          schema: getModelSchemaRef(User, {partial: true}),
-        },
-      },
-    })
-    user: Partial<User>,
-    @param.query.object('where', getWhereSchemaFor(User)) where?: Where<User>,
-  ): Promise<Count> {
-    return this.userRepository.users(id).patch(user, where);
-  }
-
-  @del('/users/{id}/users', {
-    responses: {
-      '200': {
-        description: 'User.User DELETE success count',
-        content: {'application/json': {schema: CountSchema}},
-      },
-    },
-  })
-  async delete(
-    @param.path.number('id') id: number,
-    @param.query.object('where', getWhereSchemaFor(User)) where?: Where<User>,
-  ): Promise<Count> {
-    return this.userRepository.users(id).delete(where);
-  }
-}
-
-`;
-
-
-exports[`lb4 relation HasManyThrough generates model relation with same table answers {"relationType":"hasManyThrough","sourceModel":"User","destinationModel":"User","throughModel":"Friend"} has correct default foreign keys 1`] = `
-import {Entity, model, property} from '@loopback/repository';
-
-@model()
-export class Friend extends Entity {
-  @property({
-    type: 'number',
-    id: true,
-    default: 0,
-  })
-  id?: number;
-
-  @property({
-    type: 'number',
-  })
-  userId?: number;
-
-  @property({
-    type: 'number',
-  })
-  friendId?: number;
-
-  constructor(data?: Partial<Friend>) {
-    super(data);
-  }
-}
-
-`;
-
-
-exports[`lb4 relation HasManyThrough generates model relation with same table answers {"relationType":"hasManyThrough","sourceModel":"User","destinationModel":"User","throughModel":"Friend"} has correct imports and relation name users 1`] = `
-import {Entity, model, property, hasMany} from '@loopback/repository';
-import {Friend} from './friend.model';
-
-@model()
-export class User extends Entity {
-  @property({
-    type: 'number',
-    id: true,
-    default: 0,
-  })
-  id?: number;
-
-  @property({
-    type: 'string',
-  })
-  email?: string;
-
-  @hasMany(() => User, {through: {model: () => Friend}})
-  users: User[];
-
-  constructor(data?: Partial<User>) {
-    super(data);
-  }
-}
-
-`;
-
-
-exports[`lb4 relation HasManyThrough generates model relation with same table answers {"relationType":"hasManyThrough","sourceModel":"User","destinationModel":"User","throughModel":"Friend"} has correct imports and relation name users 2`] = `
-import {inject, Getter} from '@loopback/core';
-import {DefaultCrudRepository, repository, HasManyThroughRepositoryFactory} from '@loopback/repository';
-import {DbDataSource} from '../datasources';
-import {User, Friend} from '../models';
-import {FriendRepository} from './friend.repository';
-
-export class UserRepository extends DefaultCrudRepository<
-  User,
-  typeof User.prototype.id
-> {
-
-  public readonly users: HasManyThroughRepositoryFactory<User, typeof User.prototype.id,
-          Friend,
-          typeof User.prototype.id
-        >;
-
-  constructor(@inject('datasources.db') dataSource: DbDataSource, @repository.getter('FriendRepository') protected friendRepositoryGetter: Getter<FriendRepository>, @repository.getter('UserRepository') protected userRepositoryGetter: Getter<UserRepository>,) {
-    super(User, dataSource);
-    this.users = this.createHasManyThroughRepositoryFactoryFor('users', userRepositoryGetter, friendRepositoryGetter,);
-    this.registerInclusionResolver('users', this.users.inclusionResolver);
   }
 }
 

--- a/packages/cli/snapshots/integration/generators/relation.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/relation.integration.snapshots.js
@@ -350,9 +350,3 @@ export class CustomerInheritanceOrderInheritanceController {
 }
 
 `;
-
-
-exports[`lb4 relation add controller to existing index file only once check if the controller exported to index file only once 1`] = `
-export * from './order-customer.controller';
-
-`;

--- a/packages/cli/snapshots/integration/generators/relation.references-many.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/relation.references-many.integration.snapshots.js
@@ -139,3 +139,9 @@ export class Customer extends Entity {
 }
 
 `;
+
+
+exports[`lb4 relation rejects relation when models does not exist 1`] = `
+export * from './order-customer.controller';
+
+`;

--- a/packages/cli/test/fixtures/relation/index.js
+++ b/packages/cli/test/fixtures/relation/index.js
@@ -182,6 +182,16 @@ const SourceEntries = {
     file: 'friend.repository.ts',
     content: readSourceFile('./repositories/friend.repository.ts'),
   },
+  Friend1Model: {
+    path: MODEL_APP_PATH,
+    file: 'friend1.model.ts',
+    content: readSourceFile('./models/friend1.model.ts'),
+  },
+  Friend1Repository: {
+    path: REPOSITORY_APP_PATH,
+    file: 'friend1.repository.ts',
+    content: readSourceFile('./repositories/friend1.repository.ts'),
+  },
 };
 exports.SourceEntries = SourceEntries;
 
@@ -250,6 +260,8 @@ exports.SANDBOX_FILES = [
   SourceEntries.FriendModel,
   SourceEntries.UserRepository,
   SourceEntries.FriendRepository,
+  SourceEntries.Friend1Model,
+  SourceEntries.Friend1Repository,
 ];
 
 exports.SANDBOX_FILES2 = [

--- a/packages/cli/test/fixtures/relation/models/friend1.model.ts
+++ b/packages/cli/test/fixtures/relation/models/friend1.model.ts
@@ -1,0 +1,25 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Friend1 extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  userId?: string;
+
+  @property({
+    type: 'string',
+  })
+  friendId?: string;
+
+  constructor(data?: Partial<Friend1>) {
+    super(data);
+  }
+}

--- a/packages/cli/test/fixtures/relation/repositories/friend1.repository.ts
+++ b/packages/cli/test/fixtures/relation/repositories/friend1.repository.ts
@@ -1,0 +1,13 @@
+import {inject} from '@loopback/core';
+import {DefaultCrudRepository} from '@loopback/repository';
+import {DbDataSource} from '../datasources';
+import {Friend1} from '../models';
+
+export class Friend1Repository extends DefaultCrudRepository<
+  Friend1,
+  typeof Friend1.prototype.id
+> {
+  constructor(@inject('datasources.db') dataSource: DbDataSource) {
+    super(Friend1, dataSource);
+  }
+}

--- a/packages/repository/src/relations/relation.types.ts
+++ b/packages/repository/src/relations/relation.types.ts
@@ -75,6 +75,13 @@ export interface HasManyDefinition extends RelationDefinitionBase {
   keyFrom?: string;
 
   /**
+   * customReferenceKeyTo: The custom reference key of target model
+   * customReferenceKeyFrom: The custom reference key of source model
+   */
+  customReferenceKeyTo?: string;
+  customReferenceKeyFrom?: string;
+
+  /**
    * With current architecture design, polymorphic type cannot be supported without through
    * Consider using Source-hasMany->Through->hasOne->Target(polymorphic) for one-to-many relations
    */


### PR DESCRIPTION
This PR will provide support for non-primary key references of source & target models in case of hasManyThrough relation.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
