### PR TITLE
feat(cli): add option to singularize model names in discover command

### DIFF
--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -70,6 +70,12 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
       description: g.f('Boolean to mark id property as optional field'),
       default: false,
     });
+
+    this.option('singularize', {
+      type: Boolean,
+      description: g.f('Boolean to enable singularizing model names'),
+      default: false,
+    });
   }
 
   _setupGenerator() {
@@ -351,6 +357,18 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
     }
     this.artifactInfo.indexesToBeUpdated =
       this.artifactInfo.indexesToBeUpdated || [];
+
+    if (this.options.singularize) {
+      for (const modelDefinition of this.artifactInfo.modelDefinitions) {
+        modelDefinition.name = utils.pluralize.singular(modelDefinition.name);
+        if (this.options.relations) {
+          for (const relationName in modelDefinition.settings.relations) {
+            const relation = modelDefinition.settings.relations[relationName];
+            relation.model = utils.pluralize.singular(relation.model);
+          }
+        }
+      }
+    }
 
     // eslint-disable-next-line @typescript-eslint/prefer-for-of
     for (let i = 0; i < this.artifactInfo.modelDefinitions.length; i++) {


### PR DESCRIPTION
The discover cli tool produce model from table names. In many cases table names are in plural. The cli package has already a library to singularize these names and model names in singular are more intuitive.

The patch provides another option `lb4 discover --singularize=true` and leaves it up to the user whether the model names should be singularized.

The singularization also works in conjunction with the `--relations` option.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
