### PR TITLE
fix: fix lint error

### DIFF
--- a/extensions/socketio/src/socketio.server.ts
+++ b/extensions/socketio/src/socketio.server.ts
@@ -25,10 +25,10 @@ import {cloneDeep} from 'lodash';
 import {Server, ServerOptions, Socket} from 'socket.io';
 import {
   getSocketIoMetadata,
-  SocketIoMetadata,
   SOCKET_IO_CONNECT_METADATA,
   SOCKET_IO_METADATA,
   SOCKET_IO_SUBSCRIBE_METADATA,
+  SocketIoMetadata,
 } from './decorators';
 import {SocketIoBindings, SocketIoTags} from './keys';
 import {SocketIoControllerFactory} from './socketio-controller-factory';
@@ -236,9 +236,11 @@ export class SocketIoServer extends Context {
    */
   async stop() {
     const closePromise = new Promise<void>((resolve, _reject) => {
-      this.io.close(() => {
-        resolve();
-      });
+      this.io
+        .close(() => {
+          resolve();
+        })
+        .catch(err => {});
     });
     await closePromise;
     if (this.httpServer) await this.httpServer.stop();


### PR DESCRIPTION
Currently the `npm run lint` failed with the following error which blocks the release of loopback-next modules

```
../loopback-next/extensions/socketio/src/socketio.server.ts
  239:7  error  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator
```

This PR fixes the lint error.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
