### PR TITLE
fix: add process.exit for generators

### DIFF
--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -461,6 +461,7 @@ module.exports = class BaseGenerator extends Generator {
         );
       }
     }
+    process.exit(0);
   }
 
   /**


### PR DESCRIPTION
Running `lb4 discover` with `--config` option causes it to get stuck. The lb4 discover works fine with other options like  `--dataSource` & `--schema` but it gets stuck when we run it with `--config`. The discoverer successfully generates the models but doesn't terminate. 

This PR fixes that

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
