### PR TITLE
fix: fix binding templates for base classes

### DIFF
--- a/packages/context/src/binding-inspector.ts
+++ b/packages/context/src/binding-inspector.ts
@@ -174,7 +174,8 @@ export function bindingTemplateFor<T>(
 ): BindingTemplate<T> {
   const spec = getBindingMetadata(cls);
   debug('class %s has binding metadata', cls.name, spec);
-  const templateFunctions = spec?.templates ?? [];
+  // Clone the templates array to avoid updating the cached metadata
+  const templateFunctions = [...(spec?.templates ?? [])];
   if (spec?.target !== cls) {
     // Make sure the subclass is used as the binding source
     templateFunctions.push(asClassOrProvider(cls) as BindingTemplate<unknown>);

--- a/packages/core/src/__tests__/unit/application.unit.ts
+++ b/packages/core/src/__tests__/unit/application.unit.ts
@@ -10,6 +10,7 @@ import {
   BindingTag,
   Context,
   ContextTags,
+  getBindingMetadata,
   inject,
   injectable,
   Interceptor,
@@ -380,6 +381,25 @@ describe('Application', () => {
       expect(binding.tagMap.date).to.eql('now');
       expect(binding.key).to.equal('services.my-service');
       expect(findKeysByTag(app, 'service')).to.containEql(binding.key);
+    });
+
+    it('binds subclasses of a service without mutating base class', () => {
+      @injectable({scope: BindingScope.SINGLETON})
+      class BaseService {}
+
+      class SubService extends BaseService {}
+
+      const templates = getBindingMetadata(BaseService)?.templates;
+
+      app.service(BaseService, {
+        defaultScope: BindingScope.SINGLETON,
+      });
+      app.service(SubService, {
+        defaultScope: BindingScope.SINGLETON,
+      });
+      expect(getBindingMetadata(BaseService)?.templates?.length).to.equal(
+        templates?.length,
+      );
     });
   });
 


### PR DESCRIPTION
The current code mutates base class during calculation of the subclass binding metadata template. This causes issues for 
the following examples:

```ts
@injectable({scope: BindingScope.SINGLETON})
      class BaseService {}

      class SubService extends BaseService {}

      const templates = getBindingMetadata(BaseService)?.templates;

      app.service(BaseService, {
        defaultScope: BindingScope.SINGLETON,
      });
      app.service(SubService, {
        defaultScope: BindingScope.SINGLETON,
      });
```

`app.service(SubService...` changes the metadata of `BaseService` due to in-place push of new items to the templates array.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
