### PR TITLE
fix: correct MongoDB ID conversion in hasManyThrough relations

### DIFF
--- a/packages/repository/src/relations/has-many/has-many-through.inclusion-resolver.ts
+++ b/packages/repository/src/relations/has-many/has-many-through.inclusion-resolver.ts
@@ -251,7 +251,8 @@ export function createHasManyThroughInclusionResolver<
       );
 
       const targetEntityIds = targetEntityList.map(
-        targetEntity => targetEntity[targetKey],
+        targetEntity =>
+          targetEntity[targetKey]?.toString() ?? targetEntity[targetKey],
       );
 
       const targetEntityMap = Object.fromEntries(
@@ -264,7 +265,9 @@ export function createHasManyThroughInclusionResolver<
       // convert from through entities to the target entities
       for (const entityList of throughResult) {
         if (entityList) {
-          const relatedIds = entityList.map(x => x[throughKeyTo]);
+          const relatedIds = entityList.map(
+            x => x[throughKeyTo]?.toString() ?? x[throughKeyTo],
+          );
 
           // Use the order of the original result set & apply limit
           const sortedIds = _.intersection(


### PR DESCRIPTION
This pull request addresses an issue where MongoDB ID was causing problems in hasManyThrough relations. The solution implemented attempts conversion to a string type using the toString() function for both related and entity IDs. If the [toString()](https://www.mongodb.com/docs/manual/reference/method/ObjectId.toString/) function does not exist, the ID is used as it is. This ensures consistency in ID types, allowing the [intersection](https://github.com/loopbackio/loopback-next/blob/4407b5a040a9cde22c434d798a3450f0d122664b/packages/repository/src/relations/has-many/has-many-through.inclusion-resolver.ts#L270) function to work correctly.

Fixes #10259 


## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
