### PR TITLE
feat: support relation overwrite by passing --force flag

### DIFF
--- a/packages/cli/generators/relation/base-relation.generator.js
+++ b/packages/cli/generators/relation/base-relation.generator.js
@@ -99,6 +99,8 @@ module.exports = class BaseRelationGenerator extends ArtifactGenerator {
       type: this._getRepositoryRelationPropertyType(),
     };
 
+    if (classDeclaration.getProperty(property.name)) return;
+
     // already checked the existence of property before
     relationUtils.addProperty(classDeclaration, property);
   }

--- a/packages/cli/generators/relation/belongs-to-relation.generator.js
+++ b/packages/cli/generators/relation/belongs-to-relation.generator.js
@@ -95,7 +95,9 @@ module.exports = class BelongsToRelationGenerator extends (
     );
     const sourceClass = relationUtils.getClassObj(sourceFile, sourceModel);
     // this checks if the foreign key already exists, so the 2nd param should be foreignKeyName
-    relationUtils.doesRelationExist(sourceClass, foreignKeyName);
+    relationUtils.doesRelationExist(sourceClass, foreignKeyName, {
+      force: this.options.force,
+    });
 
     const modelProperty = this.getBelongsTo(
       targetModel,

--- a/packages/cli/generators/relation/has-many-relation.generator.js
+++ b/packages/cli/generators/relation/has-many-relation.generator.js
@@ -99,7 +99,9 @@ module.exports = class HasManyRelationGenerator extends BaseRelationGenerator {
       sourceModel,
     );
     const sourceClass = relationUtils.getClassObj(sourceFile, sourceModel);
-    relationUtils.doesRelationExist(sourceClass, relationName);
+    relationUtils.doesRelationExist(sourceClass, relationName, {
+      force: this.options.force,
+    });
 
     modelProperty = this.getHasMany(
       targetModel,
@@ -120,6 +122,20 @@ module.exports = class HasManyRelationGenerator extends BaseRelationGenerator {
       targetModel,
     );
     const targetClass = relationUtils.getClassObj(targetFile, targetModel);
+
+    if (isForeignKeyExist) {
+      const existingFK = targetClass.getProperty(foreignKeyName);
+      if (
+        existingFK &&
+        !relationUtils.isValidPropertyType(targetClass, foreignKeyName, fktype)
+      ) {
+        existingFK.remove();
+        const newFK = relationUtils.addForeignKey(foreignKeyName, fktype);
+        relationUtils.addProperty(targetClass, newFK);
+        targetClass.formatText();
+        await targetFile.save();
+      }
+    }
 
     if (isForeignKeyExist) {
       if (

--- a/packages/cli/generators/relation/has-many-through-relation.generator.js
+++ b/packages/cli/generators/relation/has-many-through-relation.generator.js
@@ -133,7 +133,9 @@ module.exports = class HasManyThroughRelationGenerator extends (
       sourceModel,
     );
     const sourceClass = relationUtils.getClassObj(sourceFile, sourceModel);
-    relationUtils.doesRelationExist(sourceClass, relationName);
+    relationUtils.doesRelationExist(sourceClass, relationName, {
+      force: this.options.force,
+    });
     // add the relation to the source model
     const isDefaultSourceKey = sourceKey === dftSourceKey;
     const isDefaultTargetKey = targetKey === dftTargetKey;

--- a/packages/cli/generators/relation/has-one-relation.generator.js
+++ b/packages/cli/generators/relation/has-one-relation.generator.js
@@ -96,7 +96,9 @@ module.exports = class HasOneRelationGenerator extends BaseRelationGenerator {
       sourceModel,
     );
     const sourceClass = relationUtils.getClassObj(sourceFile, sourceModel);
-    relationUtils.doesRelationExist(sourceClass, relationName);
+    relationUtils.doesRelationExist(sourceClass, relationName, {
+      force: this.options.force,
+    });
 
     modelProperty = this.getHasOne(
       targetModel,
@@ -121,6 +123,20 @@ module.exports = class HasOneRelationGenerator extends BaseRelationGenerator {
       targetModel,
     );
     const targetClass = relationUtils.getClassObj(targetFile, targetModel);
+
+    if (isForeignKeyExist) {
+      const existingFK = targetClass.getProperty(foreignKeyName);
+      if (
+        existingFK &&
+        !relationUtils.isValidPropertyType(targetClass, foreignKeyName, fktype)
+      ) {
+        existingFK.remove();
+        const newFK = relationUtils.addForeignKey(foreignKeyName, fktype);
+        relationUtils.addProperty(targetClass, newFK);
+        targetClass.formatText();
+        await targetFile.save();
+      }
+    }
 
     if (isForeignKeyExist) {
       if (

--- a/packages/cli/generators/relation/index.js
+++ b/packages/cli/generators/relation/index.js
@@ -603,7 +603,11 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
           this.artifactInfo.relationType === 'referencesMany')
       ) {
         try {
-          relationUtils.doesRelationExist(cl, this.artifactInfo.foreignKeyName);
+          relationUtils.doesRelationExist(
+            cl,
+            this.artifactInfo.foreignKeyName,
+            {force: this.options.force},
+          );
         } catch (err) {
           /* istanbul ignore next */
           this.exit(err);
@@ -681,6 +685,19 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
       this.artifactInfo.relationType === 'referencesMany'
         ? PROMPT_MESSAGE_RELATION_NAME
         : PROMPT_MESSAGE_PROPERTY_NAME;
+
+    if (!this.options.relationName)
+      this.artifactInfo.relationName = this.artifactInfo.defaultRelationName;
+    if (
+      (this.artifactInfo.relationType === 'hasMany' ||
+        this.artifactInfo.relationType === 'hasManyThrough') &&
+      this.options.relationName &&
+      !this.options.relationName.endsWith('s')
+    ) {
+      this.artifactInfo.relationName = utils.pluralize(
+        this.artifactInfo.relationName,
+      );
+    }
 
     return this.prompt([
       {

--- a/packages/cli/generators/relation/references-many-relation.generator.js
+++ b/packages/cli/generators/relation/references-many-relation.generator.js
@@ -41,7 +41,9 @@ module.exports = class ReferencesManyRelationGenerator extends (
     );
     const sourceClass = relationUtils.getClassObj(sourceFile, sourceModel);
     // this checks if the foreign key already exists, so the 2nd param should be foreignKeyName
-    relationUtils.doesRelationExist(sourceClass, foreignKeyName);
+    relationUtils.doesRelationExist(sourceClass, foreignKeyName, {
+      force: this.options.force,
+    });
 
     const modelProperty = this.getReferencesMany(
       targetModel,

--- a/packages/cli/generators/relation/utils.generator.js
+++ b/packages/cli/generators/relation/utils.generator.js
@@ -114,22 +114,26 @@ exports.doesPropertyExist = function (classObj, propertyName) {
     .includes(propertyName);
 };
 
-exports.doesRelationExist = function (classObj, propertyName) {
+exports.doesRelationExist = function (classObj, propertyName, options = {}) {
+  const force = options.force;
   if (this.doesPropertyExist(classObj, propertyName)) {
     // If the property is decorated by `@property()`,
     // turn it to be a relational property decorated by `@belongsTo()`
     const decorators = classObj.getProperty(propertyName).getDecorators();
     const hasPropertyDecorator =
       decorators.length > 0 && decorators[0].getName() === 'property';
-    // If it's already decorated by a relational decorator,
-    // throw error
-    if (!hasPropertyDecorator) {
-      throw new Error(
-        'relational property ' +
-          propertyName +
-          ' already exist in the model ' +
-          classObj.getName(),
-      );
+    if (!force) {
+      // If it's already decorated by a relational decorator,
+      // throw error
+      if (!hasPropertyDecorator) {
+        throw new Error(
+          'relational property ' +
+            propertyName +
+            ' already exist in the model ' +
+            classObj.getName() +
+            ' Use --force to overwrite it',
+        );
+      }
     }
 
     this.deleteProperty(classObj.getProperty(propertyName));

--- a/packages/cli/test/integration/generators/relation.integration.js
+++ b/packages/cli/test/integration/generators/relation.integration.js
@@ -306,3 +306,446 @@ describe('lb4 relation', /** @this {Mocha.Suite} */ function () {
     });
   });
 });
+
+describe('lb4 relation overwrite by passing --force flag', /** @this {Mocha.Suite} */ function () {
+  this.timeout(30000);
+
+  context('Execute relation when relation already exists', () => {
+    it('rejects when relation already exists and no --force flag is provided in belongsTo relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'belongsTo',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patients',
+        ]);
+      process.chdir(projectPath);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .withArguments([
+            '--relationType',
+            'belongsTo',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patients',
+          ]),
+      ).to.be.rejectedWith(
+        /relational property .* already exist in the model .* Use --force to overwrite it/i,
+      );
+    });
+
+    it('allows overwriting when --force flag is provided in belongsTo relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+      console.log('1. projectPath:', projectPath);
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir => {
+          console.log('2. dir inside callback:', dir);
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          });
+        })
+        .withArguments([
+          '--relationType',
+          'belongsTo',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patients',
+        ]);
+      const fs = require('fs');
+      console.log('3. files after first run:', fs.readdirSync(projectPath));
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath, dir =>
+            testUtils.givenLBProject(dir, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments([
+            '--relationType',
+            'belongsTo',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patients',
+            '--force',
+          ]),
+      ).to.not.be.rejected;
+    });
+
+    it('rejects when relation already exists and no --force flag is provided in hasMany relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'hasMany',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patients',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(sandbox.path, dir =>
+            testUtils.givenLBProject(dir, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments([
+            '--relationType',
+            'hasMany',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patients',
+          ]),
+      ).to.be.rejectedWith(
+        /relational property .* already exist in the model .* Use --force to overwrite it/i,
+      );
+    });
+
+    it('allows overwriting when --force flag is provided in hasMany relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'hasMany',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patients',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath, dir =>
+            testUtils.givenLBProject(dir, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments([
+            '--relationType',
+            'hasMany',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patients',
+            '--force',
+          ]),
+      ).to.not.be.rejected;
+    });
+
+    it('rejects when relation already exists and no --force flag is provided in hasManyThrough relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'hasManyThrough',
+          '--sourceModel',
+          'Customer',
+          '--destinationModel',
+          'Order',
+          '--throughModel',
+          'Address',
+          '--relationName',
+          'orders',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath)
+          .withArguments([
+            '--relationType',
+            'hasManyThrough',
+            '--sourceModel',
+            'Customer',
+            '--destinationModel',
+            'Order',
+            '--throughModel',
+            'Address',
+            '--relationName',
+            'orders',
+          ]),
+      ).to.be.rejectedWith(
+        /relational property .* already exist in the model .* Use --force to overwrite it/i,
+      );
+    });
+
+    it('allows overwriting when --force flag is provided in hasManyThrough relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'hasManyThrough',
+          '--sourceModel',
+          'Customer',
+          '--destinationModel',
+          'Order',
+          '--throughModel',
+          'Address',
+          '--relationName',
+          'orders',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath, dir =>
+            testUtils.givenLBProject(dir, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments([
+            '--relationType',
+            'hasManyThrough',
+            '--sourceModel',
+            'Customer',
+            '--destinationModel',
+            'Order',
+            '--throughModel',
+            'Address',
+            '--relationName',
+            'orders',
+            '--force',
+          ]),
+      ).to.not.be.rejected;
+    });
+
+    it('rejects when relation already exists and no --force flag is provided in hasOne relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'hasOne',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patient',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath)
+          .withArguments([
+            '--relationType',
+            'hasOne',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patient',
+          ]),
+      ).to.be.rejectedWith(
+        /relational property .* already exist in the model .* Use --force to overwrite it/i,
+      );
+    });
+
+    it('allows overwriting when --force flag is provided in hasOne relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'hasOne',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patient',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath)
+          .withArguments([
+            '--relationType',
+            'hasOne',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patient',
+            '--force',
+          ]),
+      ).to.not.be.rejected;
+    });
+
+    it('rejects when relation already exists and no --force flag is provided in referencesMany relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'referencesMany',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patientIds',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath)
+          .withArguments([
+            '--relationType',
+            'referencesMany',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patientIds',
+          ]),
+      ).to.be.rejectedWith(
+        /relational property .* already exist in the model .* Use --force to overwrite it/i,
+      );
+    });
+
+    it('allows overwriting when --force flag is provided in referencesMany relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'referencesMany',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patientIds',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath, dir =>
+            testUtils.givenLBProject(dir, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments([
+            '--relationType',
+            'referencesMany',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patientIds',
+            '--force',
+          ]),
+      ).to.not.be.rejected;
+    });
+  });
+});

--- a/packages/cli/test/integration/generators/relation.integration.js
+++ b/packages/cli/test/integration/generators/relation.integration.js
@@ -15,6 +15,7 @@ const generator = path.join(__dirname, '../../../generators/relation');
 const SANDBOX_FILES = require('../../fixtures/relation').SANDBOX_FILES2;
 const SANDBOX_FILES4 = require('../../fixtures/relation').SANDBOX_FILES4;
 const testUtils = require('../../test-utils');
+const fs = require('fs');
 
 // Test Sandbox
 const CONTROLLER_PATH = 'src/controllers';
@@ -303,6 +304,497 @@ describe('lb4 relation', /** @this {Mocha.Suite} */ function () {
 
       assert.file(expectedControllerIndexFile);
       expectFileToMatchSnapshot(expectedControllerIndexFile);
+    });
+  });
+});
+
+describe('lb4 relation overwrite by passing --force flag', /** @this {Mocha.Suite} */ function () {
+  this.timeout(30000);
+
+  context('Execute relation when relation already exists', () => {
+    it('rejects when relation already exists and no --force flag is provided in belongsTo relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+      const doctorModel = path.join(
+        projectPath,
+        'src',
+        'models',
+        'doctor.model.ts',
+      );
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'belongsTo',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--foreignKeyName',
+          'patientId',
+          '--relationName',
+          'patients',
+        ])
+        .toPromise();
+
+      const modelWithRelation = fs.readFileSync(doctorModel, 'utf8');
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath, dir => {
+            testUtils.givenLBProject(dir, {
+              additionalFiles: SANDBOX_FILES,
+            });
+            fs.writeFileSync(doctorModel, modelWithRelation);
+            console.log(
+              '=== RESTORED MODEL CONTENT ===\n',
+              fs.readFileSync(doctorModel, 'utf8'),
+            );
+          })
+          .withArguments([
+            '--relationType',
+            'belongsTo',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--foreignKeyName',
+            'patientId',
+            '--relationName',
+            'patients',
+          ])
+          .toPromise(),
+      ).to.be.rejectedWith(
+        /relational property .* already exist in the model .* Use --force to overwrite it/i,
+      );
+    });
+
+    it('allows overwriting when --force flag is provided in belongsTo relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'belongsTo',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patients',
+        ])
+        .toPromise();
+
+      const doctorModel = path.join(
+        projectPath,
+        'src',
+        'models',
+        'doctor.model.ts',
+      );
+
+      if (fs.existsSync(doctorModel)) {
+        console.log('Doctor model:\n', fs.readFileSync(doctorModel, 'utf8'));
+      }
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath, dir =>
+            testUtils.givenLBProject(dir, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments([
+            '--relationType',
+            'belongsTo',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patients',
+            '--force',
+          ])
+          .toPromise(),
+      ).to.not.be.rejected;
+    });
+
+    it('rejects when relation already exists and no --force flag is provided in hasMany relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'hasMany',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patients',
+        ]);
+
+      const doctorModelPath = path.join(
+        projectPath,
+        'src',
+        'models',
+        'doctor.model.ts',
+      );
+
+      console.log('Doctor model exists:', fs.existsSync(doctorModelPath));
+
+      if (fs.existsSync(doctorModelPath)) {
+        console.log(
+          'Doctor model content:\n',
+          fs.readFileSync(doctorModelPath, 'utf8'),
+        );
+      }
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(sandbox.path, dir =>
+            testUtils.givenLBProject(dir, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments([
+            '--relationType',
+            'hasMany',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patients',
+          ]),
+      ).to.be.rejectedWith(
+        /relational property .* already exist in the model .* Use --force to overwrite it/i,
+      );
+    });
+
+    it('allows overwriting when --force flag is provided in hasMany relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'hasMany',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patients',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath, dir =>
+            testUtils.givenLBProject(dir, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments([
+            '--relationType',
+            'hasMany',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patients',
+            '--force',
+          ]),
+      ).to.not.be.rejected;
+    });
+
+    it('rejects when relation already exists and no --force flag is provided in hasManyThrough relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'hasManyThrough',
+          '--sourceModel',
+          'Customer',
+          '--destinationModel',
+          'Order',
+          '--throughModel',
+          'Address',
+          '--relationName',
+          'orders',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath)
+          .withArguments([
+            '--relationType',
+            'hasManyThrough',
+            '--sourceModel',
+            'Customer',
+            '--destinationModel',
+            'Order',
+            '--throughModel',
+            'Address',
+            '--relationName',
+            'orders',
+          ]),
+      ).to.be.rejectedWith(
+        /relational property .* already exist in the model .* Use --force to overwrite it/i,
+      );
+    });
+
+    it('allows overwriting when --force flag is provided in hasManyThrough relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'hasManyThrough',
+          '--sourceModel',
+          'Customer',
+          '--destinationModel',
+          'Order',
+          '--throughModel',
+          'Address',
+          '--relationName',
+          'orders',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath, dir =>
+            testUtils.givenLBProject(dir, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments([
+            '--relationType',
+            'hasManyThrough',
+            '--sourceModel',
+            'Customer',
+            '--destinationModel',
+            'Order',
+            '--throughModel',
+            'Address',
+            '--relationName',
+            'orders',
+            '--force',
+          ]),
+      ).to.not.be.rejected;
+    });
+
+    it('rejects when relation already exists and no --force flag is provided in hasOne relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'hasOne',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patient',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath)
+          .withArguments([
+            '--relationType',
+            'hasOne',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patient',
+          ]),
+      ).to.be.rejectedWith(
+        /relational property .* already exist in the model .* Use --force to overwrite it/i,
+      );
+    });
+
+    it('allows overwriting when --force flag is provided in hasOne relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'hasOne',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patient',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath)
+          .withArguments([
+            '--relationType',
+            'hasOne',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patient',
+            '--force',
+          ]),
+      ).to.not.be.rejected;
+    });
+
+    it('rejects when relation already exists and no --force flag is provided in referencesMany relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'referencesMany',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patientIds',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath)
+          .withArguments([
+            '--relationType',
+            'referencesMany',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patientIds',
+          ]),
+      ).to.be.rejectedWith(
+        /relational property .* already exist in the model .* Use --force to overwrite it/i,
+      );
+    });
+
+    it('allows overwriting when --force flag is provided in referencesMany relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'referencesMany',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--relationName',
+          'patientIds',
+        ]);
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath, dir =>
+            testUtils.givenLBProject(dir, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments([
+            '--relationType',
+            'referencesMany',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--relationName',
+            'patientIds',
+            '--force',
+          ]),
+      ).to.not.be.rejected;
     });
   });
 });

--- a/packages/cli/test/integration/generators/relation.integration.js
+++ b/packages/cli/test/integration/generators/relation.integration.js
@@ -15,6 +15,7 @@ const generator = path.join(__dirname, '../../../generators/relation');
 const SANDBOX_FILES = require('../../fixtures/relation').SANDBOX_FILES2;
 const SANDBOX_FILES4 = require('../../fixtures/relation').SANDBOX_FILES4;
 const testUtils = require('../../test-utils');
+const fs = require('fs');
 
 // Test Sandbox
 const CONTROLLER_PATH = 'src/controllers';
@@ -314,6 +315,70 @@ describe('lb4 relation overwrite by passing --force flag', /** @this {Mocha.Suit
     it('rejects when relation already exists and no --force flag is provided in belongsTo relation', async () => {
       await sandbox.reset();
       const projectPath = sandbox.path;
+      const doctorModel = path.join(
+        projectPath,
+        'src',
+        'models',
+        'doctor.model.ts',
+      );
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(projectPath, dir =>
+          testUtils.givenLBProject(dir, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments([
+          '--relationType',
+          'belongsTo',
+          '--sourceModel',
+          'Doctor',
+          '--destinationModel',
+          'Patient',
+          '--foreignKeyName',
+          'patientId',
+          '--relationName',
+          'patients',
+        ])
+        .toPromise();
+
+      const modelWithRelation = fs.readFileSync(doctorModel, 'utf8');
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(projectPath, dir => {
+            testUtils.givenLBProject(dir, {
+              additionalFiles: SANDBOX_FILES,
+            });
+            fs.writeFileSync(doctorModel, modelWithRelation);
+            console.log(
+              '=== RESTORED MODEL CONTENT ===\n',
+              fs.readFileSync(doctorModel, 'utf8'),
+            );
+          })
+          .withArguments([
+            '--relationType',
+            'belongsTo',
+            '--sourceModel',
+            'Doctor',
+            '--destinationModel',
+            'Patient',
+            '--foreignKeyName',
+            'patientId',
+            '--relationName',
+            'patients',
+          ])
+          .toPromise(),
+      ).to.be.rejectedWith(
+        /relational property .* already exist in the model .* Use --force to overwrite it/i,
+      );
+    });
+
+    it('allows overwriting when --force flag is provided in belongsTo relation', async () => {
+      await sandbox.reset();
+      const projectPath = sandbox.path;
 
       await testUtils
         .executeGenerator(generator)
@@ -331,52 +396,19 @@ describe('lb4 relation overwrite by passing --force flag', /** @this {Mocha.Suit
           'Patient',
           '--relationName',
           'patients',
-        ]);
-      process.chdir(projectPath);
+        ])
+        .toPromise();
 
-      return expect(
-        testUtils
-          .executeGenerator(generator)
-          .withArguments([
-            '--relationType',
-            'belongsTo',
-            '--sourceModel',
-            'Doctor',
-            '--destinationModel',
-            'Patient',
-            '--relationName',
-            'patients',
-          ]),
-      ).to.be.rejectedWith(
-        /relational property .* already exist in the model .* Use --force to overwrite it/i,
+      const doctorModel = path.join(
+        projectPath,
+        'src',
+        'models',
+        'doctor.model.ts',
       );
-    });
 
-    it('allows overwriting when --force flag is provided in belongsTo relation', async () => {
-      await sandbox.reset();
-      const projectPath = sandbox.path;
-      console.log('1. projectPath:', projectPath);
-
-      await testUtils
-        .executeGenerator(generator)
-        .inDir(projectPath, dir => {
-          console.log('2. dir inside callback:', dir);
-          testUtils.givenLBProject(dir, {
-            additionalFiles: SANDBOX_FILES,
-          });
-        })
-        .withArguments([
-          '--relationType',
-          'belongsTo',
-          '--sourceModel',
-          'Doctor',
-          '--destinationModel',
-          'Patient',
-          '--relationName',
-          'patients',
-        ]);
-      const fs = require('fs');
-      console.log('3. files after first run:', fs.readdirSync(projectPath));
+      if (fs.existsSync(doctorModel)) {
+        console.log('Doctor model:\n', fs.readFileSync(doctorModel, 'utf8'));
+      }
 
       return expect(
         testUtils
@@ -396,7 +428,8 @@ describe('lb4 relation overwrite by passing --force flag', /** @this {Mocha.Suit
             '--relationName',
             'patients',
             '--force',
-          ]),
+          ])
+          .toPromise(),
       ).to.not.be.rejected;
     });
 
@@ -421,6 +454,22 @@ describe('lb4 relation overwrite by passing --force flag', /** @this {Mocha.Suit
           '--relationName',
           'patients',
         ]);
+
+      const doctorModelPath = path.join(
+        projectPath,
+        'src',
+        'models',
+        'doctor.model.ts',
+      );
+
+      console.log('Doctor model exists:', fs.existsSync(doctorModelPath));
+
+      if (fs.existsSync(doctorModelPath)) {
+        console.log(
+          'Doctor model content:\n',
+          fs.readFileSync(doctorModelPath, 'utf8'),
+        );
+      }
 
       return expect(
         testUtils


### PR DESCRIPTION
Previously, creating the same relation twice in LoopBack would fail with no way to intentionally overwrite it. This PR adds a --force flag: when a relation already exists, passing --force will overwrite the existing relation instead of throwing an error.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
