### PR TITLE
fix(sequelize): modified regex to match select query with parenthesis

### DIFF
--- a/extensions/sequelize/src/sequelize/sequelize.datasource.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.datasource.base.ts
@@ -209,7 +209,7 @@ export class SequelizeDataSource implements LifeCycleObserver {
     // Sequelize returns the select query result in an array at index 0 and at index 1 is the actual Result instance
     // Whereas in juggler it is returned directly as plain array.
     // Below condition maps that 0th index to final result to match juggler's behaviour
-    if (command.match(/^select/i) && result.length >= 1) {
+    if (command.match(/^(select|\(select)/i) && result.length >= 1) {
       return result[0];
     }
 


### PR DESCRIPTION
modified regex to match select query with parenthesis

fix #10312

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
