### PR TITLE
fix: remove duplicate targetModelClassName import in has-one relation…

### DIFF
--- a/packages/cli/generators/relation/templates/controller-relation-template-has-one.ts.ejs
+++ b/packages/cli/generators/relation/templates/controller-relation-template-has-one.ts.ejs
@@ -18,7 +18,6 @@ import {
 import {<%if (sourceModelClassName != targetModelClassName) { %>
   <%= sourceModelClassName %>,<% } %>
   <%= targetModelClassName %>,
-  <%= targetModelClassName %>,
 } from '../models';
 import {<%= sourceRepositoryClassName %>} from '../repositories';
 


### PR DESCRIPTION
One of my PR introduced a bug in relation generation ([Here](https://github.com/loopbackio/loopback-next/commit/7dd40b09cf5e890a31b2075135c31d572140e938) is the commit). Generating a hasOne relation resulted in a duplicate import of `targetModelClassName` in the has-one relation template file.

This PR fixes that by removing the duplication.
## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
