### PR TITLE
docs: add security escalation policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,3 +71,12 @@ If you think you have discovered a new security issue with any LoopBack package,
 
 If you are sending us any logs as part of the report, then make sure to redact
 any sensitive data from them.
+
+## Escalation
+
+If you do not receive an acknowledgement of your report within 6 business days,
+or if you cannot find a private security contact for the project, you may
+escalate to the OpenJS Foundation CNA at `security@lists.openjsf.org`.
+
+If the project acknowledges your report but does not provide any further
+response or engagement within 14 days, escalation is also appropriate.


### PR DESCRIPTION
👋 Hi everyone! We’re @UlisesGascon and @RafaelGSS, working with the OpenJS Foundation as part of [the Alpha-Omega initiative](https://openjsf.org/blog/openjs-security-checkpoint-2025-so-far). Our focus is supporting OpenJS projects in strengthening their security posture. We can help with things like:

- Reviewing or creating security documentation (e.g., SECURITY.md, incident response plans...)
- Supporting vulnerability handling and escalation (reporting, triage, CVEs, disputes)
- Reviewing repo configurations and GitHub security settings
- Sharing best practices (e.g., OSSF Scorecard)
- Answering general questions on licenses, compliance, or incident response

:sparkles: We’re here as a resource for the LoopBack team and happy to collaborate on whatever is most useful for you. Looking forward to working together!


**References:**
- https://github.com/openjs-foundation/cross-project-council/pull/1588
- https://openjsf.org/blog/openjs-foundation-cna
- https://openjsf.org/blog/security-support-for-openjs-projects
