### PR TITLE
fix: fix accessing dependencies from yeoman's packageJson

### DIFF
--- a/packages/cli/generators/datasource/index.js
+++ b/packages/cli/generators/datasource/index.js
@@ -303,7 +303,7 @@ module.exports = class DataSourceGenerator extends ArtifactGenerator {
     if (this.shouldExit()) return false;
     debug('install npm dependencies');
     const pkgJson = this.packageJson || {};
-    const deps = pkgJson.dependencies || {};
+    const deps = pkgJson.get('dependencies') || {};
     const pkgs = [];
 
     // Connector package.

--- a/packages/cli/generators/openapi/index.js
+++ b/packages/cli/generators/openapi/index.js
@@ -496,7 +496,7 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
     if (this.shouldExit()) return false;
     debug('install npm dependencies');
     const pkgJson = this.packageJson || {};
-    const deps = pkgJson.dependencies || {};
+    const deps = pkgJson.get('dependencies') || {};
     const pkgs = [];
     const connectorVersionRange = deps['loopback-connector-openapi'];
     if (!connectorVersionRange) {

--- a/packages/cli/generators/rest-crud/index.js
+++ b/packages/cli/generators/rest-crud/index.js
@@ -382,7 +382,7 @@ module.exports = class RestCrudGenerator extends ArtifactGenerator {
     if (this.shouldExit()) return false;
     debug('install npm dependencies');
     const pkgJson = this.packageJson || {};
-    const deps = pkgJson.dependencies || {};
+    const deps = pkgJson.get('dependencies') || {};
     const pkgs = [];
 
     const version = cliPkg.config.templateDependencies['@loopback/rest-crud'];

--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -329,7 +329,7 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
       utils.toClassName(this.artifactInfo.dataSourceName) + 'DataSource';
     debug('install npm dependencies');
     const pkgJson = this.packageJson || {};
-    const deps = pkgJson.dependencies || {};
+    const deps = pkgJson.get('dependencies') || {};
     const pkgs = [];
 
     if (!deps['@loopback/service-proxy']) {


### PR DESCRIPTION
Some of the generators install dependencies like rest-crud (installs @loopback/rest-curd), service (installs @loopback/service) or openapi generator (installs loopback-connector-openapi). 

Before installing those dependencies, they see if the dependency is installed by looking at `packageJson.dependencies` (`packageJson` from yeoman-generator) - which always results in false as `packageJson` has no [property named](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/yeoman-generator/index.d.ts#L378) `dependencies`. 
Yeoman-generator's `packageJson` has no direct way to access dependencies from package.json file.

Hence the dependency is always installed even if it already exists.

This PR fixes that by properly accessing the dependencies with [`packageJson.get`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/904d081300458e8c0fd2c821cd92d0b5446d861c/types/3box/index.d.ts#L21)

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
