### PR TITLE
fix(sequelize): parse JSON columns to objects for mysql dialect

### DIFF
--- a/extensions/sequelize/src/__tests__/fixtures/models/user.model.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/models/user.model.ts
@@ -35,6 +35,11 @@ export class User extends Entity {
   })
   email: string;
 
+  @property.array('string', {
+    name: 'phone_numbers',
+  })
+  phoneNumbers: string[];
+
   @property({
     type: 'boolean',
     default: false,

--- a/extensions/sequelize/src/__tests__/integration/repository.integration.ts
+++ b/extensions/sequelize/src/__tests__/integration/repository.integration.ts
@@ -754,9 +754,6 @@ describe('Sequelize CRUD Repository (integration)', () => {
       expect(
         repo.sequelizeModel.getAttributes().address.get,
       ).to.be.a.Function();
-      expect(
-        repo.sequelizeModel.getAttributes().phoneNumbers.get,
-      ).to.be.a.Function();
 
       const Model = repo.getSequelizeModel(User);
       const model = new Model();

--- a/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
@@ -999,8 +999,11 @@ export class SequelizeCrudRepository<
       // For dialects that do not support a native JSON type, we need to parse
       // string responses to JSON objects to preserve backwards compatibility with the Juggler ORM.
       // Example: https://github.com/loopbackio/loopback-connector-mysql/blob/edf176b09234b82796f925203ff006843e045498/lib/mysql.js#L476
+      // With Sequelize v6, some of the dialects like MariaDB and SQLite already parse JSON strings to JSON objects by default:
+      //  - https://github.com/sequelize/sequelize/blob/cb8ea88c9aa37b14c908fd34dff1afc603de2ea7/src/dialects/mariadb/query.js#L191
+      //  - https://github.com/sequelize/sequelize/blob/cb8ea88c9aa37b14c908fd34dff1afc603de2ea7/src/dialects/sqlite/query.js#L365
       if (
-        this.dataSource.sequelizeConfig.dialect !== 'postgres' &&
+        this.dataSource.sequelizeConfig.dialect === 'mysql' &&
         dataType === DataTypes.JSON
       ) {
         // See: https://sequelize.org/docs/v6/core-concepts/getters-setters-virtuals/

--- a/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
@@ -998,12 +998,8 @@ export class SequelizeCrudRepository<
 
       // For dialects that do not support a native JSON type, we need to parse
       // string responses to JSON objects to preserve backwards compatibility with the Juggler ORM.
-      // Example: https://github.com/loopbackio/loopback-connector-mysql/blob/edf176b09234b82796f925203ff006843e045498/lib/mysql.js#L476
-      // With Sequelize v6, some of the dialects like MariaDB and SQLite already parse JSON strings to JSON objects by default:
-      //  - https://github.com/sequelize/sequelize/blob/cb8ea88c9aa37b14c908fd34dff1afc603de2ea7/src/dialects/mariadb/query.js#L191
-      //  - https://github.com/sequelize/sequelize/blob/cb8ea88c9aa37b14c908fd34dff1afc603de2ea7/src/dialects/sqlite/query.js#L365
       if (
-        this.dataSource.sequelizeConfig.dialect === 'mysql' &&
+        this.dataSource.parseJsonColumns === true &&
         dataType === DataTypes.JSON
       ) {
         // See: https://sequelize.org/docs/v6/core-concepts/getters-setters-virtuals/


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

By parsing the values to JSON objects, provide backward compatibility for JSON and Array entity properties when using dialects like MySQL, MariaDB, or SQLite.

Fixes: #9629
Fixes: #9598

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
