### PR TITLE
fix: remove @types/bcryptjs

### DIFF
--- a/examples/access-control-migration/package.json
+++ b/examples/access-control-migration/package.json
@@ -61,7 +61,6 @@
     "@loopback/rest-explorer": "^7.0.12",
     "@loopback/security": "^0.11.12",
     "@loopback/service-proxy": "^7.0.12",
-    "@types/bcryptjs": "3.0.0",
     "bcryptjs": "^3.0.2",
     "casbin": "^5.38.0",
     "jsonwebtoken": "^9.0.2",

--- a/examples/todo-jwt/package.json
+++ b/examples/todo-jwt/package.json
@@ -62,7 +62,6 @@
     "@loopback/rest-explorer": "^7.0.12",
     "@loopback/security": "^0.11.12",
     "@loopback/service-proxy": "^7.0.12",
-    "@types/bcryptjs": "^3.0.0",
     "bcryptjs": "^3.0.2",
     "loopback-connector-rest": "^5.0.5",
     "tslib": "^2.8.1"

--- a/extensions/authentication-jwt/package.json
+++ b/extensions/authentication-jwt/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "@loopback/security": "^0.11.12",
-    "@types/bcryptjs": "3.0.0",
     "bcryptjs": "^3.0.2",
     "debug": "^4.4.0",
     "jsonwebtoken": "^9.0.2"


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

According to [the documentation](https://www.npmjs.com/package/%40types/bcryptjs), `@types/bcryptjs` is no longer needed. 

Also, there's CI failure in https://github.com/loopbackio/loopback-next/pull/10909 that's related to `bcryptjs`. I'm trying to see if removing this will fix the issue. 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
