### PR TITLE
fix(sequelize): handle invalid inclusion filter

### DIFF
--- a/extensions/sequelize/src/__tests__/integration/repository.integration.ts
+++ b/extensions/sequelize/src/__tests__/integration/repository.integration.ts
@@ -462,6 +462,20 @@ describe('Sequelize CRUD Repository (integration)', () => {
       // Confirming the fact that it used inner join behind the scenes
       expect(relationRes.body.length).to.be.equal(1);
     });
+
+    it('throws error if the repository does not have registered resolvers', async () => {
+      try {
+        await userRepo.find({
+          include: ['nonExistingRelation'],
+        });
+      } catch (err) {
+        expect(err.message).to.be.eql(
+          `Invalid "filter.include" entries: "nonExistingRelation"`,
+        );
+        expect(err.statusCode).to.be.eql(400);
+        expect(err.code).to.be.eql('INVALID_INCLUSION_FILTER');
+      }
+    });
   });
 
   describe('Connections', () => {


### PR DESCRIPTION
Adds check if the include filter contains invalid value (the one that is not present in the inclusion resolver of that repository).

Fixes #9635

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
