### PR TITLE
feat: add relation type information in openapi specs

### DIFF
--- a/packages/cli/generators/relation/templates/controller-relation-template-has-one.ts.ejs
+++ b/packages/cli/generators/relation/templates/controller-relation-template-has-one.ts.ejs
@@ -18,7 +18,6 @@ import {
 import {<%if (sourceModelClassName != targetModelClassName) { %>
   <%= sourceModelClassName %>,<% } %>
   <%= targetModelClassName %>,
-  <%= targetModelClassName %>,
 } from '../models';
 import {<%= sourceRepositoryClassName %>} from '../repositories';
 

--- a/packages/openapi-v3/src/json-to-schema.ts
+++ b/packages/openapi-v3/src/json-to-schema.ts
@@ -143,6 +143,25 @@ export function jsonToSchemaObject(
   if (matched) {
     result['x-typescript-type'] = matched[1];
   }
+  if (result.description) {
+    const relationMatched = result.description.match(
+      /\{\"relationships\".*\$/s,
+    );
+    if (relationMatched) {
+      const stringifiedRelation = relationMatched[0].replaceAll(
+        'foreignKey',
+        'x-foreign-key',
+      );
+      if (stringifiedRelation) {
+        result['x-relationships'] =
+          JSON.parse(stringifiedRelation)['relationships'];
+        result.description = result.description.replace(
+          /\{\"relationships\".*\$/s,
+          '',
+        );
+      }
+    }
+  }
   return result;
 }
 

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -581,7 +581,114 @@ export function modelToJsonSchema<T extends object>(
         result.properties.foreignKey = (relMeta as {keyFrom: string})
           .keyFrom as JsonSchema;
       }
-
+      const foreignKey = {};
+      let relationships = {};
+      if (!relationships[relMeta.name]) {
+        relationships[relMeta.name] = {};
+      }
+      if (relMeta.type === 'belongsTo') {
+        let keyFrom = relMeta.keyFrom;
+        if (!keyFrom) {
+          keyFrom = targetType.name.toLowerCase() + 'Id';
+        }
+        foreignKey[keyFrom] = targetType.name;
+        relationships[relMeta.name].description =
+          `${relMeta.source.name} belongs to ${targetType.name}.`;
+        relationships[relMeta.name].type = 'object';
+        relationships[relMeta.name].$ref =
+          `#/definitions/${targetSchema.title}`;
+      }
+      if (relMeta.type === 'hasMany') {
+        if (relMeta.through) {
+          relationships = {};
+          if (!relationships[relMeta.name]) {
+            relationships[relMeta.name] = {};
+          }
+          let keyTo = relMeta.through.keyTo;
+          let keyFrom = relMeta.through.keyFrom;
+          if (!keyTo) {
+            keyTo = targetType.name.toLowerCase() + 'Id';
+          }
+          if (!keyFrom) {
+            keyFrom = relMeta.source.name.toLowerCase() + 'Id';
+          }
+          foreignKey[keyTo] = targetType.name;
+          foreignKey[keyFrom] = relMeta.source.name;
+          relationships[relMeta.name].description =
+            `${relMeta.source.name} have many ${targetType.name}.`;
+          relationships[relMeta.name].type = 'object';
+          relationships[relMeta.name].$ref =
+            `#/definitions/${targetSchema.title}`;
+        } else {
+          let keyFrom = relMeta.keyFrom;
+          if (!keyFrom) {
+            keyFrom = relMeta.source.name.toLowerCase() + 'Id';
+          }
+          foreignKey[keyFrom] = relMeta.source.name;
+          relationships[relMeta.name].description =
+            `${relMeta.source.name} have many ${targetType.name}.`;
+          relationships[relMeta.name].type = 'array';
+          relationships[relMeta.name].items = {
+            $ref: `#/definitions/${targetSchema.title}`,
+          };
+        }
+      }
+      if (relMeta.type === 'hasOne') {
+        relationships = {};
+        if (!relationships[relMeta.name]) {
+          relationships[relMeta.name] = {};
+        }
+        let keyTo = relMeta.keyTo;
+        if (!keyTo) {
+          keyTo = relMeta.source.name.toLowerCase() + 'Id';
+        }
+        foreignKey[keyTo] = relMeta.source.name;
+        relationships[relMeta.name].description =
+          `${relMeta.source.name} have one ${targetType.name}.`;
+        relationships[relMeta.name].type = 'object';
+        relationships[relMeta.name].$ref =
+          `#/definitions/${targetSchema.title}`;
+      }
+      if (relMeta.type === 'referencesMany') {
+        let keyFrom = relMeta.keyFrom;
+        if (!keyFrom) {
+          keyFrom = targetType.name.toLowerCase() + 'Ids';
+        }
+        foreignKey[keyFrom] = targetType.name;
+        relationships[relMeta.name].description =
+          `${relMeta.source.name} references many ${targetType.name}.`;
+        relationships[relMeta.name].type = 'array';
+        relationships[relMeta.name].items = {
+          $ref: `#/definitions/${targetSchema.title}`,
+        };
+      }
+      relationships[relMeta.name].foreignKeys = foreignKey;
+      relationships[relMeta.name]['x-relation-type'] = relMeta.type;
+      if (result.description) {
+        if (result.description.includes('relationships')) {
+          const relationMatched = result.description.match(
+            /\{\"relationships\".*\$/s,
+          );
+          if (relationMatched) {
+            const {relationships: existingRelation} = JSON.parse(
+              relationMatched[0],
+            );
+            existingRelation[Object.keys(relationships)[0]] = {
+              ...relationships,
+            };
+            result.description = result.description.replace(
+              /\{\"relationships\".*\$/s,
+              '',
+            );
+            result.description =
+              result.description +
+              `, ${JSON.stringify({relationships: existingRelation})}`;
+          }
+        } else {
+          result.description =
+            result.description + `, ${JSON.stringify({relationships})}`;
+        }
+      }
       includeReferencedSchema(targetSchema.title!, targetSchema);
     }
   }


### PR DESCRIPTION
Gathering information on relationship types between models through openapi specs is hard. In particular, there is no way to distinct a hasMany and hasMany & hasManyThrough.

This PR adds relation type in openapi specs. It adds a custom field `x-relation-type` to `relationships`.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
