### PR TITLE
Fix CI

### DIFF
--- a/examples/todo/src/__tests__/helpers.ts
+++ b/examples/todo/src/__tests__/helpers.ts
@@ -48,7 +48,7 @@ export function givenTodo(todo?: Partial<Todo>) {
 
 export const aLocation = {
   address: '1 New Orchard Road, Armonk, 10504',
-  geopoint: <GeoPoint>{y: 41.1097283577486, x: -73.7246203180502},
+  geopoint: <GeoPoint>{y: 41.109728357749, x: -73.72462031805},
   get geostring() {
     return `${this.geopoint.y},${this.geopoint.x}`;
   },

--- a/examples/webpack/src/__tests__/integration/bundle-web.integration.ts
+++ b/examples/webpack/src/__tests__/integration/bundle-web.integration.ts
@@ -40,7 +40,10 @@ skipIf<[(this: Suite) => void], void>(
     let html: string;
     before(async function (this: Mocha.Context) {
       this.timeout(15000);
-      browser = await puppeteer.launch({headless: 'new'});
+      browser = await puppeteer.launch({
+        headless: 'new',
+        args: ['--no-sandbox'],
+      });
       const page = await browser.newPage();
       await page.goto(
         url

--- a/packages/cli/.yo-rc.json
+++ b/packages/cli/.yo-rc.json
@@ -132,6 +132,12 @@
           "name": "loopbackBuild",
           "hide": false
         },
+        "editorconfig": {
+          "type": "Boolean",
+          "description": "Use preconfigured EditorConfig settings",
+          "name": "editorconfig",
+          "hide": false
+        },
         "vscode": {
           "type": "Boolean",
           "description": "Use preconfigured VSCode settings",
@@ -255,6 +261,12 @@
           "type": "Boolean",
           "description": "Use @loopback/build",
           "name": "loopbackBuild",
+          "hide": false
+        },
+        "editorconfig": {
+          "type": "Boolean",
+          "description": "Use preconfigured EditorConfig settings",
+          "name": "editorconfig",
           "hide": false
         },
         "vscode": {


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

3 tests are failing, possibly with the Node.js updates: 
```

  1) GeoLookupService
       resolves an address to a geo point:

      AssertionError: expected Array [ Object { x: -73.72462031805, y: 41.109728357749 } ] to equal Array [ Object { y: 41.1097283577486, x: -73.7246203180502 } ] (at '0' -> y, A has 41.109728357749 and B has 41.1097283577486)
      + expected - actual

       [
         {
      -    "x": -73.72462031805
      -    "y": 41.109728357749
      +    "x": -73.7246203180502
      +    "y": 41.1097283577486
         }
       ]
      
      at Assertion.fail (node_modules/should/as-function.js:275:17)
      at Assertion.value (node_modules/should/as-function.js:356:19)
      at Context.<anonymous> (examples/todo/src/__tests__/integration/services/geocoder.service.integration.ts:37:23)
      at processTicksAndRejections (node:internal/process/task_queues:105:5)

  2) TodoApplication
       creates an address-based reminder:
     AssertionError: expected Object {
  id: 3,
  title: 'do a thing',
  desc: 'There are some things that need doing',
  isComplete: false,
  remindAtAddress: '1 New Orchard Road, Armonk, 10504',
  remindAtGeo: '41.109728357749,-73.72462031805'
} to contain Todo {
  title: 'do a thing',
  desc: 'There are some things that need doing',
  isComplete: false,
  remindAtAddress: '1 New Orchard Road, Armonk, 10504',
  remindAtGeo: '41.1097283577486,-73.7246203180502'
}
    expected '41.109728357749,-73.72462031805' to have key remindAtGeo
        expected '41.109728357749,-73.72462031805' to equal '41.1097283577486,-73.7246203180502'
      at Assertion.fail (node_modules/should/as-function.js:275:17)
      at Assertion.value [as containEql] (node_modules/should/as-function.js:356:19)
      at Context.<anonymous> (examples/todo/src/__tests__/acceptance/todo.acceptance.ts:98:30)
      at processTicksAndRejections (node:internal/process/task_queues:105:5)

  3) bundle-web.js
       "before all" hook for "should see the page with greetings":
     Error: Failed to launch the browser process!
[3141:3141:1208/223136.922789:FATAL:zygote_host_impl_linux.cc(127)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
[1208/223136.930032:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[1208/223136.930073:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)


TROUBLESHOOTING: https://pptr.dev/troubleshooting

      at ChildProcess.onClose (node_modules/@puppeteer/browsers/src/launch.ts:383:11)
      at ChildProcess.emit (node:events:530:35)
      at Process.ChildProcess._handle.onexit (node:internal/child_process:293:12)
```


## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
