### PR TITLE
fix(sequelize): support "defaultScope" via Model settings

### DIFF
--- a/extensions/sequelize/src/__tests__/fixtures/controllers/index.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/controllers/index.ts
@@ -7,6 +7,7 @@ export * from './doctor.controller';
 export * from './patient.controller';
 export * from './product.controller';
 export * from './programming-languange.controller';
+export * from './scoped-task.controller';
 export * from './task.controller';
 export * from './test.controller.base';
 export * from './todo-list-todo.controller';

--- a/extensions/sequelize/src/__tests__/fixtures/controllers/scoped-task.controller.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/controllers/scoped-task.controller.ts
@@ -1,0 +1,19 @@
+import {repository} from '@loopback/repository';
+import {get, response} from '@loopback/rest';
+import {ScopedTaskRepository} from '../repositories';
+import {TestControllerBase} from './test.controller.base';
+
+export class ScopedTaskController extends TestControllerBase {
+  constructor(
+    @repository(ScopedTaskRepository)
+    public scopedTaskRepository: ScopedTaskRepository,
+  ) {
+    super(scopedTaskRepository);
+  }
+
+  @get('/scoped-tasks/sync-sequelize-model')
+  @response(200)
+  async syncSequelizeModel(): Promise<void> {
+    await this.beforeEach();
+  }
+}

--- a/extensions/sequelize/src/__tests__/fixtures/models/index.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/models/index.ts
@@ -6,6 +6,7 @@ export * from './doctor.model';
 export * from './patient.model';
 export * from './product.model';
 export * from './programming-language.model';
+export * from './scoped-task.model';
 export * from './task.model';
 export * from './todo-list.model';
 export * from './todo.model';

--- a/extensions/sequelize/src/__tests__/fixtures/models/scoped-task.model.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/models/scoped-task.model.ts
@@ -7,6 +7,9 @@ import {Entity, model, property} from '@loopback/repository';
   settings: {
     scope: {
       limit: 1,
+      where: {
+        completed: false,
+      },
     },
   },
 })
@@ -23,6 +26,12 @@ export class ScopedTask extends Entity {
     required: true,
   })
   title: string;
+
+  @property({
+    type: 'boolean',
+    default: false,
+  })
+  completed: boolean;
 
   constructor(data?: Partial<ScopedTask>) {
     super(data);

--- a/extensions/sequelize/src/__tests__/fixtures/models/scoped-task.model.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/models/scoped-task.model.ts
@@ -1,0 +1,36 @@
+import {Entity, model, property} from '@loopback/repository';
+
+/**
+ * Simplified Entity used for testing settings "scope" functionality
+ */
+@model({
+  settings: {
+    scope: {
+      limit: 1,
+    },
+  },
+})
+export class ScopedTask extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    generated: true,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  title: string;
+
+  constructor(data?: Partial<ScopedTask>) {
+    super(data);
+  }
+}
+
+export interface ScopedTaskRelations {
+  // describe navigational properties here
+}
+
+export type ScopedTaskWithRelations = ScopedTask & ScopedTaskRelations;

--- a/extensions/sequelize/src/__tests__/fixtures/repositories/index.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/repositories/index.ts
@@ -6,6 +6,7 @@ export * from './doctor.repository';
 export * from './patient.repository';
 export * from './product.repository';
 export * from './programming-language.repository';
+export * from './scoped-task.repository';
 export * from './task.repository';
 export * from './todo-list.repository';
 export * from './todo.repository';

--- a/extensions/sequelize/src/__tests__/fixtures/repositories/scoped-task.repository.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/repositories/scoped-task.repository.ts
@@ -1,0 +1,24 @@
+import {inject} from '@loopback/core';
+import {SequelizeCrudRepository} from '../../../sequelize';
+import {PrimaryDataSource} from '../datasources/primary.datasource';
+import {ScopedTask, ScopedTaskRelations} from '../models/index';
+
+/**
+ * Simplified repository used for testing Model settings "scope" functionality
+ */
+export class ScopedTaskRepository extends SequelizeCrudRepository<
+  ScopedTask,
+  typeof ScopedTask.prototype.id,
+  ScopedTaskRelations
+> {
+  constructor(@inject('datasources.primary') dataSource: PrimaryDataSource) {
+    super(ScopedTask, dataSource);
+  }
+
+  protected getDefaultFnRegistry() {
+    return {
+      ...super.getDefaultFnRegistry(),
+      customAlias: () => Math.random(),
+    };
+  }
+}

--- a/extensions/sequelize/src/__tests__/integration/repository.integration.ts
+++ b/extensions/sequelize/src/__tests__/integration/repository.integration.ts
@@ -97,6 +97,30 @@ describe('Sequelize CRUD Repository (integration)', () => {
 
         expect(tasksCustomLimit.length).to.be.eql(3);
       });
+
+      it('supports setting a default "where" filter in the Model settings', async () => {
+        await Promise.all([
+          scopedTaskRepo.create({title: 'Task 1', completed: true}),
+          scopedTaskRepo.create({title: 'Task 2', completed: false}),
+        ]);
+
+        const tasksDefaultWhereFilter = await scopedTaskRepo.find({
+          limit: 2,
+        });
+
+        expect(tasksDefaultWhereFilter).to.have.lengthOf(1);
+        expect(tasksDefaultWhereFilter[0].title).to.eql('Task 2');
+
+        const tasksCustomWhereFilter = await scopedTaskRepo.find({
+          where: {
+            completed: true,
+          },
+          limit: 2,
+        });
+
+        expect(tasksCustomWhereFilter).to.have.lengthOf(1);
+        expect(tasksCustomWhereFilter[0].title).to.eql('Task 1');
+      });
     });
 
     describe('defaultFn Support', () => {

--- a/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
@@ -682,6 +682,8 @@ export class SequelizeCrudRepository<
         timestamps: false,
         tableName: this.getTableName(entityClass),
         freezeTableName: true,
+        // Set up optional default scope: https://sequelize.org/docs/v6/other-topics/scopes/#definition
+        defaultScope: entityClass.definition.settings.scope,
       },
     );
 


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Add support for [Model settings scope](https://loopback.io/doc/en/lb4/Model.html#scope) when using the Sequelize ORM instead of Juggler.

Fixes #10169

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
