### PR TITLE
feat: add option to set column naming convention

### DIFF
--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -70,6 +70,14 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
       description: g.f('Boolean to mark id property as optional field'),
       default: false,
     });
+
+    this.option('disableCamelCase', {
+      type: Boolean,
+      description: g.f(
+        'Boolean to disable camel case naming convention for columns',
+      ),
+      default: false,
+    });
   }
 
   _setupGenerator() {
@@ -268,6 +276,7 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
         type: 'list',
         choices: this.namingConvention,
         default: false,
+        when: !this.options.disableCamelCase,
       },
     ]).then(props => {
       /* istanbul ignore next */
@@ -319,7 +328,8 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
         modelInfo.name,
         {
           schema: modelInfo.owner,
-          disableCamelCase: this.artifactInfo.disableCamelCase,
+          disableCamelCase:
+            this.options.disableCamelCase || this.artifactInfo.disableCamelCase,
           associations: this.options.relations,
           ...discoveryOptions,
         },


### PR DESCRIPTION
The cli tool "discover" do not offer an cli option to avoid the prompt for column naming convention. All other prompts can be bypassed via cli options.

Changes in this pull request make it possible using `lb4 discover --disableCamelCase=false` or `lb4 discover --disableCamelCase=true`.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
