### PR TITLE
docs: add jekyll installation info for doc site preview

### DIFF
--- a/docs/site/DEVELOPING.md
+++ b/docs/site/DEVELOPING.md
@@ -453,6 +453,10 @@ LoopBack 4 content only. This provides the fastest feedback loop possible, at
 the cost of occasional breakage when the script is not updated to accommodate
 changes made in the `loopback.io` repository.
 
+Building the preview site will need Jekyll installed on your system which
+requires a proper Ruby development environment, follow the installation steps
+here for your OS: https://jekyllrb.com/docs/installation/#guides.
+
 As the initial setup, run the following command once, before you start making
 documentation changes:
 


### PR DESCRIPTION
I had a hard time recently setting up preview of the doc site on my local system as I didn't know if `docs:prepare` command will not get me the jekyll installed. And running it will give vague errors for someone like me having the default ruby environment whereas jekyll requires specific set of versions.

So to help future explorers this PR adds the direct link to installation page of jekyll.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
