### PR TITLE
fix: check for existing relationImports

### DIFF
--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -383,7 +383,9 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
             Object.assign(templateData.properties[relation.foreignKey], {
               relation,
             });
-            relationImports.push(relation.type);
+            if (!relationImports.includes(relation.type)) {
+              relationImports.push(relation.type);
+            }
             relationDestinationImports.push(relation.model);
 
             foreignKeys[relationName] = {};

--- a/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
@@ -272,3 +272,56 @@ export interface TestRelations {
 export type TestWithRelations = Test & TestRelations;
 
 `;
+
+exports[`lb4 discover integration model discovery generate relations with --relations 1`] = `
+import {Entity, model, property, belongsTo} from '@loopback/repository';
+import {Doctor,Patient} from '.';
+
+@model({
+  settings: {
+    foreignKeys: {
+      doctorIdRel: {name: 'doctorIdRel', entity: 'Doctor', entityKey: 'id', foreignKey: 'doctorId'},
+      patientIdRel: {
+        name: 'patientIdRel',
+        entity: 'Patient',
+        entityKey: 'pid',
+        foreignKey: 'patientId'
+      }
+    }
+  }
+})
+export class Appointment extends Entity {
+  @property({
+    type: 'number',
+    precision: 10,
+    scale: 0,
+    generated: 1,
+    id: 1,
+    mysql: {columnName: 'id', dataType: 'int', dataLength: null, dataPrecision: 10, dataScale: 0, nullable: 'N', generated: 1},
+  })
+  id?: number;
+
+  @belongsTo(() => Patient)
+  patientId?: number;
+
+  @belongsTo(() => Doctor)
+  doctorId?: number;
+
+  // Define well-known properties here
+
+  // Indexer property to allow additional data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [prop: string]: any;
+
+  constructor(data?: Partial<Appointment>) {
+    super(data);
+  }
+}
+
+export interface AppointmentRelations {
+  // describe navigational properties here
+}
+
+export type AppointmentWithRelations = Appointment & AppointmentRelations;
+
+`;

--- a/packages/cli/test/fixtures/discover/mem.datasource.js.txt
+++ b/packages/cli/test/fixtures/discover/mem.datasource.js.txt
@@ -20,6 +20,21 @@ const modelList = [
     name:'Naming',
     view: true,
     schema: 'Naming'
+  },
+    {
+    name:'Doctor',
+    view: false,
+    schema: 'Doctor'
+  },
+    {
+    name:'Patient',
+    view: false,
+    schema: 'Patient'
+  },
+    {
+    name:'Appointment',
+    view: false,
+    schema: 'Appointment'
   }
 ];
 // In real model definitions, the schema is contained in options->connectorName->schema
@@ -116,6 +131,95 @@ const fullDefinitions = [
         'scale': null,
       },
     },
+  },
+    {
+    'name': 'Doctor',
+    'properties': {
+      'id': {
+        'type': 'Number',
+        'length': null,
+        'precision': null,
+        'required': false,
+        'scale': 0,
+      'id': 1,
+      },
+      'name': {
+        'type': 'String',
+        'required': false,
+        'length': 45,
+        'precision': null,
+        'scale': null,
+      },
+    },
+  },
+  {
+    'name': 'Patient',
+    'properties': {
+      'pid': {
+        'type': 'Number',
+        'length': null,
+        'precision': null,
+        'required': false,
+        'scale': 0,
+        'id': 1,
+      },
+      'name': {
+        'type': 'String',
+        'required': false,
+        'length': 45,
+        'precision': null,
+        'scale': null,
+      },
+    },
+  },
+  {
+    name: 'Appointment',
+    className: 'Appointment',
+    modelBaseClass: 'Entity',
+    isModelBaseBuiltin: true,
+    options: {
+      relations: {
+        doctorIdRel: { model: 'Doctor', type: 'belongsTo', foreignKey: 'doctorId' },
+        patientIdRel: { model: 'Patient', type: 'belongsTo', foreignKey: 'patientId' }
+      }
+    },
+    properties: {
+      id: {
+        type: "number",
+        precision: 10,
+        scale: 0,
+        generated: 1,
+        id: 1,
+        mysql: "{columnName: 'id', dataType: 'int', dataLength: null, dataPrecision: 10, dataScale: 0, nullable: 'N', generated: 1}",
+        tsType: 'number'
+      },
+      patientId: {
+        type: "number",
+        precision: 10,
+        scale: 0,
+        generated: 0,
+        mysql: "{columnName: 'patientId', dataType: 'int', dataLength: null, dataPrecision: 10, dataScale: 0, nullable: 'Y', generated: 0}",
+        tsType: 'number'
+      },
+      doctorId: {
+        type: "number",
+        precision: 10,
+        scale: 0,
+        generated: 0,
+        mysql: "{columnName: 'doctorId', dataType: 'int', dataLength: null, dataPrecision: 10, dataScale: 0, nullable: 'Y', generated: 0}",
+        tsType: 'number'
+      }
+    },
+    allowAdditionalProperties: true,
+    modelSettings: {
+      settings: {
+        idInjection: false,
+        relations: {
+          doctorIdRel: {model: 'Doctor', type: 'belongsTo', foreignKey: 'doctorId'},
+          patientIdRel: {model: 'Patient', type: 'belongsTo', foreignKey: 'patientId'}
+        }
+      }
+    }
   },
 ];
 

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -65,6 +65,11 @@ const treatTINYINT1AsTinyIntOptions = {
   treatTINYINT1AsTinyInt: false,
 };
 
+const relationsSetTrue = {
+  ...baseOptions,
+  relations: true,
+};
+
 // Expected File Name
 const defaultExpectedTestModel = path.join(
   sandbox.path,
@@ -81,6 +86,10 @@ const defaultExpectedViewModel = path.join(
 const defaultExpectedNamingModel = path.join(
   sandbox.path,
   'src/models/naming.model.ts',
+);
+const AppointmentModel = path.join(
+  sandbox.path,
+  'src/models/appointment.model.ts',
 );
 
 const defaultExpectedIndexFile = path.join(sandbox.path, 'src/models/index.ts');
@@ -196,6 +205,18 @@ describe('lb4 discover integration', () => {
 
       assert.file(defaultExpectedTestModel);
       expectFileToMatchSnapshot(defaultExpectedTestModel);
+    });
+    it('generate relations with --relations', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withOptions(relationsSetTrue);
+      assert.file(AppointmentModel);
+      expectFileToMatchSnapshot(AppointmentModel);
     });
   });
   it('generates specific models without prompts using --models', async () => {


### PR DESCRIPTION
Running `lb4 discover` with the `relations` flag generates buggy code for the hasManyThrough relation.

```
src/models/appointment.model.ts:1:45 - error TS2300: Duplicate identifier 'belongsTo'.

1 import {Entity, model, property, belongsTo, belongsTo} from '@loopback/repository';
```

This is happening due to duplicate imports [here](https://github.com/loopbackio/loopback-next/blob/master/packages/cli/generators/discover/index.js#L386). This PR fixes that by adding a check.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
