### PR TITLE
fix(docs): Fix migration link to Getting-started page

### DIFF
--- a/docs/site/migration/mounting-lb3app.md
+++ b/docs/site/migration/mounting-lb3app.md
@@ -25,7 +25,7 @@ Explorer.
 
 {% include note.html content="
 If you are not familiar with LoopBack 4, visit
-[Getting started](Getting-started.md) for an introduction.
+[Getting started](../Getting-started.md) for an introduction.
 " %}
 
 Follow


### PR DESCRIPTION
There either needs to be no fil extension, or a .html file extension .md doesn't work
When rendered .md would take you to:
https://loopback.io/doc/en/lb4/Getting-started.md

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
