### PR TITLE
fix: revert terminal-link version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -283,7 +283,6 @@
         "@loopback/rest-explorer": "^7.0.12",
         "@loopback/security": "^0.11.12",
         "@loopback/service-proxy": "^7.0.12",
-        "@types/bcryptjs": "3.0.0",
         "bcryptjs": "^3.0.2",
         "casbin": "^5.38.0",
         "jsonwebtoken": "^9.0.2",
@@ -989,7 +988,6 @@
         "@loopback/rest-explorer": "^7.0.12",
         "@loopback/security": "^0.11.12",
         "@loopback/service-proxy": "^7.0.12",
-        "@types/bcryptjs": "^3.0.0",
         "bcryptjs": "^3.0.2",
         "loopback-connector-rest": "^5.0.5",
         "tslib": "^2.8.1"
@@ -1165,7 +1163,6 @@
       "license": "MIT",
       "dependencies": {
         "@loopback/security": "^0.11.12",
-        "@types/bcryptjs": "3.0.0",
         "bcryptjs": "^3.0.2",
         "debug": "^4.4.0",
         "jsonwebtoken": "^9.0.2"
@@ -8512,16 +8509,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/bcryptjs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-3.0.0.tgz",
-      "integrity": "sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==",
-      "deprecated": "This is a stub types definition. bcryptjs provides its own type definitions, so you do not need this installed.",
-      "license": "MIT",
-      "dependencies": {
-        "bcryptjs": "*"
-      }
-    },
     "node_modules/@types/benchmark": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/benchmark/-/benchmark-2.1.5.tgz",
@@ -14568,6 +14555,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -32351,22 +32339,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/supports-hyperlinks": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
-      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -32938,37 +32910,6 @@
       "dev": true,
       "engines": {
         "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/terminal-link": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
-      "integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^7.0.0",
-        "supports-hyperlinks": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/terminal-link/node_modules/ansi-escapes": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
-      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
-      "license": "MIT",
-      "dependencies": {
-        "environment": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -37542,7 +37483,7 @@
         "swagger-parser": "^10.0.3",
         "swagger2openapi": "^7.0.8",
         "tabtab": "^3.0.2",
-        "terminal-link": "^4.0.0",
+        "terminal-link": "^2.1.1",
         "tildify": "^2.0.0",
         "ts-morph": "^25.0.1",
         "typescript": "~5.2.2",
@@ -38577,6 +38518,35 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "packages/cli/node_modules/supports-hyperlinks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/cli/node_modules/terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/cli/node_modules/tuf-js": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,7 +69,7 @@
     "swagger-parser": "^10.0.3",
     "swagger2openapi": "^7.0.8",
     "tabtab": "^3.0.2",
-    "terminal-link": "^4.0.0",
+    "terminal-link": "^2.1.1",
     "tildify": "^2.0.0",
     "ts-morph": "^25.0.1",
     "typescript": "~5.2.2",


### PR DESCRIPTION
Reverting changes in PR https://github.com/loopbackio/loopback-next/pull/10895. 

When running `npm run release`, it complained about: 
```
const link = require('terminal-link');
             ^

Error [ERR_REQUIRE_ESM]: require() of ES Module
```

After I reverted `terminal-link` version to 2.x, I was able to run the following command (which is part of the release command):
npm exec -c "cross-env LANG=en bin/cli-main.js --meta" -w @loopback/cli

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
