### PR TITLE
fix(tsdocs): re-enable proper apidocs generation

### DIFF
--- a/extensions/typeorm/src/typeorm.mixin.ts
+++ b/extensions/typeorm/src/typeorm.mixin.ts
@@ -15,6 +15,10 @@ import {
   LifeCycleObserver,
   MixinTarget,
 } from '@loopback/core';
+// `EventEmitter` required to allow tsdoc generation.
+// see: https://github.com/loopbackio/loopback-next/issues/10205
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type {EventEmitter} from 'events';
 import debugFactory from 'debug';
 import {Connection, ConnectionManager, ConnectionOptions} from 'typeorm';
 import {TypeOrmConnectionBooter} from './';

--- a/package-lock.json
+++ b/package-lock.json
@@ -34116,6 +34116,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
       "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@gar/promisify": "^1.0.1",
@@ -34126,6 +34127,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 6"
@@ -34135,6 +34137,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -34145,6 +34148,7 @@
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
       "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@npmcli/fs": "^1.0.0",
@@ -34174,6 +34178,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
@@ -34186,6 +34191,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -34206,6 +34212,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@tootallnate/once": "1",
@@ -34220,12 +34227,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "optional": true
     },
     "node_modules/sqlite3/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -34238,6 +34247,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
       "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "agentkeepalive": "^4.1.3",
@@ -34265,6 +34275,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -34277,6 +34288,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -34289,6 +34301,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
       "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "minipass": "^3.1.0",
@@ -34306,6 +34319,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
       "optional": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -34318,6 +34332,7 @@
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
       "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "env-paths": "^2.2.0",
@@ -34342,6 +34357,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "abbrev": "1"
@@ -34357,6 +34373,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -34372,6 +34389,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
       "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "agent-base": "^6.0.2",
@@ -34386,6 +34404,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
       "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "minipass": "^3.1.1"
@@ -34398,6 +34417,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "unique-slug": "^2.0.0"
@@ -34407,6 +34427,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
@@ -34416,6 +34437,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
@@ -37505,9 +37527,9 @@
       }
     },
     "node_modules/validate-npm-package-name": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.0.tgz",
-      "integrity": "sha512-bwVk/OK+Qu108aJcMAEiU4yavHUI7aN20TgZNBj9MR2iU1zPUl1Z1Otr7771ExfYTPTvfN8ZJ1pbr5Iklgt4xg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.1.tgz",
+      "integrity": "sha512-BM0Upcemlce8/9+HE+/VpWqn3u3mYh6Om/FEC8yPMnEHwf710fW5Q6fhjT1SQyRlZD1G9CJbgfH+rWgAcIvjlQ==",
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"

--- a/packages/boot/src/mixins/boot.mixin.ts
+++ b/packages/boot/src/mixins/boot.mixin.ts
@@ -16,6 +16,10 @@ import {
   createBindingFromClass,
   MixinTarget,
 } from '@loopback/core';
+// `EventEmitter` required to allow tsdoc generation.
+// see: https://github.com/loopbackio/loopback-next/issues/10205
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type {EventEmitter} from 'events';
 import {BootComponent} from '../boot.component';
 import {createComponentApplicationBooterBinding} from '../booters/component-application.booter';
 import {Bootstrapper} from '../bootstrapper';

--- a/packages/express/src/middleware-registry.ts
+++ b/packages/express/src/middleware-registry.ts
@@ -10,6 +10,10 @@ import {
   Context,
   Provider,
 } from '@loopback/core';
+// `EventEmitter` required to allow tsdoc generation.
+// see: https://github.com/loopbackio/loopback-next/issues/10205
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type {EventEmitter} from 'events';
 import {MiddlewareMixin} from './mixins/middleware.mixin';
 import {
   ExpressMiddlewareFactory,

--- a/packages/express/src/mixins/middleware.mixin.ts
+++ b/packages/express/src/mixins/middleware.mixin.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. and LoopBack contributors 2020. All Rights Reserved.
+// Copyright IBM Corp. and LoopBack contributors 2020-2025. All Rights Reserved.
 // Node module: @loopback/express
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
@@ -12,6 +12,10 @@ import {
   MixinTarget,
   Provider,
 } from '@loopback/core';
+// `EventEmitter` required to allow tsdoc generation.
+// see: https://github.com/loopbackio/loopback-next/issues/10205
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type {EventEmitter} from 'events';
 import {
   registerExpressMiddleware,
   registerMiddleware,

--- a/packages/repository/src/mixins/repository.mixin.ts
+++ b/packages/repository/src/mixins/repository.mixin.ts
@@ -14,6 +14,10 @@ import {
   createBindingFromClass,
   MixinTarget,
 } from '@loopback/core';
+// `EventEmitter` required to allow tsdoc generation.
+// see: https://github.com/loopbackio/loopback-next/issues/10205
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type {EventEmitter} from 'events';
 import debugFactory from 'debug';
 import {Class} from '../common-types';
 import {SchemaMigrationOptions} from '../datasource';

--- a/packages/service-proxy/src/mixins/service.mixin.ts
+++ b/packages/service-proxy/src/mixins/service.mixin.ts
@@ -14,6 +14,10 @@ import {
   Provider,
   ServiceOptions,
 } from '@loopback/core';
+// `EventEmitter` required to allow tsdoc generation.
+// see: https://github.com/loopbackio/loopback-next/issues/10205
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type {EventEmitter} from 'events';
 
 /**
  * Interface for classes with `new` operator.

--- a/packages/tsdocs/src/monorepo-api-extractor.ts
+++ b/packages/tsdocs/src/monorepo-api-extractor.ts
@@ -67,17 +67,6 @@ export async function runExtractorForMonorepo(options: ExtractorOptions = {}) {
   const errors: Record<string, unknown> = {};
 
   for (const pkg of packages) {
-    // TODO: api-extractor failed to generate apidocs for the repos below.
-    // Excluding them for now
-    // https://github.com/loopbackio/loopback-next/issues/10205
-    if (
-      pkg.name === '@loopback/typeorm' ||
-      pkg.name === '@loopback/boot' ||
-      pkg.name === '@loopback/express' ||
-      pkg.name === '@loopback/repository' ||
-      pkg.name === '@loopback/service-proxy'
-    )
-      continue;
     /* istanbul ignore if  */
     const err = invokeExtractorForPackage(pkg, options);
     if (err != null) {

--- a/packages/tsdocs/src/update-api-md-docs.ts
+++ b/packages/tsdocs/src/update-api-md-docs.ts
@@ -85,6 +85,7 @@ async function addJekyllMetadata(
 
     const docFile = path.join(apiDocsRoot, f);
     let doc = await fs.readFile(docFile, 'utf-8');
+    doc = doc.replace(/<td>/g, '<td markdown="1">');
 
     const pkgName = name.split('.')[0];
     // Calculate the relative uri for the package


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
- added workaround to re-enable generation of packages which use `MixinTarget<Application>`
- fixed markdown hyperlinks inside HTML tables

see: https://github.com/gettalong/kramdown/issues/822
fixes: https://github.com/loopbackio/loopback-next/issues/10205
Signed-off-by: Rifa Achrinza 
<25147899+achrinza@users.noreply.github.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
