### PR TITLE
fix(sequelize): add support for extended operators in sequelize

### DIFF
--- a/extensions/sequelize/src/__tests__/fixtures/controllers/index.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/controllers/index.ts
@@ -7,6 +7,7 @@ export * from './doctor.controller';
 export * from './patient.controller';
 export * from './product.controller';
 export * from './programming-languange.controller';
+export * from './roles.controller';
 export * from './scoped-task.controller';
 export * from './task.controller';
 export * from './test.controller.base';

--- a/extensions/sequelize/src/__tests__/fixtures/controllers/roles.controller.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/controllers/roles.controller.ts
@@ -1,0 +1,81 @@
+import {AnyObject, repository} from '@loopback/repository';
+import {
+  get,
+  getModelSchemaRef,
+  post,
+  requestBody,
+  response,
+} from '@loopback/rest';
+import {Roles} from '../models';
+import {RolesRepository} from '../repositories';
+import {TestControllerBase} from './test.controller.base';
+
+export class RolesController extends TestControllerBase {
+  constructor(
+    @repository(RolesRepository)
+    public roleRepository: RolesRepository,
+  ) {
+    super(roleRepository);
+  }
+
+  @post('/role')
+  @response(200, {
+    description: 'Role model instance',
+    content: {'application/json': {schema: getModelSchemaRef(Roles)}},
+  })
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Roles, {
+            title: 'NewRole',
+            exclude: ['id'],
+          }),
+        },
+      },
+    })
+    role: Omit<Roles, 'id'>,
+  ): Promise<Roles> {
+    return this.roleRepository.create(role);
+  }
+
+  @get('/roles-desc')
+  @response(200, {
+    description: 'Role model instance',
+    content: {
+      'application/json': {
+        schema: getModelSchemaRef(Roles, {includeRelations: true}),
+      },
+    },
+  })
+  async getRolesByDesc(): Promise<Roles[]> {
+    return this.roleRepository.find({
+      where: {
+        description: {match: 'Others'},
+      } as AnyObject,
+    });
+  }
+
+  @get('/roles-perm')
+  @response(200, {
+    description: 'Role model instance',
+    content: {
+      'application/json': {
+        schema: getModelSchemaRef(Roles, {includeRelations: true}),
+      },
+    },
+  })
+  async getRolesByPermission(): Promise<Roles[]> {
+    return this.roleRepository.find({
+      where: {
+        permissions: {contains: ['View']},
+      },
+    } as AnyObject);
+  }
+
+  @get('/roles/sync-sequelize-model')
+  @response(200)
+  async syncSequelizeModel(): Promise<void> {
+    await this.beforeEach();
+  }
+}

--- a/extensions/sequelize/src/__tests__/fixtures/controllers/roles.controller.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/controllers/roles.controller.ts
@@ -40,7 +40,7 @@ export class RolesController extends TestControllerBase {
     return this.roleRepository.create(role);
   }
 
-  @get('/roles-desc')
+  @get('/roles')
   @response(200, {
     description: 'Role model instance',
     content: {
@@ -49,22 +49,7 @@ export class RolesController extends TestControllerBase {
       },
     },
   })
-  async getRolesByDesc(
-    @param.filter(Roles) filter?: Filter<Roles>,
-  ): Promise<Roles[]> {
-    return this.roleRepository.find(filter);
-  }
-
-  @get('/roles-perm')
-  @response(200, {
-    description: 'Role model instance',
-    content: {
-      'application/json': {
-        schema: getModelSchemaRef(Roles, {includeRelations: true}),
-      },
-    },
-  })
-  async getRolesByPermission(
+  async getRoles(
     @param.filter(Roles) filter?: Filter<Roles>,
   ): Promise<Roles[]> {
     return this.roleRepository.find(filter);

--- a/extensions/sequelize/src/__tests__/fixtures/controllers/roles.controller.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/controllers/roles.controller.ts
@@ -1,7 +1,8 @@
-import {AnyObject, repository} from '@loopback/repository';
+import {Filter, repository} from '@loopback/repository';
 import {
   get,
   getModelSchemaRef,
+  param,
   post,
   requestBody,
   response,
@@ -48,12 +49,10 @@ export class RolesController extends TestControllerBase {
       },
     },
   })
-  async getRolesByDesc(): Promise<Roles[]> {
-    return this.roleRepository.find({
-      where: {
-        description: {match: 'Others'},
-      } as AnyObject,
-    });
+  async getRolesByDesc(
+    @param.filter(Roles) filter?: Filter<Roles>,
+  ): Promise<Roles[]> {
+    return this.roleRepository.find(filter);
   }
 
   @get('/roles-perm')
@@ -65,12 +64,10 @@ export class RolesController extends TestControllerBase {
       },
     },
   })
-  async getRolesByPermission(): Promise<Roles[]> {
-    return this.roleRepository.find({
-      where: {
-        permissions: {contains: ['View']},
-      },
-    } as AnyObject);
+  async getRolesByPermission(
+    @param.filter(Roles) filter?: Filter<Roles>,
+  ): Promise<Roles[]> {
+    return this.roleRepository.find(filter);
   }
 
   @get('/roles/sync-sequelize-model')

--- a/extensions/sequelize/src/__tests__/fixtures/models/index.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/models/index.ts
@@ -6,6 +6,7 @@ export * from './doctor.model';
 export * from './patient.model';
 export * from './product.model';
 export * from './programming-language.model';
+export * from './roles.model';
 export * from './scoped-task.model';
 export * from './task.model';
 export * from './todo-list.model';

--- a/extensions/sequelize/src/__tests__/fixtures/models/roles.model.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/models/roles.model.ts
@@ -1,0 +1,36 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Roles extends Entity {
+  @property({
+    type: 'string',
+    id: true,
+    generated: true,
+  })
+  id?: string;
+
+  @property({
+    type: 'array',
+    itemType: 'string',
+    required: true,
+    postgresql: {
+      dataType: 'varchar[]',
+    },
+  })
+  permissions: string[];
+
+  @property({
+    type: 'string',
+  })
+  description?: string;
+
+  constructor(data?: Partial<Roles>) {
+    super(data);
+  }
+}
+
+export interface RolesRelations {
+  // describe navigational properties here
+}
+
+export type RoleWithRelations = Roles & RolesRelations;

--- a/extensions/sequelize/src/__tests__/fixtures/repositories/index.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/repositories/index.ts
@@ -6,6 +6,7 @@ export * from './doctor.repository';
 export * from './patient.repository';
 export * from './product.repository';
 export * from './programming-language.repository';
+export * from './roles.repository';
 export * from './scoped-task.repository';
 export * from './task.repository';
 export * from './todo-list.repository';

--- a/extensions/sequelize/src/__tests__/fixtures/repositories/roles.repository.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/repositories/roles.repository.ts
@@ -1,0 +1,14 @@
+import {inject} from '@loopback/core';
+import {SequelizeCrudRepository} from '../../../sequelize';
+import {PrimaryDataSource} from '../datasources/primary.datasource';
+import {Roles, RolesRelations} from '../models';
+
+export class RolesRepository extends SequelizeCrudRepository<
+  Roles,
+  typeof Roles.prototype.id,
+  RolesRelations
+> {
+  constructor(@inject('datasources.primary') dataSource: PrimaryDataSource) {
+    super(Roles, dataSource);
+  }
+}

--- a/extensions/sequelize/src/__tests__/integration/repository.integration.ts
+++ b/extensions/sequelize/src/__tests__/integration/repository.integration.ts
@@ -1022,7 +1022,7 @@ describe('Sequelize CRUD Repository (integration)', () => {
           } as AnyObject,
         };
         const roleByDesc = await client.get(
-          `/roles-desc?filter=${encodeURIComponent(JSON.stringify(filter))}`,
+          `/roles?filter=${encodeURIComponent(JSON.stringify(filter))}`,
         );
 
         expect(roleByDesc.body).to.have.properties(
@@ -1057,7 +1057,7 @@ describe('Sequelize CRUD Repository (integration)', () => {
           },
         } as AnyObject;
         const roleByDesc = await client.get(
-          `/roles-perm?filter=${encodeURIComponent(JSON.stringify(filter))}`,
+          `/roles?filter=${encodeURIComponent(JSON.stringify(filter))}`,
         );
 
         expect(roleByDesc.body).to.have.properties(

--- a/extensions/sequelize/src/__tests__/integration/repository.integration.ts
+++ b/extensions/sequelize/src/__tests__/integration/repository.integration.ts
@@ -1016,7 +1016,14 @@ describe('Sequelize CRUD Repository (integration)', () => {
           description: 'Others',
         };
         await client.post('/role').send(role2);
-        const roleByDesc = await client.get('/roles-desc');
+        const filter = {
+          where: {
+            description: {match: 'Others'},
+          } as AnyObject,
+        };
+        const roleByDesc = await client.get(
+          `/roles-desc?filter=${encodeURIComponent(JSON.stringify(filter))}`,
+        );
 
         expect(roleByDesc.body).to.have.properties(
           'permissions',
@@ -1044,7 +1051,14 @@ describe('Sequelize CRUD Repository (integration)', () => {
           description: 'Others',
         };
         await client.post('/role').send(role2);
-        const roleByDesc = await client.get('/roles-perm');
+        const filter = {
+          where: {
+            permissions: {contains: ['ViewTodo']},
+          },
+        } as AnyObject;
+        const roleByDesc = await client.get(
+          `/roles-perm?filter=${encodeURIComponent(JSON.stringify(filter))}`,
+        );
 
         expect(roleByDesc.body).to.have.properties(
           'permissions',

--- a/extensions/sequelize/src/sequelize/operator-translation.ts
+++ b/extensions/sequelize/src/sequelize/operator-translation.ts
@@ -29,4 +29,6 @@ export const operatorTranslations: {
   regexp: Op.regexp,
   and: Op.and,
   or: Op.or,
+  match: Op.match,
+  contains: Op.contains,
 };

--- a/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
@@ -899,7 +899,14 @@ export class SequelizeCrudRepository<
         ['Array', 'array'].includes(definition[propName].type.toString())
       ) {
         // Postgres only
-        dataType = DataTypes.ARRAY(DataTypes.INTEGER);
+        const stringTypeArray =
+          definition[propName].itemType === String ||
+          ['String', 'string'].includes(
+            definition[propName].itemType?.toString() || '',
+          );
+        dataType = stringTypeArray
+          ? DataTypes.ARRAY(DataTypes.STRING)
+          : DataTypes.ARRAY(DataTypes.INTEGER);
       }
 
       if (

--- a/packages/filter/src/query.ts
+++ b/packages/filter/src/query.ts
@@ -39,7 +39,9 @@ export type Operators =
   | 'nlike' // NOT LIKE
   | 'ilike' // ILIKE'
   | 'nilike' // NOT ILIKE
-  | 'regexp'; // REGEXP'
+  | 'regexp' // REGEXP'
+  | 'match' // match
+  | 'contains'; // for array
 
 /**
  * Matching predicate comparison


### PR DESCRIPTION
postgres supports extended operators but missing in sequelize

fix #10272

**Please provide a high-level description of the changes made by your pull request.**
postgres supports extended operators but missing in sequelize
added the supported operators 
also the array field was by default given integer[] type even if it was string[].
added to condition to check before giving a default value.


Include references to all related GitHub issues and other pull requests, for example:

Fixes #10272

Example app to test - https://github.com/yeshamavani/sequelize


## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
