### PR TITLE
fix: add quotes to param names containing hyphens

### DIFF
--- a/packages/cli/generators/openapi/spec-helper.js
+++ b/packages/cli/generators/openapi/spec-helper.js
@@ -354,7 +354,8 @@ function buildMethodSpec(controllerSpec, op, options) {
     methodParameters[methodName] = [];
     if (parameters) {
       parameters.forEach(param => {
-        methodParameters[methodName].push(param.name);
+        const {argName} = buildParameter(param, {});
+        methodParameters[methodName].push(argName);
       });
     }
     if (op.spec.requestBody) {


### PR DESCRIPTION

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
