### PR TITLE
fix: add enum values to MySQL object of property decorator

### DIFF
--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -426,10 +426,16 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
           enumValuesArray.forEach(item => {
             enumItems += `'${item}',`;
           });
+          const enumItemString = enumItems.toString().replace(/,\s*$/, '');
           templateData.properties[key]['type'] = 'String';
           templateData.properties[key]['tsType'] = 'string';
           templateData.properties[key]['jsonSchema'] =
-            `{enum: [${enumItems.toString()}]}`;
+            `{enum: [${enumItemString}]}`;
+          const mysqlString = templateData.properties[key]['mysql'];
+          templateData.properties[key]['mysql'] = mysqlString.replace(
+            "'enum',",
+            `'enum', value: "${enumItemString}",`,
+          );
         }
       });
       this.copyTemplatedFiles(


### PR DESCRIPTION
## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
