### PR TITLE
fix(sequelize): resolves SQL error when order filter is an empty string

### DIFF
--- a/extensions/sequelize/src/__tests__/integration/repository.integration.ts
+++ b/extensions/sequelize/src/__tests__/integration/repository.integration.ts
@@ -487,6 +487,23 @@ describe('Sequelize CRUD Repository (integration)', () => {
       expect(getResponse.body).to.be.deepEqual(reversedArray);
     });
 
+    it('ignores an empty `order` filter', async () => {
+      const users = [
+        getDummyUser({name: 'ABoy'}),
+        getDummyUser({name: 'BBoy'}),
+        getDummyUser({name: 'CBoy'}),
+      ];
+      const createAllResponse = await client.post('/users-bulk').send(users);
+      const filter = {
+        order: '',
+      };
+      const getResponse = await client.get(`/users`).query({
+        filter,
+      });
+
+      expect(getResponse.body).to.be.deepEqual(createAllResponse.body);
+    });
+
     it('supports `limit` filter', async () => {
       const users = [getDummyUser(), getDummyUser(), getDummyUser()];
       await client.post('/users-bulk').send(users);

--- a/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
@@ -469,7 +469,7 @@ export class SequelizeCrudRepository<
    * @returns Sequelize compatible order filter value
    */
   protected buildSequelizeOrder(order?: string[] | string): Order | undefined {
-    if (order === undefined) {
+    if (order === undefined || order === '') {
       return undefined;
     }
 


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Ignore the "order" field if it is an empty string for backward-compatible behavior with the Loopback Juggler ORM.

Fixes #10275

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
