### PR TITLE
chore: add Node.js 22 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,12 +20,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [16, 18, 20]
+        node-version: [18, 20, 22]
         include:
           - os: windows-latest
-            node-version: 18 # LTS
+            node-version: 20 # LTS
           - os: macos-latest
-            node-version: 18 # LTS
+            node-version: 20 # LTS
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 18 # LTS
+          node-version: 20 # LTS
       - name: Install dependencies
         run: npm ci
       - name: Build
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 18 # LTS
+          node-version: 20 # LTS
       - name: Install dependencies
         run: npm ci
       - name: Build
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 18 # LTS
+          node-version: 20 # LTS
       - name: Install dependencies
         run: npm ci
       - name: Verify commit linting
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 18 # LTS
+          node-version: 20 # LTS
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -20,6 +20,6 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 18 # LTS
+          node-version: 20 # LTS
       - name: Validate Renovate config
         run: npx -p renovate --yes renovate-config-validator

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,8 +16,8 @@
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true,
-    "source.fixAll.eslint": true
+    "source.organizeImports": "explicit",
+    "source.fixAll.eslint": "explicit"
   },
   "files.eol": "\n",
   "files.exclude": {

--- a/acceptance/extension-logging-fluentd/package.json
+++ b/acceptance/extension-logging-fluentd/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/extension-logging-fluentd"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-cloudant/package.json
+++ b/acceptance/repository-cloudant/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/repository-cloudant"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-mongodb/package.json
+++ b/acceptance/repository-mongodb/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/repository-mongodb"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-mysql/package.json
+++ b/acceptance/repository-mysql/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/repository-mysql"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-postgresql/package.json
+++ b/acceptance/repository-postgresql/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/repository-postgresql"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -19,7 +19,7 @@
     "directory": "benchmark"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/bodyparsers/rest-msgpack/package.json
+++ b/bodyparsers/rest-msgpack/package.json
@@ -13,7 +13,7 @@
     "directory": "bodyparsers/rest-msgpack"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "directory": "docs"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "version": "node ./bin/copy-readmes.js && node ./bin/copy-changelogs.js && cd .. && npm run tsdocs",

--- a/examples/access-control-migration/package.json
+++ b/examples/access-control-migration/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/access-control-migration"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/binding-resolution/package.json
+++ b/examples/binding-resolution/package.json
@@ -21,7 +21,7 @@
     "directory": "examples/binding-resolution"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/context/package.json
+++ b/examples/context/package.json
@@ -19,7 +19,7 @@
     "directory": "examples/context"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -20,7 +20,7 @@
     "directory": "examples/express-composition"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/file-transfer/package.json
+++ b/examples/file-transfer/package.json
@@ -20,7 +20,7 @@
     "directory": "examples/file-transfer"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -17,7 +17,7 @@
     "directory": "examples/graphql"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/loopbackio/loopback-next/issues"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/greeting-app/package.json
+++ b/examples/greeting-app/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/loopbackio/loopback-next/issues"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -19,7 +19,7 @@
     "directory": "examples/hello-world"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/lb3-application/package.json
+++ b/examples/lb3-application/package.json
@@ -18,7 +18,7 @@
     "directory": "examples/lb3-application"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/loopbackio/loopback-next/issues"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/metrics-prometheus/package.json
+++ b/examples/metrics-prometheus/package.json
@@ -19,7 +19,7 @@
     "directory": "examples/metrics-prometheus"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/multi-tenancy/package.json
+++ b/examples/multi-tenancy/package.json
@@ -18,7 +18,7 @@
     "directory": "examples/multi-tenancy"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/passport-login/package.json
+++ b/examples/passport-login/package.json
@@ -21,7 +21,7 @@
     "directory": "examples/passport-login"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/references-many/package.json
+++ b/examples/references-many/package.json
@@ -24,7 +24,7 @@
     "directory": "examples/references-many"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/rest-crud/package.json
+++ b/examples/rest-crud/package.json
@@ -21,7 +21,7 @@
     "directory": "examples/rest-crud"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -17,7 +17,7 @@
     "directory": "examples/rpc-server"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -20,7 +20,7 @@
     "directory": "examples/soap-calculator"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/socketio/package.json
+++ b/examples/socketio/package.json
@@ -17,7 +17,7 @@
     "directory": "examples/socketio"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/todo-jwt/package.json
+++ b/examples/todo-jwt/package.json
@@ -24,7 +24,7 @@
     "directory": "examples/todo-jwt"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -24,7 +24,7 @@
     "directory": "examples/todo-list"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/todo"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/validation-app/package.json
+++ b/examples/validation-app/package.json
@@ -19,7 +19,7 @@
     "directory": "examples/validation-app"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -20,7 +20,7 @@
     "directory": "examples/webpack"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/apiconnect/package.json
+++ b/extensions/apiconnect/package.json
@@ -17,7 +17,7 @@
     "directory": "extensions/apiconnect"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/authentication-jwt/package.json
+++ b/extensions/authentication-jwt/package.json
@@ -18,7 +18,7 @@
     "directory": "extensions/authentication-jwt"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/authentication-passport/package.json
+++ b/extensions/authentication-passport/package.json
@@ -18,7 +18,7 @@
     "directory": "extensions/authentication-passport"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/context-explorer/package.json
+++ b/extensions/context-explorer/package.json
@@ -19,7 +19,7 @@
     "directory": "extensions/context-explorer"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/cron/package.json
+++ b/extensions/cron/package.json
@@ -18,7 +18,7 @@
     "directory": "extensions/cron"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/graphql/package.json
+++ b/extensions/graphql/package.json
@@ -17,7 +17,7 @@
     "directory": "extensions/graphql"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/health/package.json
+++ b/extensions/health/package.json
@@ -18,7 +18,7 @@
     "directory": "extensions/health"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/logging/package.json
+++ b/extensions/logging/package.json
@@ -20,7 +20,7 @@
     "directory": "extensions/logging"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/metrics/package.json
+++ b/extensions/metrics/package.json
@@ -19,7 +19,7 @@
     "directory": "extensions/metrics"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/pooling/package.json
+++ b/extensions/pooling/package.json
@@ -17,7 +17,7 @@
     "directory": "extensions/pooling"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/sequelize/package.json
+++ b/extensions/sequelize/package.json
@@ -19,7 +19,7 @@
     "directory": "extensions/sequelize"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/socketio/package.json
+++ b/extensions/socketio/package.json
@@ -21,7 +21,7 @@
     "directory": "extensions/socketio"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/typeorm/package.json
+++ b/extensions/typeorm/package.json
@@ -13,7 +13,7 @@
     "directory": "extensions/typeorm"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/fixtures/mock-oauth2-provider/package.json
+++ b/fixtures/mock-oauth2-provider/package.json
@@ -13,7 +13,7 @@
     "directory": "fixtures/mock-oauth2-provider"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/fixtures/tsdocs-monorepo/package.json
+++ b/fixtures/tsdocs-monorepo/package.json
@@ -12,7 +12,7 @@
     "directory": "fixtures/tsdocs-monorepo"
   },
   "engines": {
-    "node": "18 || 20",
+    "node": "18 || 20 || 22",
     "npm": ">=7"
   },
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20",
+        "node": "18 || 20 || 22",
         "npm": ">=7"
       }
     },
@@ -62,7 +62,7 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "acceptance/extension-logging-fluentd/node_modules/@types/node": {
@@ -92,7 +92,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "acceptance/repository-cloudant/node_modules/@types/node": {
@@ -116,7 +116,7 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "acceptance/repository-mongodb/node_modules/@types/node": {
@@ -140,7 +140,7 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "acceptance/repository-mysql/node_modules/@types/node": {
@@ -164,7 +164,7 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "acceptance/repository-postgresql/node_modules/@types/node": {
@@ -204,7 +204,7 @@
         "source-map-support": "^0.5.21"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "benchmark/node_modules/@types/node": {
@@ -233,7 +233,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0",
@@ -258,7 +258,7 @@
         "@loopback/build": "^11.0.1"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/access-control-migration": {
@@ -293,7 +293,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/access-control-migration/node_modules/@types/node": {
@@ -324,7 +324,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/binding-resolution/node_modules/@types/node": {
@@ -350,7 +350,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/context/node_modules/@types/node": {
@@ -383,7 +383,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/express-composition/node_modules/@types/node": {
@@ -415,7 +415,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/file-transfer/node_modules/@types/node": {
@@ -449,7 +449,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/graphql/node_modules/@types/node": {
@@ -478,7 +478,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/greeter-extension/node_modules/@types/node": {
@@ -510,7 +510,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/greeting-app/node_modules/@types/node": {
@@ -537,7 +537,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/hello-world/node_modules/@types/node": {
@@ -578,7 +578,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/lb3-application/node_modules/@types/node": {
@@ -608,7 +608,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/log-extension/node_modules/@types/node": {
@@ -637,7 +637,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/metrics-prometheus/node_modules/@types/node": {
@@ -673,7 +673,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/multi-tenancy/node_modules/@types/node": {
@@ -740,7 +740,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/passport-login/node_modules/@types/node": {
@@ -775,7 +775,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/references-many/node_modules/@types/node": {
@@ -810,7 +810,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/rest-crud/node_modules/@types/node": {
@@ -838,7 +838,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/rpc-server/node_modules/@types/node": {
@@ -873,7 +873,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/soap-calculator/node_modules/@types/node": {
@@ -908,7 +908,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/socketio/node_modules/@types/node": {
@@ -945,7 +945,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/todo-jwt": {
@@ -979,7 +979,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/todo-jwt/node_modules/@types/node": {
@@ -1014,7 +1014,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/todo-list/node_modules/@types/node": {
@@ -1053,7 +1053,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/validation-app/node_modules/@types/node": {
@@ -1088,7 +1088,7 @@
         "webpack-cli": "^5.1.4"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "examples/webpack/node_modules/@types/node": {
@@ -1113,7 +1113,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0",
@@ -1155,7 +1155,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/authentication": "^11.0.0",
@@ -1207,7 +1207,7 @@
         "supertest": "^6.3.3"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/authentication": "^11.0.0",
@@ -1255,7 +1255,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0",
@@ -1287,7 +1287,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0"
@@ -1326,7 +1326,7 @@
         "class-transformer": "^0.5.1"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/boot": "^7.0.0",
@@ -1356,7 +1356,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0",
@@ -1390,7 +1390,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0",
@@ -1422,7 +1422,7 @@
         "express": "^4.19.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0",
@@ -1453,7 +1453,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0"
@@ -1489,7 +1489,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0",
@@ -1526,7 +1526,7 @@
         "socket.io-client": "^4.7.5"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/boot": "^7.0.0",
@@ -1556,7 +1556,7 @@
         "sqlite3": "^5.1.4"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/boot": "^7.0.0",
@@ -1594,7 +1594,7 @@
         "@loopback/testlab": "^7.0.1"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "fixtures/mock-oauth2-provider/node_modules/@types/node": {
@@ -1613,7 +1613,7 @@
         "@loopback/build": "^11.0.1"
       },
       "engines": {
-        "node": "18 || 20",
+        "node": "18 || 20 || 22",
         "npm": ">=7"
       }
     },
@@ -36136,7 +36136,7 @@
         "jsonwebtoken": "^9.0.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0",
@@ -36167,7 +36167,7 @@
         "casbin": "^5.30.0"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0"
@@ -36203,7 +36203,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0"
@@ -36244,7 +36244,7 @@
         "loopback-boot": "^3.3.1"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/boot": "^7.0.0",
@@ -36289,7 +36289,7 @@
         "lb-ttsc": "bin/compile-package.js"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "packages/build/node_modules/@types/node": {
@@ -36370,7 +36370,7 @@
         "yeoman-test": "^6.3.0"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "packages/cli/node_modules/@types/node": {
@@ -36427,7 +36427,7 @@
         "bluebird": "^3.7.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "packages/context/node_modules/@types/node": {
@@ -36453,7 +36453,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "packages/core/node_modules/@types/node": {
@@ -36474,7 +36474,7 @@
         "eslint-plugin-mocha": "^10.4.3"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "eslint": "^8.57.0"
@@ -36510,7 +36510,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0"
@@ -36536,7 +36536,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "packages/filter/node_modules/@types/node": {
@@ -36568,7 +36568,7 @@
         "tunnel": "0.0.6"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "packages/http-caching-proxy/node_modules/@types/node": {
@@ -36596,7 +36596,7 @@
         "@types/stoppable": "^1.1.3"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "packages/http-server/node_modules/@types/node": {
@@ -36624,7 +36624,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "packages/metadata/node_modules/@types/node": {
@@ -36647,7 +36647,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0",
@@ -36675,7 +36675,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "packages/openapi-spec-builder/node_modules/@types/node": {
@@ -36710,7 +36710,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0"
@@ -36745,7 +36745,7 @@
         "bson": "5.5.1"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0"
@@ -36771,7 +36771,7 @@
         "ajv-formats": "^2.1.1"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0",
@@ -36804,7 +36804,7 @@
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0",
@@ -36878,7 +36878,7 @@
         "multer": "^1.4.4"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0"
@@ -36903,7 +36903,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0",
@@ -36938,7 +36938,7 @@
         "express": "^4.19.2"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0",
@@ -36973,7 +36973,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0"
@@ -37001,7 +37001,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       },
       "peerDependencies": {
         "@loopback/core": "^6.0.0"
@@ -37038,7 +37038,7 @@
         "@types/node": "^16.18.96"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "packages/testlab/node_modules/@types/node": {
@@ -37078,7 +37078,7 @@
         "@types/npmcli__package-json": "^4.0.4"
       },
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "packages/tsdocs/node_modules/@types/node": {
@@ -37092,7 +37092,7 @@
       "version": "6.0.0",
       "license": "MIT",
       "engines": {
-        "node": "18 || 20"
+        "node": "18 || 20 || 22"
       }
     },
     "sandbox/loopback.io": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "18 || 20",
+    "node": "18 || 20 || 22",
     "npm": ">=7"
   },
   "private": true,

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/authentication"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/authorization"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/boot"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/boot/src/__tests__/fixtures/package.json
+++ b/packages/boot/src/__tests__/fixtures/package.json
@@ -7,7 +7,7 @@
     "loopback"
   ],
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {},
   "repository": {

--- a/packages/booter-lb3app/package.json
+++ b/packages/booter-lb3app/package.json
@@ -19,7 +19,7 @@
     "directory": "packages/booter-lb3app"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -21,7 +21,7 @@
     "directory": "packages/build"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "test": "npm run mocha",

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -12,7 +12,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -12,7 +12,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "directory": "packages/cli"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "test": "lb-mocha --lang en_US.UTF-8 \"test/**/*.js\"",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -22,7 +22,7 @@
     "directory": "packages/context"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/core"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/eslint-config"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/express"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/filter"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -20,7 +20,7 @@
     "directory": "packages/http-caching-proxy"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/http-server"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/metadata"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/model-api-builder/package.json
+++ b/packages/model-api-builder/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/model-api-builder"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -20,7 +20,7 @@
     "directory": "packages/openapi-spec-builder"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/openapi-v3"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/repository-json-schema"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/repository-tests/package.json
+++ b/packages/repository-tests/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/repository-tests"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/repository"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/rest-crud/package.json
+++ b/packages/rest-crud/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/rest-crud"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/rest-explorer"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/rest"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/rest/src/__tests__/unit/parser.unit.ts
+++ b/packages/rest/src/__tests__/unit/parser.unit.ts
@@ -11,14 +11,12 @@ import {
   SchemaObject,
 } from '@loopback/openapi-v3';
 import {
-  expect,
   ShotRequestOptions,
+  expect,
   stubExpressContext,
 } from '@loopback/testlab';
 import {
-  createResolvedRoute,
   JsonBodyParser,
-  parseOperationArgs,
   PathParameterValues,
   RawBodyParser,
   Request,
@@ -29,6 +27,8 @@ import {
   StreamBodyParser,
   TextBodyParser,
   UrlEncodedBodyParser,
+  createResolvedRoute,
+  parseOperationArgs,
 } from '../..';
 
 describe('operationArgsParser', () => {
@@ -343,7 +343,9 @@ describe('operationArgsParser', () => {
           details: {
             syntaxError:
               NODE_MAJOR_VERSION >= 19
-                ? "Expected ':' after property name in JSON at position 17"
+                ? NODE_MAJOR_VERSION >= 22
+                  ? "Expected ':' after property name in JSON at position 17 (line 1 column 18)"
+                  : "Expected ':' after property name in JSON at position 17"
                 : 'Unexpected token } in JSON at position 17',
           },
         }),

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/security"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/service-proxy"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/testlab"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/tsdocs/package.json
+++ b/packages/tsdocs/package.json
@@ -23,7 +23,7 @@
     "directory": "packages/tsdocs"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "build:tsdocs": "npm run build && npm run -s extract-apidocs && npm run -s document-apidocs && npm run -s update-apidocs",

--- a/sandbox/example/package.json
+++ b/sandbox/example/package.json
@@ -13,7 +13,7 @@
     "directory": "sandbox/example"
   },
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "test": "echo \"This is an example for sandbox\""


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Node.js 22 has released, and entering LTS in Oct. 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
