### PR TITLE
fix(sequelize): extend Inclusion interface with "required" property

### DIFF
--- a/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
@@ -68,6 +68,27 @@ import {isTruelyObject} from './utils';
 const debug = debugFactory('loopback:sequelize:repository');
 const debugModelBuilder = debugFactory('loopback:sequelize:modelbuilder');
 
+interface InclusionWithRequired extends Inclusion {
+  /**
+   * Setting this option to true will result in an inner join query that
+   * explicitly requires the specified condition for the child model.
+   *
+   * @see https://loopback.io/pages/en/lb4/readmes/loopback-next/extensions/sequelize/#inner-join
+   */
+  required?: boolean;
+}
+
+type InclusionFilterWithRequired = string | InclusionWithRequired;
+
+interface FilterWithRequired<T extends object> extends Filter<T> {
+  include?: InclusionFilterWithRequired[];
+}
+
+type FilterWithRequiredExcludingWhere<T extends object> = Omit<
+  FilterExcludingWhere<T>,
+  'where'
+>;
+
 /**
  * Sequelize implementation of CRUD repository to be used with default loopback entities
  * and SequelizeDataSource for SQL Databases
@@ -231,7 +252,7 @@ export class SequelizeCrudRepository<
   }
 
   async find(
-    filter?: Filter<T>,
+    filter?: FilterWithRequired<T>,
     options?: AnyObject,
   ): Promise<(T & Relations)[]> {
     const data = await this.sequelizeModel.findAll({
@@ -252,7 +273,7 @@ export class SequelizeCrudRepository<
   }
 
   async findOne(
-    filter?: Filter<T>,
+    filter?: FilterWithRequired<T>,
     options?: AnyObject,
   ): Promise<(T & Relations) | null> {
     const data = await this.sequelizeModel.findOne({
@@ -279,7 +300,7 @@ export class SequelizeCrudRepository<
 
   async findById(
     id: ID,
-    filter?: FilterExcludingWhere<T>,
+    filter?: FilterWithRequiredExcludingWhere<T>,
     options?: AnyObject,
   ): Promise<T & Relations> {
     const data = await this.sequelizeModel.findByPk(

--- a/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
@@ -15,7 +15,6 @@ import {
   EntityNotFoundError,
   Fields,
   Filter,
-  FilterExcludingWhere,
   Getter,
   HasManyDefinition,
   HasManyRepositoryFactory,
@@ -85,7 +84,7 @@ interface FilterWithRequired<T extends object> extends Filter<T> {
 }
 
 type FilterWithRequiredExcludingWhere<T extends object> = Omit<
-  FilterExcludingWhere<T>,
+  FilterWithRequired<T>,
   'where'
 >;
 

--- a/extensions/sequelize/src/types.ts
+++ b/extensions/sequelize/src/types.ts
@@ -3,6 +3,18 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+declare module '@loopback/repository' {
+  interface Inclusion {
+    /**
+     * Setting this option to true will result in an inner join query that
+     * explicitly requires the specified condition for the child model.
+     *
+     * @see https://loopback.io/pages/en/lb4/readmes/loopback-next/extensions/sequelize/#inner-join
+     */
+    required?: boolean;
+  }
+}
+
 /**
  * Interface defining the component's options object
  */

--- a/extensions/sequelize/src/types.ts
+++ b/extensions/sequelize/src/types.ts
@@ -3,18 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-declare module '@loopback/repository' {
-  interface Inclusion {
-    /**
-     * Setting this option to true will result in an inner join query that
-     * explicitly requires the specified condition for the child model.
-     *
-     * @see https://loopback.io/pages/en/lb4/readmes/loopback-next/extensions/sequelize/#inner-join
-     */
-    required?: boolean;
-  }
-}
-
 /**
  * Interface defining the component's options object
  */


### PR DESCRIPTION
Partial fix for: #10193

This resolves Typescript errors such as the following when trying to use the new property with a repository call using "find", "findOne", "findById":
```ts
Type '{ relation: string; scope: { where: { id: number; }; }; required: true; }'
is not assignable to type 'InclusionFilter'.
  Object literal may only specify known properties, and 'required'
does not exist in type 'Inclusion'.

53           required: true
```

Reference:
https://loopback.io/pages/en/lb4/readmes/loopback-next/extensions/sequelize/

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
