### PR TITLE
fix: handle enum

### DIFF
--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -414,7 +414,25 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
           templateData.settings,
         );
       }
-
+      Object.keys(templateData.properties).forEach(key => {
+        const property = templateData.properties[key];
+        // if the type is enum
+        if (property.type.startsWith(`'enum`)) {
+          property.type = property.type.slice(1, -1);
+          const enumRemoved = property.type.split(`enum`)[1];
+          const enumValues = enumRemoved.slice(1, -1).replaceAll(`'`, '');
+          const enumValuesArray = enumValues.split(',');
+          let enumItems = '';
+          enumValuesArray.forEach(item => {
+            enumItems += `'${item}',`;
+          });
+          templateData.properties[key]['type'] = 'String';
+          templateData.properties[key]['tsType'] = 'string';
+          templateData.properties[key][
+            'jsonSchema'
+          ] = `{enum: [${enumItems.toString()}]}`;
+        }
+      });
       this.copyTemplatedFiles(
         modelDiscoverer.MODEL_TEMPLATE_PATH,
         fullPath,

--- a/packages/cli/test/unit/discover/import-discovered-model.test.js
+++ b/packages/cli/test/unit/discover/import-discovered-model.test.js
@@ -157,6 +157,29 @@ describe('importDiscoveredModel', () => {
     });
   });
 
+  it('imports enum properties', () => {
+    const discoveredModel = {
+      name: 'TestModel',
+      properties: {
+        patient: {
+          type: 'String',
+          jsonSchema: {enum: ['INPATIENT', 'OUTPATIENT']},
+          required: false,
+          length: null,
+          precision: null,
+          scale: null,
+        },
+      },
+    };
+
+    const modelData = importDiscoveredModel(discoveredModel);
+    expect(modelData.properties).to.have.property('patient').deepEqual({
+      jsonSchema: "{enum: ['INPATIENT', 'OUTPATIENT']}",
+      type: `'string'`,
+      tsType: 'string',
+    });
+  });
+
   it('converts connector metadata to TypeScript object', () => {
     const discoveredModel = {
       name: 'TestModel',


### PR DESCRIPTION
`lb4 discover` doesn't handle enum properly. This PR implements [this](https://loopback.io/doc/en/lb4/Model.html#enum-property) workaround for the enum in `lb4 discover`.

Related GitHub issues & PRs:

PR https://github.com/loopbackio/loopback-connector-mysql/pull/525

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
