### PR TITLE
docs: add `@loopback/sequelize` in official components

### DIFF
--- a/docs/site/Component.md
+++ b/docs/site/Component.md
@@ -197,11 +197,13 @@ These components add additional capabilities to LoopBack.
   Resource pooling service for LoopBack 4
 - [@loopback/typeorm](https://github.com/loopbackio/loopback-next/tree/master/extensions/typeorm) -
   Adds support for TypeORM in LoopBack
+- [@loopback/sequelize](https://github.com/loopbackio/loopback-next/tree/master/extensions/sequelize) -
+  Adds support for Sequelize in LoopBack
 
 ### Community extensions
 
 For a list of components created by community members, refer to
-[Community extensions](./Community-extensions.html).
+[Community extensions](./Community-extensions.md).
 
 ## Creating components
 


### PR DESCRIPTION
Added Sequelize extension in component.md and fixed a broken link.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
