### PR TITLE
fix(sequelize): resolves SQL error when order property is an empty string

### DIFF
--- a/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
@@ -489,7 +489,7 @@ export class SequelizeCrudRepository<
    * @returns Sequelize compatible order filter value
    */
   protected buildSequelizeOrder(order?: string[] | string): Order | undefined {
-    if (order === undefined) {
+    if (order === undefined || order === '') {
       return undefined;
     }
 


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Ignore the "order" field if it is an empty string for backwards-compatible behavior with the Loopback Juggler ORM.

Fixes #10275

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
