### PR TITLE
For for MySQL connector on UpdateById when an existing entity update lead to Entity Not Found errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ benchmark/dist
 # Docs preview
 docs/_loopback.io/
 docs/_preview/
+
+#Vscode local history
+.history

--- a/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
@@ -227,7 +227,13 @@ export class SequelizeCrudRepository<
     (where as AnyObject)[idProp] = id;
     const result = await this.updateAll(data, where, options);
     if (result.count === 0) {
-      throw new EntityNotFoundError(this.entityClass, id);
+      // as MySQL didn't provide affected rows when the values are same as what database have
+      if (this.dataSource.config.connector === 'mysql') {
+        const entity = await this.findById(id);
+        if (!entity) throw new EntityNotFoundError(this.entityClass, id);
+      } else {
+        throw new EntityNotFoundError(this.entityClass, id);
+      }
     }
   }
 

--- a/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
+++ b/extensions/sequelize/src/sequelize/sequelize.repository.base.ts
@@ -228,9 +228,8 @@ export class SequelizeCrudRepository<
     const result = await this.updateAll(data, where, options);
     if (result.count === 0) {
       // as MySQL didn't provide affected rows when the values are same as what database have
-      if (this.dataSource.config.connector === 'mysql') {
-        const entity = await this.findById(id);
-        if (!entity) throw new EntityNotFoundError(this.entityClass, id);
+      if (this.dataSource.sequelizeConfig.dialect === 'mysql') {
+        await this.findById(id);
       } else {
         throw new EntityNotFoundError(this.entityClass, id);
       }


### PR DESCRIPTION
"MySQL 'updateById' triggers 'entity not found' due to 0 affected rows."

An 'entity not found' error is triggered during the execution of 'updateById' on a MySQL connector. This behavior is attributed to MySQL's practice of reporting 0 affected rows when no changes are made, as outlined in the MySQL C API documentation (https://dev.mysql.com/doc/c-api/8.3/en/mysql-affected-rows.html).

Fixes: [#9618](https://github.com/loopbackio/loopback-next/issues/9618)

## Checklist

- [X] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [X] `npm test` passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
