### PR TITLE
fix: make filter work on count for consistency

### DIFF
--- a/packages/filter/src/query.ts
+++ b/packages/filter/src/query.ts
@@ -248,6 +248,14 @@ export type FilterExcludingWhere<MT extends object = AnyObject> = Omit<
 >;
 
 /**
+ * Filter without additional properties for count
+ */
+export type FilterExcludingsForCount<MT extends object = AnyObject> = Omit<
+  Filter<MT>,
+  'fields' | 'order' | 'limit' | 'skip' | 'offset' | 'include'
+>;
+
+/**
  * TypeGuard for Filter
  * @param candidate
  */

--- a/packages/rest-crud/src/__tests__/acceptance/default-model-crud-rest.acceptance.ts
+++ b/packages/rest-crud/src/__tests__/acceptance/default-model-crud-rest.acceptance.ts
@@ -154,6 +154,14 @@ describe('CrudRestController for a simple Product model', () => {
         .expect(200);
       expect(body).to.deepEqual({count: 1 /* pencil was omitted */});
     });
+
+    it('supports `filter` query param', async () => {
+      const {body} = await client
+        .get('/products/count')
+        .query({'filter[where][name]': pen.name})
+        .expect(200);
+      expect(body).to.deepEqual({count: 1 /* pencil was omitted */});
+    });
   });
 
   describe('updateAll', () => {

--- a/packages/rest-crud/src/crud-rest.controller.ts
+++ b/packages/rest-crud/src/crud-rest.controller.ts
@@ -10,6 +10,7 @@ import {
   Entity,
   EntityCrudRepository,
   Filter,
+  FilterExcludingsForCount,
   FilterExcludingWhere,
   Where,
 } from '@loopback/repository';
@@ -189,8 +190,15 @@ export function defineCrudRestController<
     async count(
       @param.where(modelCtor)
       where?: Where<T>,
+      @param.query.object(
+        'filter',
+        getFilterSchemaFor(modelCtor, {
+          exclude: ['fields', 'order', 'limit', 'skip', 'offset', 'include'],
+        }),
+      )
+      filter?: FilterExcludingsForCount<T>,
     ): Promise<Count> {
-      return this.repository.count(where);
+      return this.repository.count(where || filter?.where);
     }
   }
 


### PR DESCRIPTION
The `count` endpoint generated with rest-crud has a where filter but doesn't have `filter` itself.
So `GET /count?where={"name":<name>}` would work but `GET /count?filter={"where":{"name":<name>}}` will not work.

I think this is intentional as the count endpoint would only require a where clause. But this causes inconsistency of filter in GET /count and `GET /` and `PATCH /`.

I am creating this draft PR to discuss if we add `filter` to `/count` too in order to make it consistent with other endpoints.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
