### PR TITLE
docs: fix requestBody.array JsDoc example

### DIFF
--- a/packages/openapi-v3/src/decorators/request-body.decorator.ts
+++ b/packages/openapi-v3/src/decorators/request-body.decorator.ts
@@ -127,7 +127,7 @@ export namespace requestBody {
    * export class MyController {
    *   @post('/greet')
    *   greet(@requestBody.array(
-   *     {schema: {type: 'string'}},
+   *     {type: 'string'},
    *     {description: 'an array of names', required: false}
    *   ) names: string[]): string {
    *     return `Hello, ${names}`;


### PR DESCRIPTION
Fixes #9791

Fixes the `requestBody.array` example. 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

