### PR TITLE
fix: add missing keys from config passed to lb4 relation

### DIFF
--- a/packages/cli/generators/relation/index.js
+++ b/packages/cli/generators/relation/index.js
@@ -612,6 +612,9 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
   }
 
   async _promptKeyFromOnThroughModel() {
+    if (this.options.sourceKeyOnThrough) {
+      this.artifactInfo.sourceKeyOnThrough = this.options.sourceKeyOnThrough;
+    }
     if (this.shouldExit()) return false;
     return this.prompt([
       {
@@ -623,7 +626,7 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
           )} to define on the through model`,
         ),
         default: this.artifactInfo.defaultSourceKeyOnThrough,
-        when: !this.options.sourceKeyOnThrough,
+        when: !this.artifactInfo.sourceKeyOnThrough,
         validate: utils.validateKeyName,
       },
     ]).then(props => {
@@ -635,6 +638,9 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
 
   async _promptKeyToOnThroughModel() {
     if (this.shouldExit()) return false;
+    if (this.options.targetKeyOnThrough) {
+      this.artifactInfo.targetKeyOnThrough = this.options.targetKeyOnThrough;
+    }
     return this.prompt([
       {
         type: 'string',
@@ -645,7 +651,7 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
           )} to define on the through model`,
         ),
         default: this.artifactInfo.defaultTargetKeyOnThrough,
-        when: !this.options.targetKeyOnThrough,
+        when: !this.artifactInfo.targetKeyOnThrough,
         validate: input =>
           utils.validateKeyToKeyFrom(
             input,

--- a/packages/cli/snapshots/integration/generators/relation.has-many-through.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/relation.has-many-through.integration.snapshots.js
@@ -487,6 +487,71 @@ export class Appointment extends Entity {
 `;
 
 
+exports[`lb4 relation HasManyThrough generates model relation with custom keyFrom and/or keyTo with --config add custom keyTo and/or keyFrom to the through model 1`] = `
+import {Entity, model, property, hasMany} from '@loopback/repository';
+import {Patient} from './patient.model';
+import {Appointment} from './appointment.model';
+
+@model()
+export class Doctor extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  name?: string;
+
+  @hasMany(() => Patient, {through: {model: () => Appointment, keyFrom: 'customKeyFrom', keyTo: 'customKeyTo'}})
+  patients: Patient[];
+
+  constructor(data?: Partial<Doctor>) {
+    super(data);
+  }
+}
+
+`;
+
+
+exports[`lb4 relation HasManyThrough generates model relation with custom keyFrom and/or keyTo with --config add custom keyTo and/or keyFrom to the through model 2`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Appointment extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  des?: string;
+
+  @property({
+    type: 'number',
+  })
+  customKeyFrom?: number;
+
+  @property({
+    type: 'number',
+  })
+  customKeyTo?: number;
+
+  constructor(data?: Partial<Appointment>) {
+    super(data);
+  }
+}
+
+`;
+
+
 exports[`lb4 relation HasManyThrough generates model relation with custom relation name answers {"relationType":"hasManyThrough","sourceModel":"Doctor","destinationModel":"Patient","throughModel":"Appointment","relationName":"myPatients"} relation name should be myPatients 1`] = `
 import {Entity, model, property, hasMany} from '@loopback/repository';
 import {Patient} from './patient.model';

--- a/packages/cli/test/integration/generators/relation.has-many-through.integration.js
+++ b/packages/cli/test/integration/generators/relation.has-many-through.integration.js
@@ -213,6 +213,44 @@ describe('lb4 relation HasManyThrough', /** @this {Mocha.Suite} */ function () {
     }
   });
 
+  context(
+    'generates model relation with custom keyFrom and/or keyTo with --config',
+    () => {
+      before(async function runGeneratorWithAnswers() {
+        await sandbox.reset();
+        await testUtils
+          .executeGenerator(generator)
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments([
+            '--config',
+            '{"sourceModel": "Doctor", "destinationModel": "Patient", "throughModel": "Appointment", "relationType": "hasManyThrough", "sourceKeyOnThrough": "customKeyFrom", "targetKeyOnThrough": "customKeyTo"}',
+          ]);
+      });
+
+      it('add custom keyTo and/or keyFrom to the through model', async () => {
+        const sourceFilePath = path.join(
+          sandbox.path,
+          MODEL_APP_PATH,
+          sourceFileName,
+        );
+
+        const throughFilePath = path.join(
+          sandbox.path,
+          MODEL_APP_PATH,
+          throughFileName,
+        );
+        assert.file(sourceFilePath);
+        assert.file(throughFilePath);
+        expectFileToMatchSnapshot(sourceFilePath);
+        expectFileToMatchSnapshot(throughFilePath);
+      });
+    },
+  );
+
   context('checks if the controller file is created ', () => {
     const promptArray = [
       {


### PR DESCRIPTION
`lb4 relation` with --config fails to recognize `sourceKeyOnThrough` & `targetKeyOnThrough`. This PR fixes that.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
