### PR TITLE
fix: pin ts-query to 5.x as 6.x breaks cli tests on macos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6040,18 +6040,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@phenomnomnominal/tsquery": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-6.1.2.tgz",
-      "integrity": "sha512-NahxUvas4D4iRV1NqlL6Z3mIl2Fo+rw1x77wgZpYyaQjQnS4svv6XoVzjcRRtnP5cfY6XuVKLZki8Zltkz8z0w==",
-      "dependencies": {
-        "@types/esquery": "^1.5.0",
-        "esquery": "^1.5.0"
-      },
-      "peerDependencies": {
-        "typescript": "^3 || ^4 || ^5"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -7127,18 +7115,11 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/@types/esquery": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@types/esquery/-/esquery-1.5.0.tgz",
-      "integrity": "sha512-MNQ5gCt3j1idWHlj/dEF+WPS1kl6Woe0Agzwy96JvrwDQdDadqeIBhY7mUca51CCUzxf7BsnXzcyKi6ENpEtmQ==",
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
     },
     "node_modules/@types/expect": {
       "version": "1.20.4",
@@ -32527,7 +32508,7 @@
         "@npmcli/map-workspaces": "^3.0.4",
         "@npmcli/package-json": "^4.0.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "^4.0.5",
-        "@phenomnomnominal/tsquery": "^6.1.2",
+        "@phenomnomnominal/tsquery": "~5.0.1",
         "camelcase-keys": "^7.0.2",
         "chalk": "^4.1.2",
         "change-case": "^4.1.2",
@@ -32593,6 +32574,17 @@
       },
       "engines": {
         "node": "16 || 18 || 20"
+      }
+    },
+    "packages/cli/node_modules/@phenomnomnominal/tsquery": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-5.0.1.tgz",
+      "integrity": "sha512-3nVv+e2FQwsW8Aw6qTU6f+1rfcJ3hrcnvH/mu9i8YhxO+9sqbOfpL8m6PbET5+xKOlz/VSbp0RoYWYCtIsnmuA==",
+      "dependencies": {
+        "esquery": "^1.4.0"
+      },
+      "peerDependencies": {
+        "typescript": "^3 || ^4 || ^5"
       }
     },
     "packages/cli/node_modules/lru-cache": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
     "@npmcli/map-workspaces": "^3.0.4",
     "@npmcli/package-json": "^4.0.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^4.0.5",
-    "@phenomnomnominal/tsquery": "^6.1.2",
+    "@phenomnomnominal/tsquery": "~5.0.1",
     "camelcase-keys": "^7.0.2",
     "chalk": "^4.1.2",
     "change-case": "^4.1.2",


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
