### PR TITLE
docs(docs): fix incorrect directory name for base repository classes

### DIFF
--- a/docs/site/Repository-generator.md
+++ b/docs/site/Repository-generator.md
@@ -93,7 +93,7 @@ The tool will prompt you for:
   skipped, otherwise it will present you a list of repositories. The default
   repository is inferred from the datasource type.
 
-  Any repository in the `src/repository` folder with the file format
+  Any repository in the `src/repositor` folder with the file format
   `*.repository.base.ts` will be added to the list too.
 
 - **Please enter the name of the ID property for _modelName_.** _(id)_ If the

--- a/docs/site/Repository-generator.md
+++ b/docs/site/Repository-generator.md
@@ -93,7 +93,7 @@ The tool will prompt you for:
   skipped, otherwise it will present you a list of repositories. The default
   repository is inferred from the datasource type.
 
-  Any repository in the `src/repositor` folder with the file format
+  Any repository in the `src/repositories` folder with the file format
   `*.repository.base.ts` will be added to the list too.
 
 - **Please enter the name of the ID property for _modelName_.** _(id)_ If the


### PR DESCRIPTION
Fix incorrect directory name for base repository classes

fix #10611

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
