### PR TITLE
fix: iterate through content object properties

### DIFF
--- a/packages/cli/generators/openapi/spec-helper.js
+++ b/packages/cli/generators/openapi/spec-helper.js
@@ -396,8 +396,8 @@ function buildMethodSpec(controllerSpec, op, options) {
       const json = content && content['application/json'];
       propSchema = json && json.schema;
       if (propSchema == null && content) {
-        for (const m of content) {
-          propSchema = content[m].schema;
+        for (const eachContent in content) {
+          propSchema = eachContent.schema;
           if (propSchema) break;
         }
       }

--- a/packages/cli/snapshots/integration/generators/openapi-uspto.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-uspto.integration.snapshots.js
@@ -330,6 +330,7 @@ the syntax options shown below.
    * @param dataset Name of the dataset. In this case, the default value is
 oa_citations
    * @param version Version of the dataset.
+   * @param page Page you would like to fetch.
    * @returns The dataset api for the given version is found and it is accessible
 to consume.
    */
@@ -359,6 +360,16 @@ to consume.
       schema: {
         type: 'string',
         default: 'v1',
+      },
+    },
+    {
+      name: 'page',
+      in: 'query',
+      description: 'Page you would like to fetch.',
+      content: {
+        '*/*': {
+          type: 'string',
+        },
       },
     },
   ],
@@ -403,7 +414,16 @@ to consume.
     type: 'string',
     default: 'v1',
   },
-}) version: string): Promise<string> {
+}) version: string, @param({
+  name: 'page',
+  in: 'query',
+  description: 'Page you would like to fetch.',
+  content: {
+    '*/*': {
+      type: 'string',
+    },
+  },
+}) page: string | undefined): Promise<string> {
      throw new Error('Not implemented'); 
   }
 }
@@ -530,6 +550,7 @@ the syntax options shown below.
    * @param dataset Name of the dataset. In this case, the default value is
 oa_citations
    * @param version Version of the dataset.
+   * @param page Page you would like to fetch.
    * @returns The dataset api for the given version is found and it is accessible
 to consume.
    */
@@ -559,6 +580,16 @@ to consume.
       schema: {
         type: 'string',
         default: 'v1',
+      },
+    },
+    {
+      name: 'page',
+      in: 'query',
+      description: 'Page you would like to fetch.',
+      content: {
+        '*/*': {
+          type: 'string',
+        },
       },
     },
   ],
@@ -603,7 +634,16 @@ to consume.
     type: 'string',
     default: 'v1',
   },
-}) version: string): Promise<string> {
+}) version: string, @param({
+  name: 'page',
+  in: 'query',
+  description: 'Page you would like to fetch.',
+  content: {
+    '*/*': {
+      type: 'string',
+    },
+  },
+}) page: string | undefined): Promise<string> {
      throw new Error('Not implemented'); 
   }
 }

--- a/packages/cli/test/fixtures/openapi/3.0/uspto.yaml
+++ b/packages/cli/test/fixtures/openapi/3.0/uspto.yaml
@@ -90,6 +90,12 @@ paths:
           schema:
             type: string
             default: v1
+        - name: page
+          in: query
+          description: Page you would like to fetch.
+          content:
+            '*/*':
+              type: string
       responses:
         '200':
           description: >-


### PR DESCRIPTION
From OpenAPI specification, `content` is a map (an object) not an array. This PR makes the spec-helper iterate through content object properties rather than considering it an object.
## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
