### PR TITLE
fix: revert lerna version to 8.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "fs-extra": "^11.2.0",
         "husky": "^9.0.11",
-        "lerna": "^8.1.3",
+        "lerna": "^8.1.2",
         "lint-staged": "^15.2.5",
         "markdown-table": "^3.0.3",
         "open-cli": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "fs-extra": "^11.2.0",
     "husky": "^9.0.11",
-    "lerna": "^8.1.3",
+    "lerna": "^8.1.2",
     "lint-staged": "^15.2.5",
     "markdown-table": "^3.0.3",
     "open-cli": "^8.0.0",


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

When trying to publish (running the command `npx lerna publish from-package`), it seems to be stuck even after a few trial. Saw someone [mentioning](https://github.com/lerna/lerna/issues/4010) downgrading from 8.1.3 to 8.1.2 works. So giving this a try.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
