### PR TITLE
fix(repository): use a shallow clone for applying polymorphism to options

### DIFF
--- a/packages/repository/src/relations/belongs-to/belongs-to.repository.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.repository.ts
@@ -4,7 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Getter} from '@loopback/core';
-import {cloneDeep} from 'lodash';
 import {EntityNotFoundError, TypeResolver} from '../../';
 import {DataObject, Options} from '../../common-types';
 import {Entity} from '../../model';
@@ -101,7 +100,7 @@ export class DefaultBelongsToRepository<
       result = result.concat(
         await targetRepository.find(
           constrainFilter(undefined, this.constraint),
-          Object.assign(cloneDeep(options ?? {}), {polymorphicType: key}),
+          {...options, polymorphicType: key},
         ),
       );
       if (result.length >= 1) {

--- a/packages/repository/src/relations/has-many/has-many-through.repository.ts
+++ b/packages/repository/src/relations/has-many/has-many-through.repository.ts
@@ -3,7 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {cloneDeep} from 'lodash';
 import {
   constrainDataObject,
   constrainFilter,
@@ -304,10 +303,10 @@ export class DefaultHasManyThroughRepository<
         throughCategorized[key],
       );
       allTargets = allTargets.concat(
-        await targetRepository.find(
-          constrainFilter(filter, targetConstraint),
-          Object.assign(cloneDeep(options ?? {}), {polymorphicType: key}),
-        ),
+        await targetRepository.find(constrainFilter(filter, targetConstraint), {
+          ...options,
+          polymorphicType: key,
+        }),
       );
     }
 

--- a/packages/repository/src/relations/has-one/has-one.inclusion-resolver.ts
+++ b/packages/repository/src/relations/has-one/has-one.inclusion-resolver.ts
@@ -4,7 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Filter, InclusionFilter} from '@loopback/filter';
-import {cloneDeep} from 'lodash';
 import {includeFieldIfNot, InvalidPolymorphismError} from '../../';
 import {AnyObject, Options} from '../../common-types';
 import {Entity} from '../../model';
@@ -113,7 +112,7 @@ export function createHasOneInclusionResolver<
         targetKey,
         sourceIdsCategorized[k],
         scope,
-        Object.assign(cloneDeep(options ?? {}), {polymorphicType: k}),
+        {...options, polymorphicType: k},
       );
       targetCategorized[k] = flattenTargetsOfOneToOneRelation(
         sourceIdsCategorized[k],

--- a/packages/repository/src/relations/has-one/has-one.repository.ts
+++ b/packages/repository/src/relations/has-one/has-one.repository.ts
@@ -5,7 +5,6 @@
 
 import {Getter} from '@loopback/core';
 import {Filter, Where} from '@loopback/filter';
-import {cloneDeep} from 'lodash';
 import {TypeResolver} from '../../';
 import {Count, DataObject, Options} from '../../common-types';
 import {EntityNotFoundError, InvalidPolymorphismError} from '../../errors';
@@ -182,7 +181,7 @@ export class DefaultHasOneRepository<
       const targetRepository = await this.getTargetRepositoryDict[key]();
       const found = await targetRepository.find(
         Object.assign({limit: 1}, constrainFilter(filter, this.constraint)),
-        Object.assign(cloneDeep(options ?? {}), {polymorphicType: key}),
+        {...options, polymorphicType: key},
       );
       if (found.length >= 1) {
         return found[0];


### PR DESCRIPTION
The `options` object will often have a `transaction`, which contains database connection resources that must not be cloned.

Fixes #10194
Introduced by #8026

Signed-off-by: Matthew Gabeler-Lee <mgabeler-lee@6river.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
