### PR TITLE
feat(sequelize): add `defaultFn` support

### DIFF
--- a/extensions/sequelize/src/__tests__/fixtures/controllers/index.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/controllers/index.ts
@@ -7,6 +7,7 @@ export * from './doctor.controller';
 export * from './patient.controller';
 export * from './product.controller';
 export * from './programming-languange.controller';
+export * from './task.controller';
 export * from './test.controller.base';
 export * from './todo-list-todo.controller';
 export * from './todo-list.controller';

--- a/extensions/sequelize/src/__tests__/fixtures/controllers/task.controller.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/controllers/task.controller.ts
@@ -1,0 +1,186 @@
+import {
+  Count,
+  CountSchema,
+  Filter,
+  FilterExcludingWhere,
+  repository,
+  Where,
+} from '@loopback/repository';
+import {
+  del,
+  get,
+  getModelSchemaRef,
+  param,
+  patch,
+  post,
+  put,
+  requestBody,
+  response,
+} from '@loopback/rest';
+import {Task} from '../models';
+import {TaskRepository} from '../repositories';
+import {TestControllerBase} from './test.controller.base';
+export class TaskController extends TestControllerBase {
+  constructor(
+    @repository(TaskRepository)
+    public taskRepository: TaskRepository,
+  ) {
+    super(taskRepository);
+  }
+
+  @post('/tasks')
+  @response(200, {
+    description: 'task model instance',
+    content: {'application/json': {schema: getModelSchemaRef(Task)}},
+  })
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Task, {
+            title: 'NewTask',
+            exclude: ['id'],
+          }),
+        },
+      },
+    })
+    task: Omit<Task, 'id'>,
+  ): Promise<Task> {
+    return this.taskRepository.create(task);
+  }
+
+  @post('/tasks-bulk')
+  @response(200, {
+    description: 'task model instances',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'array',
+          items: getModelSchemaRef(Task),
+        },
+      },
+    },
+  })
+  async createAll(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: getModelSchemaRef(Task, {
+              title: 'NewTask',
+              exclude: ['id'],
+            }),
+          },
+        },
+      },
+    })
+    tasks: Array<Omit<Task, 'id'>>,
+  ): Promise<Task[]> {
+    return this.taskRepository.createAll(tasks);
+  }
+
+  @get('/tasks/count')
+  @response(200, {
+    description: 'Task model count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async count(@param.where(Task) where?: Where<Task>): Promise<Count> {
+    return this.taskRepository.count(where);
+  }
+
+  @get('/tasks')
+  @response(200, {
+    description: 'Array of Task model instances',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'array',
+          items: getModelSchemaRef(Task, {includeRelations: true}),
+        },
+      },
+    },
+  })
+  async find(@param.filter(Task) filter?: Filter<Task>): Promise<Task[]> {
+    return this.taskRepository.find(filter);
+  }
+
+  @patch('/tasks')
+  @response(200, {
+    description: 'Task PATCH success count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async updateAll(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Task, {partial: true}),
+        },
+      },
+    })
+    task: Task,
+    @param.where(Task) where?: Where<Task>,
+  ): Promise<Count> {
+    return this.taskRepository.updateAll(task, where);
+  }
+
+  @get('/tasks/{id}')
+  @response(200, {
+    description: 'Task model instance',
+    content: {
+      'application/json': {
+        schema: getModelSchemaRef(Task, {includeRelations: true}),
+      },
+    },
+  })
+  async findById(
+    @param.path.number('id') id: number,
+    @param.filter(Task, {exclude: 'where'})
+    filter?: FilterExcludingWhere<Task>,
+  ): Promise<Task> {
+    return this.taskRepository.findById(id, filter);
+  }
+
+  @patch('/tasks/{id}')
+  @response(204, {
+    description: 'Task PATCH success',
+  })
+  async updateById(
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Task, {partial: true}),
+        },
+      },
+    })
+    task: Task,
+  ): Promise<void> {
+    await this.taskRepository.updateById(id, task);
+  }
+
+  @put('/tasks/{id}')
+  @response(204, {
+    description: 'Task PUT success',
+  })
+  async replaceById(
+    @param.path.number('id') id: number,
+    @requestBody() task: Task,
+  ): Promise<void> {
+    await this.taskRepository.replaceById(id, task);
+  }
+
+  @del('/tasks/{id}')
+  @response(204, {
+    description: 'Task DELETE success',
+  })
+  async deleteById(@param.path.number('id') id: number): Promise<void> {
+    await this.taskRepository.deleteById(id);
+  }
+
+  @get('/tasks/sync-sequelize-model')
+  @response(200)
+  async syncSequelizeModel(): Promise<void> {
+    await this.beforeEach();
+  }
+}

--- a/extensions/sequelize/src/__tests__/fixtures/models/index.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/models/index.ts
@@ -6,6 +6,7 @@ export * from './doctor.model';
 export * from './patient.model';
 export * from './product.model';
 export * from './programming-language.model';
+export * from './task.model';
 export * from './todo-list.model';
 export * from './todo.model';
 export * from './user.model';

--- a/extensions/sequelize/src/__tests__/fixtures/models/task.model.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/models/task.model.ts
@@ -1,0 +1,63 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Task extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    generated: true,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  title: string;
+
+  @property({
+    type: 'string',
+    defaultFn: 'uuid',
+  })
+  uuidv1: string;
+
+  @property({
+    type: 'string',
+    defaultFn: 'uuidv4',
+  })
+  uuidv4: string;
+
+  @property({
+    type: 'string',
+    defaultFn: 'shortid',
+  })
+  shortId: string;
+
+  @property({
+    type: 'string',
+    defaultFn: 'nanoid',
+  })
+  nanoId: string;
+
+  @property({
+    type: 'number',
+    defaultFn: 'customAlias',
+  })
+  customAlias: number;
+
+  @property({
+    type: Date,
+    defaultFn: 'now',
+  })
+  createdAt: Date;
+
+  constructor(data?: Partial<Task>) {
+    super(data);
+  }
+}
+
+export interface TaskRelations {
+  // describe navigational properties here
+}
+
+export type TaskWithRelations = Task & TaskRelations;

--- a/extensions/sequelize/src/__tests__/fixtures/repositories/index.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/repositories/index.ts
@@ -6,6 +6,7 @@ export * from './doctor.repository';
 export * from './patient.repository';
 export * from './product.repository';
 export * from './programming-language.repository';
+export * from './task.repository';
 export * from './todo-list.repository';
 export * from './todo.repository';
 export * from './user.repository';

--- a/extensions/sequelize/src/__tests__/fixtures/repositories/task.repository.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/repositories/task.repository.ts
@@ -1,0 +1,21 @@
+import {inject} from '@loopback/core';
+import {SequelizeCrudRepository} from '../../../sequelize';
+import {PrimaryDataSource} from '../datasources/primary.datasource';
+import {Task, TaskRelations} from '../models/index';
+
+export class TaskRepository extends SequelizeCrudRepository<
+  Task,
+  typeof Task.prototype.id,
+  TaskRelations
+> {
+  constructor(@inject('datasources.primary') dataSource: PrimaryDataSource) {
+    super(Task, dataSource);
+  }
+
+  protected getDefaultFnRegistry() {
+    return {
+      ...super.getDefaultFnRegistry(),
+      customAlias: () => Math.random(),
+    };
+  }
+}


### PR DESCRIPTION
`@loopback/sequelize`: Added support for `defaultFn` property with overridable registry of aliases.

The default registry includes existing ones that juggler provides such as uuid, now, shortid etc.

Fixes #9597

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
