### PR TITLE
fix(sequelize): add type coercion for booleans in the Where filter

### DIFF
--- a/extensions/sequelize/src/__tests__/integration/repository.integration.ts
+++ b/extensions/sequelize/src/__tests__/integration/repository.integration.ts
@@ -280,6 +280,73 @@ describe('Sequelize CRUD Repository (integration)', () => {
       ]);
     });
 
+    it('creates an entity and finds it using Where filter boolean conditions', async () => {
+      const user = getDummyUser();
+
+      await client.post('/users').send(user);
+
+      const expectedUser = {
+        id: 1,
+        ..._.omit(user, ['password']),
+      };
+
+      const userResponse1 = await client
+        .get('/users')
+        .query({
+          filter: {
+            where: {
+              active: true,
+            },
+          },
+        })
+        .send();
+
+      expect(userResponse1.body).deepEqual([expectedUser]);
+
+      const userResponse2 = await client
+        .get('/users')
+        .query({
+          filter: {
+            where: {
+              active: false,
+            },
+          },
+        })
+        .send();
+
+      expect(userResponse2.body).deepEqual([]);
+
+      const userResponse3 = await client
+        .get('/users')
+        .query({
+          filter: {
+            where: {
+              active: {
+                eq: true,
+              },
+            },
+          },
+        })
+        .send();
+
+      expect(userResponse3.body).deepEqual([expectedUser]);
+
+      const userResponse4 = await client
+        .get('/users')
+        .query({
+          filter: {
+            where: {
+              active: {
+                eq: false,
+              },
+            },
+          },
+        })
+        .send();
+
+      expect(userResponse4.body).deepEqual([]);
+    });
+
     it('counts created entities', async () => {
       await client.post('/users').send(getDummyUser());
       const getResponse = await client.get('/users/count').send();

--- a/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
@@ -63,7 +63,7 @@ import {MakeNullishOptional} from 'sequelize/types/utils';
 import {operatorTranslations} from './operator-translation';
 import {SequelizeDataSource} from './sequelize.datasource.base';
 import {SequelizeModel} from './sequelize.model';
-import {isTruelyObject} from './utils';
+import {castToBoolean, isTruelyObject} from './utils';
 
 const debug = debugFactory('loopback:sequelize:repository');
 const debugModelBuilder = debugFactory('loopback:sequelize:modelbuilder');
@@ -626,6 +626,10 @@ export class SequelizeCrudRepository<
         continue;
       }
 
+      const entityClassCol = this.entityClass.definition.properties[columnName];
+      const isBooleanColumn =
+        entityClassCol && entityClassCol.type === 'boolean';
+
       if (isTruelyObject(conditionValue)) {
         sequelizeWhere[columnName] = {};
 
@@ -633,8 +637,16 @@ export class SequelizeCrudRepository<
           const sequelizeOperator = this.getSequelizeOperator(
             lb4Operator as keyof typeof operatorTranslations,
           );
-          sequelizeWhere[columnName][sequelizeOperator] =
-            conditionValue![lb4Operator as keyof typeof conditionValue];
+
+          if (isBooleanColumn) {
+            // Handles boolean column conditions like `{ neq: true }` or `{ eq: false }`
+            sequelizeWhere[columnName][sequelizeOperator] = castToBoolean(
+              conditionValue![lb4Operator as keyof typeof conditionValue],
+            );
+          } else {
+            sequelizeWhere[columnName][sequelizeOperator] =
+              conditionValue![lb4Operator as keyof typeof conditionValue];
+          }
         }
       } else if (
         ['and', 'or'].includes(columnName) &&
@@ -653,9 +665,12 @@ export class SequelizeCrudRepository<
           [sequelizeOperator]: conditions,
         });
       } else {
-        // Equals
+        // Equals operation. Casting boolean columns to avoid passing strings as boolean values
+        // to the Sequelize query builders.
         sequelizeWhere[columnName] = {
-          [Op.eq]: conditionValue,
+          [Op.eq]: isBooleanColumn
+            ? castToBoolean(conditionValue)
+            : conditionValue,
         };
       }
     }

--- a/extensions/sequelize/src/sequelize/utils.ts
+++ b/extensions/sequelize/src/sequelize/utils.ts
@@ -11,3 +11,21 @@
 export const isTruelyObject = (value?: unknown) => {
   return typeof value === 'object' && !Array.isArray(value) && value !== null;
 };
+
+/**
+ * Coerces a value to a boolean. This is used for Where Filter type coercion
+ * to avoid passing "true" or "false" as strings to the internal Sequelize queries.
+ *
+ * @param value - The value to be serialized.
+ * @returns The coerced boolean value: true / false.
+ */
+export const castToBoolean = (value: unknown): boolean => {
+  if (typeof value === 'boolean') {
+    return value;
+  } else if (typeof value === 'string') {
+    return value.toLowerCase() === 'true';
+  } else {
+    // e.g. null, undefined, 0, 1, etc.
+    return Boolean(value);
+  }
+};


### PR DESCRIPTION
Cast entity columns with type "boolean" from strings to boolean values in the Loopback 4 Where Filter to Sequelize operation translation layer.

This addresses a backward compatibility issue with the Juggler ORM for `Where` filter values passed in from REST API calls.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Fixes #10149

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
