### PR TITLE
fix(sequelize): preserve error context

### DIFF
--- a/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
@@ -124,16 +124,10 @@ export class SequelizeCrudRepository<
   public sequelizeModel: ModelStatic<Model<T>>;
 
   async create(entity: DataObject<T>, options?: AnyObject): Promise<T> {
-    let err = null;
-    const data = await this.sequelizeModel
-      .create(entity as MakeNullishOptional<T>, options)
-      .catch(error => {
-        err = error;
-      });
-
-    if (!data) {
-      throw new Error(err ?? 'Something went wrong');
-    }
+    const data = await this.sequelizeModel.create(
+      entity as MakeNullishOptional<T>,
+      options,
+    );
     return new this.entityClass(this.excludeHiddenProps(data.toJSON())) as T;
   }
 
@@ -216,20 +210,15 @@ export class SequelizeCrudRepository<
     filter?: Filter<T>,
     options?: AnyObject,
   ): Promise<(T & Relations)[]> {
-    const data = await this.sequelizeModel
-      .findAll({
-        include: this.buildSequelizeIncludeFilter(filter?.include),
-        where: this.buildSequelizeWhere(filter?.where),
-        attributes: this.buildSequelizeAttributeFilter(filter?.fields),
-        order: this.buildSequelizeOrder(filter?.order),
-        limit: filter?.limit,
-        offset: filter?.offset ?? filter?.skip,
-        ...options,
-      })
-      .catch(err => {
-        debug('findAll() error:', err);
-        throw new Error(err);
-      });
+    const data = await this.sequelizeModel.findAll({
+      include: this.buildSequelizeIncludeFilter(filter?.include),
+      where: this.buildSequelizeWhere(filter?.where),
+      attributes: this.buildSequelizeAttributeFilter(filter?.fields),
+      order: this.buildSequelizeOrder(filter?.order),
+      limit: filter?.limit,
+      offset: filter?.offset ?? filter?.skip,
+      ...options,
+    });
 
     return this.includeReferencesIfRequested(
       data,
@@ -242,19 +231,14 @@ export class SequelizeCrudRepository<
     filter?: Filter<T>,
     options?: AnyObject,
   ): Promise<(T & Relations) | null> {
-    const data = await this.sequelizeModel
-      .findOne({
-        include: this.buildSequelizeIncludeFilter(filter?.include),
-        where: this.buildSequelizeWhere(filter?.where),
-        attributes: this.buildSequelizeAttributeFilter(filter?.fields),
-        order: this.buildSequelizeOrder(filter?.order),
-        offset: filter?.offset ?? filter?.skip,
-        ...options,
-      })
-      .catch(err => {
-        debug('findOne() error:', err);
-        throw new Error(err);
-      });
+    const data = await this.sequelizeModel.findOne({
+      include: this.buildSequelizeIncludeFilter(filter?.include),
+      where: this.buildSequelizeWhere(filter?.where),
+      attributes: this.buildSequelizeAttributeFilter(filter?.fields),
+      order: this.buildSequelizeOrder(filter?.order),
+      offset: filter?.offset ?? filter?.skip,
+      ...options,
+    });
 
     if (data === null) {
       return Promise.resolve(null);


### PR DESCRIPTION
Removes remapping of thrown errors by Sequelize models.

Fixes #9626

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
