### PR TITLE
fix: enable lb4 relation generate relation with same table

### DIFF
--- a/packages/cli/generators/relation/templates/controller-relation-template-has-one.ts.ejs
+++ b/packages/cli/generators/relation/templates/controller-relation-template-has-one.ts.ejs
@@ -15,8 +15,9 @@ import {
   post,
   requestBody,
 } from '@loopback/rest';
-import {
-  <%= sourceModelClassName %>,
+import {<%if (sourceModelClassName != targetModelClassName) { %>
+  <%= sourceModelClassName %>,<% } %>
+  <%= targetModelClassName %>,
   <%= targetModelClassName %>,
 } from '../models';
 import {<%= sourceRepositoryClassName %>} from '../repositories';


### PR DESCRIPTION
Generating a hasOne relation with lb4 relations with the same table generates buggy code as it add imports for both source & target models are same. This PR fixes that.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
