### PR TITLE
fix(sequelize): use keyFrom as foreign key for belongsto relation definition

### DIFF
--- a/extensions/sequelize/src/__tests__/fixtures/models/todo.model.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/models/todo.model.ts
@@ -22,7 +22,17 @@ export class Todo extends Entity {
   })
   isComplete?: boolean;
 
-  @belongsTo(() => TodoList, {name: 'todoList'}, {name: 'todo_list_id'})
+  @belongsTo(
+    () => TodoList,
+    {
+      keyTo: 'id',
+      keyFrom: 'todoListId',
+      name: 'todoList',
+    },
+    {
+      name: 'todo_list_id',
+    },
+  )
   todoListId: number;
 
   constructor(data?: Partial<Todo>) {

--- a/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
@@ -700,12 +700,14 @@ export class SequelizeCrudRepository<
         entityClass.definition.relations[key].type ===
         LoopbackRelationType.belongsTo
       ) {
-        const foreignKey = (
-          entityClass.definition.relations[key] as BelongsToDefinition
-        ).keyTo;
+        const relationDefinition = entityClass.definition.relations[
+          key
+        ] as BelongsToDefinition;
+        const foreignKey = relationDefinition.keyFrom;
+        const targetKey = relationDefinition.keyTo;
         sourceModel.belongsTo(targetModel, {
           foreignKey: {name: foreignKey},
-
+          targetKey,
           // Which client will pass on in loopback style include filter, eg. `include: ["thisName"]`
           as: entityClass.definition.relations[key].name,
         });


### PR DESCRIPTION
NOTE: This is an updated PR on top of https://github.com/loopbackio/loopback-next/pull/9926 which was originally authored by @KalleV . 

Belongsto relation definition was not picking the right key for id. It was reproducible if there are multiple entries in the foreign table. 
Used keyFrom to handle the issue. 

Fixes #9591 
See also https://github.com/loopbackio/loopback-next/pull/9926

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
Co-author: @KalleV 