### PR TITLE
fix: remove import for model for same model relation

### DIFF
--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -382,7 +382,7 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
 
       if (this.options.relations) {
         const relationImports = [];
-        const relationDestinationImports = [];
+        let relationDestinationImports = [];
         const foreignKeys = {};
         for (const relationName in templateData.settings.relations) {
           const relation = templateData.settings.relations[relationName];
@@ -409,6 +409,12 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
               foreignKey: relation.foreignKey,
             });
           }
+        }
+        // remove model import if the model relation is with itself
+        if (relationDestinationImports.includes(templateData['name'])) {
+          relationDestinationImports = relationDestinationImports.filter(
+            e => e !== templateData['name'],
+          );
         }
         templateData.relationImports = relationImports;
         templateData.relationDestinationImports = relationDestinationImports;

--- a/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
@@ -57,6 +57,53 @@ export type ViewWithRelations = View & ViewRelations;
 `;
 
 
+exports[`lb4 discover integration model discovery discovers models with --relations 1`] = `
+import {Entity, model, property, belongsTo} from '@loopback/repository';
+
+@model({
+  settings: {
+    foreignKeys: {
+      doctorRel: {name: 'doctorRel', entity: 'Doctor', entityKey: 'id', foreignKey: 'reportsTo'}
+    }
+  }
+})
+export class Doctor extends Entity {
+  @property({
+    type: 'number',
+    scale: 0,
+    id: 1,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+    length: 45,
+  })
+  name?: string;
+
+  @belongsTo(() => Doctor)
+  reportsTo?: number;
+
+  // Define well-known properties here
+
+  // Indexer property to allow additional data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [prop: string]: any;
+
+  constructor(data?: Partial<Doctor>) {
+    super(data);
+  }
+}
+
+export interface DoctorRelations {
+  // describe navigational properties here
+}
+
+export type DoctorWithRelations = Doctor & DoctorRelations;
+
+`;
+
+
 exports[`lb4 discover integration model discovery does not mark id property as required based on optionalId option 1`] = `
 import {Entity, model, property} from '@loopback/repository';
 

--- a/packages/cli/test/fixtures/discover/mem.datasource.js.txt
+++ b/packages/cli/test/fixtures/discover/mem.datasource.js.txt
@@ -134,6 +134,14 @@ const fullDefinitions = [
   },
     {
     'name': 'Doctor',
+    className: 'Doctor',
+    modelBaseClass: 'Entity',
+    isModelBaseBuiltin: true,
+    options: {
+      relations: {
+        doctorRel: { model: 'Doctor', type: 'belongsTo', foreignKey: 'reportsTo' },
+      }
+    },
     'properties': {
       'id': {
         'type': 'Number',
@@ -150,7 +158,24 @@ const fullDefinitions = [
         'precision': null,
         'scale': null,
       },
+      reportsTo: {
+        type: "number",
+        precision: 10,
+        scale: 0,
+        generated: 0,
+        mysql: "{columnName: 'reportsTo', dataType: 'int', dataLength: null, dataPrecision: 10, dataScale: 0, nullable: 'Y', generated: 0}",
+        tsType: 'number'
+      }
     },
+    allowAdditionalProperties: true,
+    modelSettings: {
+      settings: {
+        idInjection: false,
+        relations: {
+          doctorRel: {model: 'Doctor', type: 'belongsTo', foreignKey: 'reportsTo'},
+        }
+      }
+    }
   },
   {
     'name': 'Patient',

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -96,6 +96,7 @@ const appointmentModel = path.join(
   sandbox.path,
   'src/models/appointment.model.ts',
 );
+const doctorModel = path.join(sandbox.path, 'src/models/doctor.model.ts');
 
 const defaultExpectedIndexFile = path.join(sandbox.path, 'src/models/index.ts');
 const movedExpectedTestModel = path.join(sandbox.path, 'src/test.model.ts');
@@ -222,6 +223,18 @@ describe('lb4 discover integration', () => {
         .withOptions(relationsSetTrue);
       assert.file(appointmentModel);
       expectFileToMatchSnapshot(appointmentModel);
+    });
+    it('discovers models with --relations', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withOptions(relationsSetTrue);
+      assert.file(doctorModel);
+      expectFileToMatchSnapshot(doctorModel);
     });
   });
   it('generates specific models without prompts using --models', async () => {


### PR DESCRIPTION
While discovering the model, if we set `relations` to `true` (which will discover relations along with models), the discoverer generates buggy model code if the model relation is with itself (same table relation). This PR fixes that.
## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
