### PR TITLE
change dataSource to datasource

### DIFF
--- a/docs/site/Discovering-models.md
+++ b/docs/site/Discovering-models.md
@@ -35,7 +35,8 @@ Models can be discovered from a supported datasource by running the
 
 ### Options
 
-`--dataSource`: Put a valid datasource name here to skip the datasource prompt
+`--dataSource or --datasource`: Put a valid datasource name here to skip the
+datasource prompt
 
 `--views`: Choose whether to discover views. Default is true
 

--- a/packages/cli/.yo-rc.json
+++ b/packages/cli/.yo-rc.json
@@ -1243,6 +1243,12 @@
           "name": "dataSource",
           "hide": false
         },
+        "datasource": {
+          "type": "String",
+          "description": "The name of the datasource to discover",
+          "name": "datasource",
+          "hide": false
+        },
         "views": {
           "type": "Boolean",
           "description": "Boolean to discover views",

--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -25,6 +25,11 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
       description: g.f('The name of the datasource to discover'),
     });
 
+    this.option('datasource', {
+      type: String,
+      description: g.f('The name of the datasource to discover'),
+    });
+
     this.option('views', {
       type: Boolean,
       description: g.f('Boolean to discover views'),
@@ -88,10 +93,12 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
    */
   setOptions() {
     /* istanbul ignore next */
-    if (this.options.dataSource) {
-      debug(`Data source specified: ${this.options.dataSource}`);
+    if (this.options.dataSource || this.options.datasource) {
+      debug(
+        `Data source specified: ${this.options.dataSource || this.options.datasource}`,
+      );
       this.artifactInfo.dataSource = modelMaker.loadDataSourceByName(
-        this.options.dataSource,
+        this.options.dataSource || this.options.datasource,
       );
     }
     // remove not needed .env property
@@ -132,15 +139,15 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
         path.resolve(dsDir, `${utils.toFileName(s)}.datasource.js`),
       ),
     );
-    if (this.options.dataSource) {
+    if (this.options.dataSource || this.options.datasource) {
       if (
         this.dataSourceChoices
           .map(d => d.name)
-          .includes(this.options.dataSource)
+          .includes(this.options.dataSource || this.options.datasource)
       ) {
         Object.assign(this.artifactInfo, {
           dataSource: this.dataSourceChoices.find(
-            d => d.name === this.options.dataSource,
+            d => d.name === this.options.dataSource || this.options.datasource,
           ),
         });
       }

--- a/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
@@ -1301,6 +1301,12 @@ exports[`cli saves command metadata to .yo-rc.json 1`] = `
           "name": "dataSource",
           "hide": false
         },
+        "datasource": {
+          "type": "String",
+          "description": "The name of the datasource to discover",
+          "name": "datasource",
+          "hide": false
+        },
         "views": {
           "type": "Boolean",
           "description": "Boolean to discover views",

--- a/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
@@ -7,6 +7,56 @@
 
 'use strict';
 
+exports[`lb4 discover integration generates all models without prompts using --all --datasource 1`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Schema extends Entity {
+  // Define well-known properties here
+
+  // Indexer property to allow additional data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [prop: string]: any;
+
+  constructor(data?: Partial<Schema>) {
+    super(data);
+  }
+}
+
+export interface SchemaRelations {
+  // describe navigational properties here
+}
+
+export type SchemaWithRelations = Schema & SchemaRelations;
+
+`;
+
+
+exports[`lb4 discover integration generates all models without prompts using --all --datasource 2`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class View extends Entity {
+  // Define well-known properties here
+
+  // Indexer property to allow additional data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [prop: string]: any;
+
+  constructor(data?: Partial<View>) {
+    super(data);
+  }
+}
+
+export interface ViewRelations {
+  // describe navigational properties here
+}
+
+export type ViewWithRelations = View & ViewRelations;
+
+`;
+
+
 exports[`lb4 discover integration model discovery does not mark id property as required based on optionalId option 1`] = `
 import {Entity, model, property} from '@loopback/repository';
 

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -69,6 +69,12 @@ const specificModelsOptions = {
   views: false,
   disableCamelCase: true,
 };
+
+const baseOptionsWithSmallS = {
+  all: true,
+  datasource: 'mem',
+};
+
 // Expected File Name
 const defaultExpectedTestModel = path.join(
   sandbox.path,
@@ -230,5 +236,21 @@ describe('lb4 discover integration', () => {
 
     basicModelFileChecks(defaultExpectedTestModel, defaultExpectedIndexFile);
     assert.file(defaultExpectedTestModel);
+  });
+
+  it('generates all models without prompts using --all --datasource', /** @this {Mocha.Context} */ async function () {
+    this.timeout(10000);
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(sandbox.path, () =>
+        testUtils.givenLBProject(sandbox.path, {
+          additionalFiles: SANDBOX_FILES,
+        }),
+      )
+      .withOptions(baseOptionsWithSmallS);
+
+    basicModelFileChecks(defaultExpectedTestModel, defaultExpectedIndexFile);
+    expectFileToMatchSnapshot(defaultExpectedSchemaModel);
+    expectFileToMatchSnapshot(defaultExpectedViewModel);
   });
 });


### PR DESCRIPTION
The `lb4 discoverer` names the argument to pass datasource as "dataSource". This PR makes the argument consistent with the `lb4 datasource` without breaking existing cli command 'lb4 dataSource'.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
