### PR TITLE
fix: show readOnly in openapi specs if readOnly is true in mode

### DIFF
--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -203,12 +203,12 @@ describe('build-schema', () => {
       });
     });
 
-    it('show generated', () => {
+    it('show readOnly if readOnly: true', () => {
       expect(
         metaToJsonProperty({
           type: String,
           description: 'test',
-          generated: true,
+          readOnly: true,
         }),
       ).to.eql({
         type: 'string',

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -271,7 +271,7 @@ export function metaToJsonProperty(meta: PropertyDefinition): JsonSchema {
   } else {
     result = propDef;
   }
-  if (meta.generated) {
+  if (meta.readOnly) {
     result.readOnly = true;
   }
 


### PR DESCRIPTION
My previous PR added readOnly to openapi specs if a model property is generated - which was [not a correct implementation](https://github.com/loopbackio/loopback-next/pull/10635#issuecomment-2466229446). This PR fixes that.
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
