### PR TITLE
feat: show foreign key in openapi specs

### DIFF
--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -1112,7 +1112,10 @@ describe('build-schema', () => {
             properties: {
               id: {type: 'number'},
               categoryId: {type: 'number'},
-              category: {$ref: '#/definitions/CategoryWithRelations'},
+              category: {
+                $ref: '#/definitions/CategoryWithRelations',
+              },
+              foreignKey: 'categoryId' as JsonSchema,
             },
             additionalProperties: false,
           },
@@ -1121,7 +1124,9 @@ describe('build-schema', () => {
           id: {type: 'number'},
           products: {
             type: 'array',
-            items: {$ref: '#/definitions/ProductWithRelations'},
+            items: {
+              $ref: '#/definitions/ProductWithRelations',
+            },
           },
         },
         additionalProperties: false,
@@ -1164,6 +1169,7 @@ describe('build-schema', () => {
               category: {
                 $ref: '#/definitions/CategoryWithoutPropWithRelations',
               },
+              foreignKey: 'categoryId' as JsonSchema,
             },
             additionalProperties: false,
           },

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -567,6 +567,11 @@ export function modelToJsonSchema<T extends object>(
 
       result.properties[relMeta.name] =
         result.properties[relMeta.name] || propDef;
+      if ((relMeta as {keyFrom: string}).keyFrom) {
+        result.properties.foreignKey = (relMeta as {keyFrom: string})
+          .keyFrom as JsonSchema;
+      }
+
       includeReferencedSchema(targetSchema.title!, targetSchema);
     }
   }


### PR DESCRIPTION
Provide foreign key in openapi specification in case of a relation. 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
