### PR TITLE
fix: enable controller update in case of multiple belongsTo relation

### DIFF
--- a/packages/cli/snapshots/integration/generators/relation.belongs-to.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/relation.belongs-to.integration.snapshots.js
@@ -238,6 +238,92 @@ export * from './order-customer.controller';
 `;
 
 
+exports[`lb4 relation checks if the controller file created for multiple relations answers {"relationType":"belongsTo","sourceModel":"Task","destinationModel":"Employee","relationName":"assignedTo"} checks controller content with belongsTo relation for multiple relations 1`] = `
+import {
+  repository,
+} from '@loopback/repository';
+import {
+  param,
+  get,
+  getModelSchemaRef,
+} from '@loopback/rest';
+import {
+  Task,
+  Employee,
+} from '../models';
+import {TaskRepository} from '../repositories';
+
+export class TaskEmployeeController {
+  constructor(
+    @repository(TaskRepository)
+    public taskRepository: TaskRepository,
+  ) { }
+
+  @get('/tasks/{id}/employee', {
+    responses: {
+      '200': {
+        description: 'Employee belonging to Task',
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(Employee),
+          },
+        },
+      },
+    },
+  })
+  async getEmployee(
+    @param.path.number('id') id: typeof Task.prototype.id,
+  ): Promise<Employee> {
+    return this.taskRepository.assignedTo(id);
+  }
+}
+
+`;
+
+
+exports[`lb4 relation checks if the controller file created for multiple relations answers {"relationType":"belongsTo","sourceModel":"Task","destinationModel":"Employee","relationName":"createdBy"} checks controller content with belongsTo relation for multiple relations 1`] = `
+import {
+  repository,
+} from '@loopback/repository';
+import {
+  param,
+  get,
+  getModelSchemaRef,
+} from '@loopback/rest';
+import {
+  Task,
+  Employee,
+} from '../models';
+import {TaskRepository} from '../repositories';
+
+export class TaskEmployeeController {
+  constructor(
+    @repository(TaskRepository)
+    public taskRepository: TaskRepository,
+  ) { }
+
+  @get('/tasks/{id}/employee', {
+    responses: {
+      '200': {
+        description: 'Employee belonging to Task',
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(Employee),
+          },
+        },
+      },
+    },
+  })
+  async getEmployee(
+    @param.path.number('id') id: typeof Task.prototype.id,
+  ): Promise<Employee> {
+    return this.taskRepository.createdBy(id);
+  }
+}
+
+`;
+
+
 exports[`lb4 relation checks if the controller file created for same table relation answers {"relationType":"belongsTo","sourceModel":"Employee","destinationModel":"Employee"} checks controller content with belongsTo relation with same table 1`] = `
 export class EmployeeController {}
 

--- a/packages/cli/test/fixtures/relation/controllers/task-employee.controller.ts
+++ b/packages/cli/test/fixtures/relation/controllers/task-employee.controller.ts
@@ -1,0 +1,1 @@
+export class TaskEmployeeController {}

--- a/packages/cli/test/fixtures/relation/index.js
+++ b/packages/cli/test/fixtures/relation/index.js
@@ -234,6 +234,7 @@ exports.SANDBOX_FILES = [
   SourceEntries.PatientRepository,
   SourceEntries.AppointmentRepository,
   SourceEntries.EmployeeRepository,
+  SourceEntries.TaskRepository,
 
   SourceEntries.AccountModel,
   SourceEntries.CustomerModel,

--- a/packages/cli/test/fixtures/relation/models/task.model.ts
+++ b/packages/cli/test/fixtures/relation/models/task.model.ts
@@ -1,0 +1,20 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Task extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  title?: string;
+
+  constructor(data?: Partial<Task>) {
+    super(data);
+  }
+}

--- a/packages/cli/test/fixtures/relation/repositories/task.repository.ts
+++ b/packages/cli/test/fixtures/relation/repositories/task.repository.ts
@@ -1,0 +1,17 @@
+import {inject} from '@loopback/core';
+import {BelongsToAccessor, DefaultCrudRepository} from '@loopback/repository';
+import {DbDataSource} from '../datasources';
+import {Customer, Task} from '../models';
+
+export class TaskRepository extends DefaultCrudRepository<
+  Task,
+  typeof Task.prototype.id
+> {
+  public readonly myCustomer: BelongsToAccessor<
+    Customer,
+    typeof Task.prototype.id
+  >;
+  constructor(@inject('datasources.db') dataSource: DbDataSource) {
+    super(Task, dataSource);
+  }
+}

--- a/packages/cli/test/integration/generators/relation.belongs-to.integration.js
+++ b/packages/cli/test/integration/generators/relation.belongs-to.integration.js
@@ -23,6 +23,7 @@ const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 const sourceFileName = 'order.model.ts';
 const controllerFileName = 'order-customer.controller.ts';
 const controllerFileNameForSameTableRelation = 'employee.controller.ts';
+const controllerFileNameForMultipleRelations = 'task-employee.controller.ts';
 const repositoryFileName = 'order.repository.ts';
 const repositoryFileNameForSameTableRelation = 'employee.repository.ts';
 // speed up tests by avoiding reading docs
@@ -495,6 +496,54 @@ describe('lb4 relation', /** @this {Mocha.Suite} */ function () {
         assert.file(sourceFilePath);
         expectFileToMatchSnapshot(sourceFilePath);
       });
+    },
+  );
+
+  context(
+    'checks if the controller file created for multiple relations',
+    () => {
+      const promptArray = [
+        {
+          relationType: 'belongsTo',
+          sourceModel: 'Task',
+          destinationModel: 'Employee',
+          relationName: 'createdBy',
+        },
+        {
+          relationType: 'belongsTo',
+          sourceModel: 'Task',
+          destinationModel: 'Employee',
+          relationName: 'assignedTo',
+        },
+      ];
+      promptArray.forEach(function (multiItemPrompt) {
+        describe('answers ' + JSON.stringify(multiItemPrompt), () => {
+          suite(multiItemPrompt);
+        });
+      });
+      function suite(multiItemPrompt) {
+        before(async function runGeneratorWithAnswers() {
+          await sandbox.reset();
+          await testUtils
+            .executeGenerator(generator)
+            .inDir(sandbox.path, () =>
+              testUtils.givenLBProject(sandbox.path, {
+                additionalFiles: SANDBOX_FILES,
+              }),
+            )
+            .withOptions(options)
+            .withPrompts(multiItemPrompt);
+        });
+        it('checks controller content with belongsTo relation for multiple relations', async () => {
+          const filePath = path.join(
+            sandbox.path,
+            CONTROLLER_PATH,
+            controllerFileNameForMultipleRelations,
+          );
+          assert.file(filePath);
+          expectFileToMatchSnapshot(filePath);
+        });
+      }
     },
   );
 });


### PR DESCRIPTION
While trying to create more than one belongsTo relation, cli asks to _replace_ the controller file (as it creates the new file and considers a conflict).

The model and repository files are updated just fine. The only issue that happens is with the controller file.

I am sharing a Dockerfile that can be used to reproduce this issue.

```
FROM node:lts-slim

RUN apt update

RUN npm update -g npm && npm i -g @loopback/cli@6.2.3

USER node
RUN mkdir -p /home/node/app
WORKDIR /home/node/app
RUN npm update && lb4 app --config '{ "name": "reproduce", "outdir": ".", "mocha": "true", "repositories":"true"}' --yes && npm run build
ENV HOST=0.0.0.0 PORT=3000

RUN lb4 datasource -c '{"file": "", "localStorage": "", "name": "memory", "connector": "memory"}' --yes && yarn build
RUN lb4 model -c '{"force": "true","yes":"true","base":"Entity","name":"User","properties":{"name":{"type":"string"},"email":{"type":"string"},"role":{"type":"string"},"id":{"generated":true,"id":true,"type":"number"}}}' --yes
RUN lb4 model -c '{"force": "true","yes":"true","base":"Entity","name":"Order","properties":{"description":{"type":"string"},"total":{"type":"string"},"salesRepId":{"type":"number"},"customerId":{"type":"number"},"id":{"generated":true,"id":true,"type":"number"}}}' --yes

RUN lb4 repository -c '{"name":"User", "datasource":"memory", "model":"User", "repositoryBaseClass":"DefaultCrudRepository"}' --yes
RUN lb4 repository -c '{"name":"Order", "datasource":"memory", "model":"Order", "repositoryBaseClass":"DefaultCrudRepository"}' --yes

RUN lb4 relation -c '{"relationName": "customers", "sourceModel": "Order", "destinationModel": "User", "foreignKeyName": "customerId", "relationType": "belongsTo", "registerInclusionResolver": true}' --yes
RUN lb4 relation -c '{"relationName": "salesRep", "sourceModel": "Order", "destinationModel": "User", "foreignKeyName": "salesRepId", "relationType": "belongsTo", "registerInclusionResolver": true}' --yes

RUN yarn build

EXPOSE ${PORT}
```

After starting the container, it can be noticed that the model and repo files are updated but the controller file has no changes.

This PR adds a check if the controller file already exists and then updates it. And if it doesn't exist, it creates the file.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
