### PR TITLE
fix: map type buffer & binary to string in open api specs

### DIFF
--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -76,7 +76,25 @@ describe('build-schema', () => {
           title: 'TestModel',
           type: 'object',
           properties: {
-            image: {type: 'buffer'},
+            image: {type: 'string', format: 'binary'},
+          },
+          additionalProperties: false,
+        });
+      });
+
+      it('allows property of buffer type', () => {
+        @model()
+        class TestModel {
+          @property({type: 'buffer'})
+          image: Buffer;
+        }
+
+        const jsonSchema = modelToJsonSchema(TestModel);
+        expect(jsonSchema).to.eql({
+          title: 'TestModel',
+          type: 'object',
+          properties: {
+            image: {type: 'string', format: 'buffer'},
           },
           additionalProperties: false,
         });

--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -78,6 +78,20 @@ describe('build-schema', () => {
       });
     });
 
+    it('converts Binary', () => {
+      expect(metaToJsonProperty({type: 'Binary'})).to.eql({
+        type: 'string',
+        format: 'binary',
+      });
+    });
+
+    it('converts buffer', () => {
+      expect(metaToJsonProperty({type: 'buffer'})).to.eql({
+        type: 'string',
+        format: 'buffer',
+      });
+    });
+
     it('converts String', () => {
       expect(metaToJsonProperty({type: String})).to.eql({
         type: 'string',

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -280,6 +280,16 @@ export function metaToJsonProperty(meta: PropertyDefinition): JsonSchema {
       type: 'string',
       format: 'date-time',
     });
+  } else if (propertyType === 'buffer') {
+    Object.assign(propDef, {
+      type: 'string',
+      format: 'buffer',
+    });
+  } else if (propertyType === 'Binary') {
+    Object.assign(propDef, {
+      type: 'string',
+      format: 'binary',
+    });
   } else if (propertyType === 'any') {
     // no-op, the json schema for any type is {}
   } else if (isBuiltinType(resolvedType)) {


### PR DESCRIPTION
## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
