### PR TITLE
fix(sequelize): init Sequelize instance in constructor

### DIFF
--- a/extensions/sequelize/package.json
+++ b/extensions/sequelize/package.json
@@ -56,6 +56,7 @@
     "@loopback/rest": "^13.1.4",
     "@loopback/testlab": "^6.1.4",
     "@types/node": "^16.18.68",
+    "oracledb": "^5.5.0",
     "pg": "^8.11.3",
     "pg-hstore": "^2.3.4",
     "sqlite3": "5.1.4",

--- a/extensions/sequelize/src/__tests__/fixtures/observers/index.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/observers/index.ts
@@ -1,0 +1,1 @@
+export * from './test.observer';

--- a/extensions/sequelize/src/__tests__/fixtures/observers/test.observer.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/observers/test.observer.ts
@@ -1,0 +1,26 @@
+import {lifeCycleObserver, type LifeCycleObserver} from '@loopback/core';
+import {repository} from '@loopback/repository';
+import {UserRepository} from '../repositories';
+
+/**
+ * Test observer for validating that the Sequelize repositories are available in Loopback Observers during server startup.
+ */
+@lifeCycleObserver('test')
+export class TestObserver implements LifeCycleObserver {
+  constructor(
+    @repository(UserRepository)
+    private userRepository: UserRepository,
+  ) {}
+
+  async start(): Promise<void> {
+    try {
+      await this.userRepository.find();
+    } catch (error) {
+      // For the repository tests, the database schema is not created until after the server is initialized:
+      // extensions/sequelize/src/__tests__/integration/repository.integration.ts
+      if (!error.message.includes('no such table: User')) {
+        throw error;
+      }
+    }
+  }
+}

--- a/extensions/sequelize/src/__tests__/integration/repository.integration.ts
+++ b/extensions/sequelize/src/__tests__/integration/repository.integration.ts
@@ -1047,6 +1047,7 @@ describe('Sequelize CRUD Repository (integration)', () => {
         'task.controller',
         'scoped-task.controller',
       ],
+      observers: ['index', 'test.observer'],
     };
 
     const copyFilePromises: Array<Promise<unknown>> = [];

--- a/extensions/sequelize/src/sequelize/sequelize.datasource.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.datasource.base.ts
@@ -45,12 +45,7 @@ export class SequelizeDataSource implements LifeCycleObserver {
         } is not supported.`,
       );
     }
-  }
 
-  sequelize?: Sequelize;
-  sequelizeConfig: SequelizeOptions;
-  async init(): Promise<void> {
-    const {config} = this;
     const {
       connector,
       file,
@@ -86,7 +81,11 @@ export class SequelizeDataSource implements LifeCycleObserver {
     } else {
       this.sequelize = new Sequelize(this.sequelizeConfig);
     }
+  }
 
+  sequelize: Sequelize;
+  sequelizeConfig: SequelizeOptions;
+  async init(): Promise<void> {
     await this.sequelize.authenticate();
     debug('Connection has been established successfully.');
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1485,6 +1485,7 @@
         "@loopback/rest": "^13.1.4",
         "@loopback/testlab": "^6.1.4",
         "@types/node": "^16.18.68",
+        "oracledb": "^5.5.0",
         "pg": "^8.11.3",
         "pg-hstore": "^2.3.4",
         "sqlite3": "5.1.4",
@@ -25774,6 +25775,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/oracledb": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-5.5.0.tgz",
+      "integrity": "sha512-i5cPvMENpZP8nnqptB6l0pjiOyySj1IISkbM4Hr3yZEDdANo2eezarwZb9NQ8fTh5pRjmgpZdSyIbnn9N3AENw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=10.16"
       }
     },
     "node_modules/os-locale": {


### PR DESCRIPTION
This resolves initialization errors in Loopback 4 observers attempting to use repositories extending the Sequelize CRUD repository on start up.

Adds dev dependency for "oracledb" to address this test error:
```
parses pool options for oracle:
     Error: Please install oracledb package manually
      at OracleConnectionManager._loadDialectModule (node_modules/sequelize/src/dialects/abstract/connection-manager.js:81:15)
      at new OracleConnectionManager (node_modules/sequelize/src/dialects/oracle/connection-manager.js:28:21)
      at new OracleDialect (node_modules/sequelize/src/dialects/oracle/index.js:17:30)
      at new Sequelize (node_modules/sequelize/src/sequelize.js:368:20)
      at new SequelizeDataSource (extensions/sequelize/src/sequelize/sequelize.datasource.base.ts:9:34)
      at Context.<anonymous> (extensions/sequelize/src/__tests__/unit/sequelize.datasource.unit.ts:100:24)
      at processImmediate (node:internal/timers:466:21)
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Fixes #9606

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
