### PR TITLE
fix: add condition to check type of property before parsing from json

### DIFF
--- a/packages/cli/generators/datasource/index.js
+++ b/packages/cli/generators/datasource/index.js
@@ -235,7 +235,9 @@ module.exports = class DataSourceGenerator extends ArtifactGenerator {
             if (props[key] == null || props[key] === '') {
               delete props[key];
             } else {
-              props[key] = JSON.parse(props[key]);
+              if (typeof props[key] === 'string') {
+                props[key] = JSON.parse(props[key]);
+              }
             }
             break;
         }

--- a/packages/cli/snapshots/integration/generators/datasource.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/datasource.integration.snapshots.js
@@ -146,6 +146,65 @@ export class DsDataSource extends juggler.DataSource
 
 `;
 
+exports[`lb4 datasource integration correctly coerces setting input of type object and array with config 1`] = `
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
+import {juggler} from '@loopback/repository';
+
+const config = {
+  name: 'ds',
+  connector: 'rest',
+  localConfigOnly: true,
+  sharedData: {},
+  forwardErrorToEnvironment: false,
+  skipInstall: true,
+  skipCache: true,
+  skipLocalCache: true,
+  force: true,
+  'skip-cache': true,
+  'skip-install': true,
+  resolved: '/home/aaqilniz/working-space/patrick/forked/loopback-next/packages/cli/generators/datasource/index.js',
+  namespace: 'home:aaqilniz:working-space:patrick:forked:loopback-next:packages:cli:datasource',
+  _: [],
+  config: '{"name":"ds","connector":"rest","options":"{\\"test\\": \\"value\\"}","operations":"[\\"get\\", \\"post\\"]"}',
+  yes: true,
+  'force-install': false,
+  'ask-answered': false,
+  c: '{"name":"ds","connector":"rest","options":"{\\"test\\": \\"value\\"}","operations":"[\\"get\\", \\"post\\"]"}',
+  y: [
+    '@@_YEOMAN_EMPTY_MARKER_@@',
+    true
+  ],
+  options: {
+    test: 'value'
+  },
+  operations: [
+    'get',
+    'post'
+  ],
+  baseURL: null,
+  crud: false
+};
+
+// Observe application's life cycle to disconnect the datasource when
+// application is stopped. This allows the application to be shut down
+// gracefully. The \`stop()\` method is inherited from \`juggler.DataSource\`.
+// Learn more at https://loopback.io/doc/en/lb4/Life-cycle.html
+@lifeCycleObserver('datasource')
+export class DsDataSource extends juggler.DataSource
+  implements LifeCycleObserver {
+  static dataSourceName = 'ds';
+  static readonly defaultConfig = config;
+
+  constructor(
+    @inject('datasources.config.ds', {optional: true})
+    dsConfig: object = config,
+  ) {
+    super(dsConfig);
+  }
+}
+
+`;
+
 
 exports[`lb4 datasource integration scaffolds correct file with cloudant input 1`] = `
 import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';

--- a/packages/cli/test/integration/generators/datasource.integration.js
+++ b/packages/cli/test/integration/generators/datasource.integration.js
@@ -131,6 +131,19 @@ describe('lb4 datasource integration', () => {
 
     checkDataSourceFilesAgainstSnapshot();
   });
+
+  it('correctly coerces setting input of type object and array with config', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
+      .withArguments([
+        '--config',
+        `${JSON.stringify(complexCLIInput)}`,
+        '--yes',
+      ]);
+
+    checkDataSourceFilesAgainstSnapshot();
+  });
 });
 
 function checkDataSourceFilesAgainstSnapshot() {


### PR DESCRIPTION
While generating a datasource based on the REST connector, the generator works fine with prompts. But it fails to work with --config option.

The connector fails to parse the incoming option that has object type (`options` and `operations` option) as the `config` has already been parsed at [`base-generator.js`](https://github.com/loopbackio/loopback-next/blob/master/packages/cli/lib/base-generator.js#L187).

The following works:

```
lb4 datasource 
? Datasource name: rest
? Select the connector for rest:  REST services (supported by StrongLoop)
? Base URL for the REST service: /sample
? Default options for the request: {"headers":{"Accept":"application/json","Content-Type":"application/json"}}
? An array of operation templates: []
? Use default CRUD mapping: No
```

But passing the same options as `config` fails:

```
lb4 datasource -c '{"name":"rest","connector":"rest","baseURL":"/sample","options":{"headers":{"Accept":"application/json","Content-Type":"application/json"}}, "operations":[]}' --yes
```

To fix this, I have added a check (to see if it is a string - hence not been parsed) before parsing the options at the datasource generator.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
