### PR TITLE
fix(sequelize): exclude test environment from NPM publish

### DIFF
--- a/extensions/sequelize/package.json
+++ b/extensions/sequelize/package.json
@@ -36,7 +36,8 @@
     "README.md",
     "dist",
     "src",
-    "!*/__tests__"
+    "!*/__tests__",
+    "!dist/.sandbox"
   ],
   "peerDependencies": {
     "@loopback/core": "^5.0.0",


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Exclude test sandbox temp directory from the NPM publish.

Fixes: #10173

## Tests

Tested fix with`npm pack`:
![Screenshot 2023-11-09 at 9 32 11 AM](https://github.com/loopbackio/loopback-next/assets/5942028/d83813f6-a95a-4f8b-8853-035a0926a114)

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
