### PR TITLE
fix(build): correctly join file paths on windows when copying resources

### DIFF
--- a/packages/build/bin/compile-package.js
+++ b/packages/build/bin/compile-package.js
@@ -271,7 +271,7 @@ function copyResources(rootDir, packageDir, tsConfigFile, outDir, options) {
      * Trim path that matches tsConfig.compilerOptions.rootDir
      */
     let targetFile = file;
-    if (compilerRootDir && file.startsWith(compilerRootDir + '/')) {
+    if (compilerRootDir && file.startsWith(path.join(compilerRootDir + '/'))) {
       targetFile = file.substring(compilerRootDir.length + 1);
     }
 


### PR DESCRIPTION
On Windows resources aren't copied to the dist directory.

This is because `glob` changed the behavior of file resolving on version 9 and now uses `\` instead of `/`. 

This commit joins the paths to be cross-platform compatible.