### PR TITLE
feat: support outDir option for controllers

### DIFF
--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -56,6 +56,11 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
       required: false,
       description: g.f('Type for the %s', this.artifactInfo.type),
     });
+    this.option('outDir', {
+      type: String,
+      required: false,
+      description: 'Custom output directory for controller',
+    });
 
     return super._setupGenerator();
   }
@@ -260,6 +265,9 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
     const source = this.templatePath(path.join('src', 'controllers', template));
     if (debug.enabled) {
       debug(`Using template at: ${source}`);
+    }
+    if (this.options.outDir) {
+      this.artifactInfo.outDir = path.resolve(this.options.outDir);
     }
     const dest = this.destinationPath(
       path.join(this.artifactInfo.outDir, this.artifactInfo.outFile),

--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -494,20 +494,20 @@ module.exports = class BaseGenerator extends Generator {
   }
 
   async _updateIndexFile(dir, file) {
-    await updateIndex(dir, file, this.fs);
-
-    // Output for users
     const updateDirRelPath = path.relative(
       this.artifactInfo.relPath,
       this.artifactInfo.outDir,
     );
 
-    const outPath = path.join(
+    await updateIndex(
       this.artifactInfo.relPath,
+      file,
+      this.fs,
       updateDirRelPath,
-      'index.ts',
     );
 
+    // Output for users
+    const outPath = path.join(this.artifactInfo.relPath, 'index.ts');
     this.log(chalk.green('   update'), `${outPath}`);
   }
 };

--- a/packages/cli/lib/update-index.js
+++ b/packages/cli/lib/update-index.js
@@ -19,7 +19,7 @@ const defaultFs = {
  * @param {String} dir The directory in which index.ts is to be updated/created
  * @param {*} file The new file to be exported from index.ts
  */
-module.exports = async function (dir, file, fsApis) {
+module.exports = async function (dir, file, fsApis, subDir = '') {
   const {read, write, append, exists} = {...defaultFs, ...fsApis};
   debug(`Updating index with ${path.join(dir, file)}`);
   const indexFile = path.join(dir, 'index.ts');
@@ -32,7 +32,7 @@ module.exports = async function (dir, file, fsApis) {
   if (indexExists) {
     index = await read(indexFile);
   }
-  const content = `export * from './${file.slice(0, -3)}';\n`;
+  const content = `export * from './${subDir ? subDir + '/' : ''}${file.slice(0, -3)}';\n`;
   if (!index.includes(content)) {
     if (indexExists) {
       await append(indexFile, content);


### PR DESCRIPTION
There is no way to specify a subdirectory for controllers. This PR enables `lb4 controller` to accept `outDir` to create controllers under some subdirectory.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
