### PR TITLE
fix(monorepo): creating packages post-Lerna@7

### DIFF
--- a/bin/create-package.js
+++ b/bin/create-package.js
@@ -32,10 +32,11 @@
  * 4. Run `lb4 copyright` to update `LICENSE` and copyright headers for `*.ts`
  * and `*.js`.
  *
- * 5. Run `lerna bootstrap --scope <full-package-name>` to link its local
+ * 5. Run `npm install --workspace <full-package-name>` to link its local
  * dependencies.
  *
  * 6. Run `update-ts-project-refs` to update TypeScript project references
+ * (via NPM `postinstall` hook)
  *
  * 7. Remind to update `CODEOWNERS` and `docs/site/MONOREPO.md`
  */
@@ -44,7 +45,7 @@
 const path = require('node:path');
 const fse = require('fs-extra');
 const build = require('../packages/build');
-const {runMain, updateTsProjectRefs} = require('./script-util');
+const {runMain} = require('./script-util');
 
 const cwd = process.cwd();
 
@@ -115,7 +116,6 @@ async function createPackage(name) {
   await fixupProject(project);
   await updateCopyrightAndLicense(project, options);
   await bootstrapProject(project);
-  await updateTsProjectRefs({dryRun: false});
 
   promptActions(project);
 }
@@ -152,8 +152,8 @@ async function bootstrapProject({repoRoot, name}) {
   process.chdir(repoRoot);
   // Run `npx lerna bootstrap --scope @loopback/<name>`
   const shell = build.runShell(
-    'npx',
-    ['lerna', 'bootstrap', '--scope', `@loopback/${name}`],
+    'npm',
+    ['install', '--workspace', `@loopback/${name}`],
     {
       cwd: repoRoot,
     },


### PR DESCRIPTION
Updates internal monorepo package creator to use `npm install` instead of `lerna bootstrap`.

This fix prevents the following error:
```
node ./bin/create-package.js packages/model
...
ERR! bootstrap The "bootstrap" command was removed by default in v7, and is no longer maintained.
ERR! bootstrap Learn more about this change at https://lerna.js.org/docs/legacy-package-management
 Command aborts (code 1 signal null): npx "lerna" "bootstrap" "--scope" "@loopback/model".
Error: Process 1192 exits with code 1 signal null
    at ChildProcess.<anonymous> (/home/user/Documents/git-repos/loopbackio/loopback-next/bin/create-package.js:61:11)
    at ChildProcess.emit (node:events:519:28)
    at ChildProcess._handle.onexit (node:internal/child_process:294:12)
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
