### PR TITLE
fix(repository-json-schema): use correct behavior for hidden properties

### DIFF
--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -486,6 +486,19 @@ export function modelToJsonSchema<T extends object>(
       continue;
     }
 
+    if (meta?.settings?.hiddenProperties?.includes(p)) {
+      debug(
+        'Property % is hidden by model hiddenProperties settings %s',
+        meta?.settings?.hiddenProperties?.includes(p),
+      );
+      continue;
+    }
+
+    if (meta.properties[p].hidden) {
+      debug('Property % is hidden by model property hidden setting', p);
+      continue;
+    }
+
     if (meta.properties[p].type == null) {
       // Circular import of model classes can lead to this situation
       throw new Error(


### PR DESCRIPTION
Update emitted json schema to always omit properties marked as hidden at both model and property levels.
 
This also affects schema emitted for related models.

 Currently, `hidden` properties are only omitted at the top level in the model schema. If a related model was included as part of the emitted schema, the `hidden`behavior on the model or model properties would be ignored, and the entire nested schema emitted, defeating the purpose of the hidden fields, and requiring additional models / extra work to omit them from the emitted schema.

Potentially Fixes #7517 
Fixes #4495
Fixes #1914

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
