### PR TITLE
ci: add step for CLI testing (Linux only)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,6 +46,9 @@ jobs:
         run: node packages/build/bin/run-nyc node packages/build/bin/run-mocha --lang en_US.UTF-8 --reporter spec "extensions/*/dist/__tests__/**/*.js"
       - name: Run example tests
         run: node packages/build/bin/run-nyc node packages/build/bin/run-mocha --lang en_US.UTF-8 --reporter spec "examples/*/dist/__tests__/**/*.js" --exclude "examples/webpack/**"
+      - name: Run CLI tests
+        shell: 'script -q -e -c "bash {0}"'
+        run: node packages/build/bin/run-nyc node packages/build/bin/run-mocha --lang en_US.UTF-8 --reporter spec "packages/cli/test/**/*.js"
       - name: Generate coverage report
         run: node packages/build/bin/run-nyc report --reporter=lcov
       - name: Publish coverage report to Coveralls


### PR DESCRIPTION
As the PR https://github.com/actions/runner/issues/241 remains unresolved and FakeTTY has not been updated, we will implement this option for the time being.