### PR TITLE
fix: exclude id properties for patch & put requests

### DIFF
--- a/packages/rest-crud/src/crud-rest.controller.ts
+++ b/packages/rest-crud/src/crud-rest.controller.ts
@@ -14,23 +14,23 @@ import {
   Where,
 } from '@loopback/repository';
 import {
+  JsonSchemaOptions,
+  MediaTypeObject,
+  ParameterObject,
+  ResponsesObject,
+  SchemaObject,
   api,
   del,
   get,
   getFilterSchemaFor,
   getJsonSchema,
   getModelSchemaRef,
-  JsonSchemaOptions,
   jsonToSchemaObject,
-  MediaTypeObject,
   param,
-  ParameterObject,
   patch,
   post,
   put,
   requestBody,
-  ResponsesObject,
-  SchemaObject,
 } from '@loopback/rest';
 import assert from 'assert';
 
@@ -225,7 +225,11 @@ export function defineCrudRestController<
       }),
     })
     async updateAll(
-      @body(modelCtor, {partial: true}) data: Partial<T>,
+      @body(modelCtor, {
+        partial: true,
+        exclude: modelCtor.getIdProperties() as (keyof T)[],
+      })
+      data: Partial<T>,
       @param.where(modelCtor)
       where?: Where<T>,
     ): Promise<Count> {
@@ -244,7 +248,11 @@ export function defineCrudRestController<
     })
     async updateById(
       @param(idPathParam) id: IdType,
-      @body(modelCtor, {partial: true}) data: Partial<T>,
+      @body(modelCtor, {
+        partial: true,
+        exclude: modelCtor.getIdProperties() as (keyof T)[],
+      })
+      data: Partial<T>,
     ): Promise<void> {
       await this.repository.updateById(
         id,
@@ -261,7 +269,10 @@ export function defineCrudRestController<
     })
     async replaceById(
       @param(idPathParam) id: IdType,
-      @body(modelCtor) data: T,
+      @body(modelCtor, {
+        exclude: modelCtor.getIdProperties() as (keyof T)[],
+      })
+      data: T,
     ): Promise<void> {
       await this.repository.replaceById(id, data);
     }


### PR DESCRIPTION
Currently, the id properties are only excluded if there is a post request. For patch & put requests, if a user tries to update id properties, the server throws an internal server error. This PR would exclude the id properties from the patch like in the post.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
