### PR TITLE
chore: drop Node.js 16 support

### DIFF
--- a/acceptance/extension-logging-fluentd/package.json
+++ b/acceptance/extension-logging-fluentd/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/extension-logging-fluentd"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-cloudant/package.json
+++ b/acceptance/repository-cloudant/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/repository-cloudant"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-mongodb/package.json
+++ b/acceptance/repository-mongodb/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/repository-mongodb"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-mysql/package.json
+++ b/acceptance/repository-mysql/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/repository-mysql"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-postgresql/package.json
+++ b/acceptance/repository-postgresql/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/repository-postgresql"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -19,7 +19,7 @@
     "directory": "benchmark"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/bodyparsers/rest-msgpack/package.json
+++ b/bodyparsers/rest-msgpack/package.json
@@ -13,7 +13,7 @@
     "directory": "bodyparsers/rest-msgpack"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "directory": "docs"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "version": "node ./bin/copy-readmes.js && node ./bin/copy-changelogs.js && cd .. && npm run tsdocs",

--- a/examples/access-control-migration/package.json
+++ b/examples/access-control-migration/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/access-control-migration"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/binding-resolution/package.json
+++ b/examples/binding-resolution/package.json
@@ -21,7 +21,7 @@
     "directory": "examples/binding-resolution"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/context/package.json
+++ b/examples/context/package.json
@@ -19,7 +19,7 @@
     "directory": "examples/context"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -20,7 +20,7 @@
     "directory": "examples/express-composition"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/file-transfer/package.json
+++ b/examples/file-transfer/package.json
@@ -20,7 +20,7 @@
     "directory": "examples/file-transfer"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -17,7 +17,7 @@
     "directory": "examples/graphql"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/loopbackio/loopback-next/issues"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/greeting-app/package.json
+++ b/examples/greeting-app/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/loopbackio/loopback-next/issues"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -19,7 +19,7 @@
     "directory": "examples/hello-world"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/lb3-application/package.json
+++ b/examples/lb3-application/package.json
@@ -18,7 +18,7 @@
     "directory": "examples/lb3-application"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/loopbackio/loopback-next/issues"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/metrics-prometheus/package.json
+++ b/examples/metrics-prometheus/package.json
@@ -19,7 +19,7 @@
     "directory": "examples/metrics-prometheus"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/multi-tenancy/package.json
+++ b/examples/multi-tenancy/package.json
@@ -18,7 +18,7 @@
     "directory": "examples/multi-tenancy"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/passport-login/package.json
+++ b/examples/passport-login/package.json
@@ -21,7 +21,7 @@
     "directory": "examples/passport-login"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/references-many/package.json
+++ b/examples/references-many/package.json
@@ -24,7 +24,7 @@
     "directory": "examples/references-many"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/rest-crud/package.json
+++ b/examples/rest-crud/package.json
@@ -21,7 +21,7 @@
     "directory": "examples/rest-crud"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -17,7 +17,7 @@
     "directory": "examples/rpc-server"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -20,7 +20,7 @@
     "directory": "examples/soap-calculator"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/socketio/package.json
+++ b/examples/socketio/package.json
@@ -17,7 +17,7 @@
     "directory": "examples/socketio"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/todo-jwt/package.json
+++ b/examples/todo-jwt/package.json
@@ -24,7 +24,7 @@
     "directory": "examples/todo-jwt"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -24,7 +24,7 @@
     "directory": "examples/todo-list"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/todo"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/validation-app/package.json
+++ b/examples/validation-app/package.json
@@ -19,7 +19,7 @@
     "directory": "examples/validation-app"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -20,7 +20,7 @@
     "directory": "examples/webpack"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/apiconnect/package.json
+++ b/extensions/apiconnect/package.json
@@ -17,7 +17,7 @@
     "directory": "extensions/apiconnect"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/authentication-jwt/package.json
+++ b/extensions/authentication-jwt/package.json
@@ -18,7 +18,7 @@
     "directory": "extensions/authentication-jwt"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/authentication-passport/package.json
+++ b/extensions/authentication-passport/package.json
@@ -18,7 +18,7 @@
     "directory": "extensions/authentication-passport"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/context-explorer/package.json
+++ b/extensions/context-explorer/package.json
@@ -19,7 +19,7 @@
     "directory": "extensions/context-explorer"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/cron/package.json
+++ b/extensions/cron/package.json
@@ -18,7 +18,7 @@
     "directory": "extensions/cron"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/graphql/package.json
+++ b/extensions/graphql/package.json
@@ -17,7 +17,7 @@
     "directory": "extensions/graphql"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/health/package.json
+++ b/extensions/health/package.json
@@ -18,7 +18,7 @@
     "directory": "extensions/health"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/logging/package.json
+++ b/extensions/logging/package.json
@@ -20,7 +20,7 @@
     "directory": "extensions/logging"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/metrics/package.json
+++ b/extensions/metrics/package.json
@@ -19,7 +19,7 @@
     "directory": "extensions/metrics"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/pooling/package.json
+++ b/extensions/pooling/package.json
@@ -17,7 +17,7 @@
     "directory": "extensions/pooling"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/sequelize/package.json
+++ b/extensions/sequelize/package.json
@@ -19,7 +19,7 @@
     "directory": "extensions/sequelize"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/socketio/package.json
+++ b/extensions/socketio/package.json
@@ -21,7 +21,7 @@
     "directory": "extensions/socketio"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/typeorm/package.json
+++ b/extensions/typeorm/package.json
@@ -13,7 +13,7 @@
     "directory": "extensions/typeorm"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/fixtures/mock-oauth2-provider/package.json
+++ b/fixtures/mock-oauth2-provider/package.json
@@ -13,7 +13,7 @@
     "directory": "fixtures/mock-oauth2-provider"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/fixtures/tsdocs-monorepo/package.json
+++ b/fixtures/tsdocs-monorepo/package.json
@@ -12,7 +12,7 @@
     "directory": "fixtures/tsdocs-monorepo"
   },
   "engines": {
-    "node": "16 || 18 || 20",
+    "node": "18 || 20",
     "npm": ">=7"
   },
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20",
+        "node": "18 || 20",
         "npm": ">=7"
       }
     },
@@ -62,7 +62,7 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "acceptance/extension-logging-fluentd/node_modules/@types/node": {
@@ -92,7 +92,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "acceptance/repository-cloudant/node_modules/@types/node": {
@@ -116,7 +116,7 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "acceptance/repository-mongodb/node_modules/@types/node": {
@@ -140,7 +140,7 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "acceptance/repository-mysql/node_modules/@types/node": {
@@ -164,7 +164,7 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "acceptance/repository-postgresql/node_modules/@types/node": {
@@ -204,7 +204,7 @@
         "source-map-support": "^0.5.21"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "benchmark/node_modules/@types/node": {
@@ -233,7 +233,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0",
@@ -258,7 +258,7 @@
         "@loopback/build": "^10.1.5"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/access-control-migration": {
@@ -293,7 +293,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/access-control-migration/node_modules/@types/node": {
@@ -324,7 +324,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/binding-resolution/node_modules/@types/node": {
@@ -350,7 +350,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/context/node_modules/@types/node": {
@@ -383,7 +383,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/express-composition/node_modules/@types/node": {
@@ -415,7 +415,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/file-transfer/node_modules/@types/node": {
@@ -449,7 +449,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/graphql/node_modules/@types/node": {
@@ -478,7 +478,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/greeter-extension/node_modules/@types/node": {
@@ -510,7 +510,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/greeting-app/node_modules/@types/node": {
@@ -537,7 +537,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/hello-world/node_modules/@types/node": {
@@ -579,7 +579,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/lb3-application/node_modules/@types/node": {
@@ -609,7 +609,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/log-extension/node_modules/@types/node": {
@@ -638,7 +638,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/metrics-prometheus/node_modules/@types/node": {
@@ -674,7 +674,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/multi-tenancy/node_modules/@types/node": {
@@ -741,7 +741,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/passport-login/node_modules/@types/node": {
@@ -777,7 +777,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/references-many/node_modules/@types/node": {
@@ -812,7 +812,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/rest-crud/node_modules/@types/node": {
@@ -840,7 +840,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/rpc-server/node_modules/@types/node": {
@@ -875,7 +875,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/soap-calculator/node_modules/@types/node": {
@@ -910,7 +910,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/socketio/node_modules/@types/node": {
@@ -947,7 +947,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/todo-jwt": {
@@ -981,7 +981,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/todo-jwt/node_modules/@types/node": {
@@ -1017,7 +1017,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/todo-list/node_modules/@types/node": {
@@ -1056,7 +1056,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/validation-app/node_modules/@types/node": {
@@ -1091,7 +1091,7 @@
         "webpack-cli": "^5.1.4"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "examples/webpack/node_modules/@types/node": {
@@ -1116,7 +1116,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0",
@@ -1158,7 +1158,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/authentication": "^10.0.0",
@@ -1210,7 +1210,7 @@
         "supertest": "^6.3.3"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/authentication": "^10.0.0",
@@ -1258,7 +1258,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0",
@@ -1290,7 +1290,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0"
@@ -1329,7 +1329,7 @@
         "class-transformer": "^0.5.1"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/boot": "^6.0.0",
@@ -1359,7 +1359,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0",
@@ -1393,7 +1393,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0",
@@ -1425,7 +1425,7 @@
         "express": "^4.18.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0",
@@ -1456,7 +1456,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0"
@@ -1492,7 +1492,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0",
@@ -1529,7 +1529,7 @@
         "socket.io-client": "^4.7.3"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/boot": "^6.0.0",
@@ -1559,7 +1559,7 @@
         "sqlite3": "^5.1.4"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/boot": "^6.0.0",
@@ -1721,7 +1721,7 @@
         "@loopback/testlab": "^6.1.5"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "fixtures/mock-oauth2-provider/node_modules/@types/node": {
@@ -1740,7 +1740,7 @@
         "@loopback/build": "^10.1.5"
       },
       "engines": {
-        "node": "16 || 18 || 20",
+        "node": "18 || 20",
         "npm": ">=7"
       }
     },
@@ -36008,7 +36008,7 @@
         "jsonwebtoken": "^9.0.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0",
@@ -36039,7 +36039,7 @@
         "casbin": "^5.28.0"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0"
@@ -36075,7 +36075,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0"
@@ -36116,7 +36116,7 @@
         "loopback-boot": "^3.3.1"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/boot": "^6.0.0",
@@ -36161,7 +36161,7 @@
         "lb-ttsc": "bin/compile-package.js"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "packages/build/node_modules/@types/node": {
@@ -36242,7 +36242,7 @@
         "yeoman-test": "^6.3.0"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "packages/cli/node_modules/@types/node": {
@@ -36274,7 +36274,7 @@
         "bluebird": "^3.7.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "packages/context/node_modules/@types/node": {
@@ -36300,7 +36300,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "packages/core/node_modules/@types/node": {
@@ -36321,7 +36321,7 @@
         "eslint-plugin-mocha": "^10.2.0"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "eslint": "^8.51.0"
@@ -36357,7 +36357,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0"
@@ -36383,7 +36383,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "packages/filter/node_modules/@types/node": {
@@ -36415,7 +36415,7 @@
         "tunnel": "0.0.6"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "packages/http-caching-proxy/node_modules/@types/node": {
@@ -36443,7 +36443,7 @@
         "@types/stoppable": "^1.1.3"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "packages/http-server/node_modules/@types/node": {
@@ -36471,7 +36471,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "packages/metadata/node_modules/@types/node": {
@@ -36494,7 +36494,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0",
@@ -36522,7 +36522,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "packages/openapi-spec-builder/node_modules/@types/node": {
@@ -36557,7 +36557,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0"
@@ -36592,7 +36592,7 @@
         "bson": "5.5.1"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0"
@@ -36618,7 +36618,7 @@
         "ajv-formats": "^2.1.1"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0",
@@ -36651,7 +36651,7 @@
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0",
@@ -36725,7 +36725,7 @@
         "multer": "^1.4.4"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0"
@@ -36750,7 +36750,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0",
@@ -36785,7 +36785,7 @@
         "express": "^4.18.2"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0",
@@ -36820,7 +36820,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0"
@@ -36848,7 +36848,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       },
       "peerDependencies": {
         "@loopback/core": "^5.0.0"
@@ -36885,7 +36885,7 @@
         "@types/node": "^16.18.70"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "packages/testlab/node_modules/@types/node": {
@@ -36925,7 +36925,7 @@
         "@types/npmcli__package-json": "^4.0.3"
       },
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "packages/tsdocs/node_modules/@types/node": {
@@ -36939,7 +36939,7 @@
       "version": "5.0.0",
       "license": "MIT",
       "engines": {
-        "node": "16 || 18 || 20"
+        "node": "18 || 20"
       }
     },
     "sandbox/loopback.io": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "16 || 18 || 20",
+    "node": "18 || 20",
     "npm": ">=7"
   },
   "private": true,

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/authentication"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/authorization"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/boot"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/boot/src/__tests__/fixtures/package.json
+++ b/packages/boot/src/__tests__/fixtures/package.json
@@ -7,7 +7,7 @@
     "loopback"
   ],
   "engines": {
-    "node": "12 || 14 || 16 || 17"
+    "node": "18 || 20"
   },
   "scripts": {},
   "repository": {

--- a/packages/booter-lb3app/package.json
+++ b/packages/booter-lb3app/package.json
@@ -19,7 +19,7 @@
     "directory": "packages/booter-lb3app"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -21,7 +21,7 @@
     "directory": "packages/build"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "test": "npm run mocha",

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -12,7 +12,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -12,7 +12,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "directory": "packages/cli"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "test": "lb-mocha --lang en_US.UTF-8 \"test/**/*.js\"",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -22,7 +22,7 @@
     "directory": "packages/context"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/core"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/eslint-config"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/express"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/filter"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -20,7 +20,7 @@
     "directory": "packages/http-caching-proxy"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/http-server"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/metadata"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/model-api-builder/package.json
+++ b/packages/model-api-builder/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/model-api-builder"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -20,7 +20,7 @@
     "directory": "packages/openapi-spec-builder"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/openapi-v3"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/repository-json-schema"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/repository-tests/package.json
+++ b/packages/repository-tests/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/repository-tests"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/repository"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/rest-crud/package.json
+++ b/packages/rest-crud/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/rest-crud"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/rest-explorer"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/rest"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/security"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/service-proxy"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/testlab"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/tsdocs/package.json
+++ b/packages/tsdocs/package.json
@@ -23,7 +23,7 @@
     "directory": "packages/tsdocs"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "build:tsdocs": "npm run build && npm run -s extract-apidocs && npm run -s document-apidocs && npm run -s update-apidocs",

--- a/sandbox/example/package.json
+++ b/sandbox/example/package.json
@@ -13,7 +13,7 @@
     "directory": "sandbox/example"
   },
   "engines": {
-    "node": "16 || 18 || 20"
+    "node": "18 || 20"
   },
   "scripts": {
     "test": "echo \"This is an example for sandbox\""


### PR DESCRIPTION
BREAKING CHANGE: Drop Node.js 16 support in all LB4 modules and extensions

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
