### PR TITLE
fix: fix CLI execution with explicit --controllerType=BASIC option

### DIFF
--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -88,7 +88,8 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
 
     if (this.options.controllerType) {
       Object.assign(this.artifactInfo, {
-        controllerType: this.options.controllerType,
+        controllerType:
+          ControllerGenerator[this.options.controllerType.toUpperCase()],
       });
       return;
     }

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -24,8 +24,12 @@ const {expectFileToMatchSnapshot} = require('../../snapshots');
 const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 // CLI Inputs
+const defaultCLIInput = {
+  name: 'productReview',
+};
 const basicCLIInput = {
   name: 'productReview',
+  controllerType: 'ControllerGenerator.BASIC',
 };
 const restCLIInput = {
   name: 'productReview',
@@ -54,7 +58,7 @@ describe('lb4 controller', () => {
         .inDir(sandbox.path, () =>
           testUtils.givenLBProject(sandbox.path, {excludePackageJSON: true}),
         )
-        .withPrompts(basicCLIInput),
+        .withPrompts(defaultCLIInput),
     ).to.be.rejectedWith(/No package.json found in/);
   });
 
@@ -65,12 +69,21 @@ describe('lb4 controller', () => {
         .inDir(sandbox.path, () =>
           testUtils.givenLBProject(sandbox.path, {excludeLoopbackCore: true}),
         )
-        .withPrompts(basicCLIInput),
+        .withPrompts(defaultCLIInput),
     ).to.be.rejectedWith(/No `@loopback\/core` package found/);
   });
 
   describe('basic controller', () => {
     it('scaffolds correct file with input', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
+        .withPrompts(defaultCLIInput);
+
+      checkBasicContents();
+    });
+
+    it('scaffolds correct file with controllerType BASIC specified explicitly', async () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))


### PR DESCRIPTION
fix #10494

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
Fix controller failure when --controllerType=BASIC is explicitly specified

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
