### PR TITLE
fix: fix release issue in cli.js

### DIFF
--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -202,8 +202,10 @@ function main(opts, log) {
         commandOptions[n] = {...opt, type: opt.type.name};
       }
       const commandArgs = [];
-      for (const arg of gen._arguments) {
-        commandArgs.push({...arg, type: arg.type.name});
+      if (!gen) {
+        for (const arg of gen._arguments) {
+          commandArgs.push({...arg, type: arg.type.name});
+        }
       }
       optionsAndArgs[name] = {
         options: commandOptions,


### PR DESCRIPTION
When trying to publish the release for the LB4 modules, I got the following error: 
```
/somepath/loopback-next/packages/cli/lib/cli.js:208
      for (const arg of gen._arguments) {
                            ^

TypeError: gen._arguments is not iterable
    at main (/somepath/loopback-next/packages/cli/lib/cli.js:208:29)
    at Object.<anonymous> (/somepath/loopback-next/packages/cli/bin/cli-main.js:66:1)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:173:12)
    at node:internal/main/run_main_module:28:49
```



<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
