### PR TITLE
fix: fix the last peerDependencies

### DIFF
--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -39,7 +39,7 @@
     "!*/__tests__"
   ],
   "peerDependencies": {
-    "@loopback/core": "^6.0.0"
+    "@loopback/core": "^7.0.1"
   },
   "dependencies": {
     "debug": "^4.4.1",


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

A follow up PR from PR #11018 . When updating the `peerDependencies`, I didn't realize the one in `@loopback/security` was not saved. I checked all the peerDependencies in the package.json files, it should be the last one 🤞 . 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
