### PR TITLE
Update Getting-started.md add "npm install" comando line in the "starting the project" item.

### DIFF
--- a/docs/site/Getting-started.md
+++ b/docs/site/Getting-started.md
@@ -62,6 +62,7 @@ running the project.
 
 ```sh
 cd getting-started
+npm install
 npm start
 ```
 


### PR DESCRIPTION
When trying to run the tutorial following the tutorial I identified the lack of the "npm install" command in the "starting the project" item. This causes an error when running the “npm start” command.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
