### PR TITLE
docs: mention another possible type of index attribute (object)

### DIFF
--- a/docs/site/Model.md
+++ b/docs/site/Model.md
@@ -558,8 +558,8 @@ Here are general attributes for property definitions:
     <tr>
       <td><code>index</code></td>
       <td>No</td>
-      <td>Boolean</td>
-      <td>Whether the property represents a column (field) that is a database index.</td>
+      <td>Boolean | Object</td>
+      <td>If boolean it shows whether the property represents a column (field) that is a database index. It can be an object, for example, `index: {unique: true}` to make a property unique. Note: This depends on connector whether it supports or not.</td>
     </tr>
     <tr>
       <td><code>required</code></td>


### PR DESCRIPTION
The [docs for Property Decorator](https://loopback.io/doc/en/lb4/Model.html#property-decorator) mentions that the index is a boolean type. But it can have an object like `index: {unique: true}`  to apply a particular index. This PR fixes the document and adds the required details.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
