### PR TITLE
fix: show readonly in openapi spec of model property if it is generated

### DIFF
--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -203,6 +203,20 @@ describe('build-schema', () => {
       });
     });
 
+    it('show generated', () => {
+      expect(
+        metaToJsonProperty({
+          type: String,
+          description: 'test',
+          generated: true,
+        }),
+      ).to.eql({
+        type: 'string',
+        description: 'test',
+        readOnly: true,
+      });
+    });
+
     it('keeps AJV keywords', () => {
       const schema = metaToJsonProperty({
         type: String,

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -271,6 +271,9 @@ export function metaToJsonProperty(meta: PropertyDefinition): JsonSchema {
   } else {
     result = propDef;
   }
+  if (meta.generated) {
+    result.readOnly = true;
+  }
 
   const wrappedType = stringTypeToWrapper(propertyType);
   const resolvedType = resolveType(wrappedType);


### PR DESCRIPTION
Openapi specs provide an option `readOnly` to show if a field is supposed to be generated and not provided in request data. This PR adds `readOnly: true` to a model property in openapi specs that is `generated: true`.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
