### PR TITLE
fix(sequelize): get table name dynamically

### DIFF
--- a/extensions/sequelize/src/__tests__/fixtures/models/test.model.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/models/test.model.ts
@@ -1,0 +1,22 @@
+import {Entity, model} from '@loopback/repository';
+
+export const eventTableName = 'tbl_event';
+@model({
+  name: eventTableName,
+})
+export class Event extends Entity {
+  // No properties are needed, This model is just used for testing the table names
+
+  constructor(data?: Partial<Event>) {
+    super(data);
+  }
+}
+
+@model()
+export class Box extends Entity {
+  // No properties are needed, This model is just used for testing the table names
+
+  constructor(data?: Partial<Box>) {
+    super(data);
+  }
+}


### PR DESCRIPTION
Now picking up table name from the name parameter in `@model` decorator if specified. Or fallback to lowercase when using postgres dialect to match loopback connector's behaviour.

Fixes [loopback4-sequelize#34](https://github.com/sourcefuse/loopback4-sequelize/issues/34)

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated