### PR TITLE
feat(graphql): migrate to apollo server 5

### DIFF
--- a/extensions/graphql/package.json
+++ b/extensions/graphql/package.json
@@ -44,7 +44,8 @@
     "@loopback/rest": "^15.0.1"
   },
   "dependencies": {
-    "@apollo/server": "^4.13.0",
+    "@apollo/server": "^5.5.1",
+    "@as-integrations/express4": "^1.1.2",
     "@graphql-tools/utils": "^11.1.0",
     "@loopback/http-server": "^7.0.12",
     "body-parser": "^2.2.2",

--- a/extensions/graphql/src/__tests__/unit/graphql.server.unit.ts
+++ b/extensions/graphql/src/__tests__/unit/graphql.server.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ExpressContextFunctionArgument} from '@apollo/server/dist/esm/express4';
+import {ExpressContextFunctionArgument} from '@as-integrations/express4';
 import {expect} from '@loopback/testlab';
 import {
   field,

--- a/extensions/graphql/src/graphql.container.ts
+++ b/extensions/graphql/src/graphql.container.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ExpressContextFunctionArgument} from '@apollo/server/dist/esm/express4';
+import {ExpressContextFunctionArgument} from '@as-integrations/express4';
 import {
   Binding,
   BindingScope,

--- a/extensions/graphql/src/graphql.server.ts
+++ b/extensions/graphql/src/graphql.server.ts
@@ -8,23 +8,25 @@ import {
   ApolloServerOptionsWithSchema,
   BaseContext,
 } from '@apollo/server';
-import {ExpressMiddlewareOptions} from '@apollo/server/dist/esm/express4';
-import {expressMiddleware} from '@apollo/server/express4';
+import {
+  ExpressMiddlewareOptions,
+  expressMiddleware,
+} from '@as-integrations/express4';
 import {printSchemaWithDirectives} from '@graphql-tools/utils';
 import {
   Binding,
   BindingFromClassOptions,
   BindingKey,
   BindingScope,
-  config,
   Constructor,
   Context,
   ContextTags,
+  Server,
+  config,
   createBindingFromClass,
   filterByTag,
   inject,
   lifeCycleObserver,
-  Server,
 } from '@loopback/core';
 import {HttpServer} from '@loopback/http-server';
 import {RestBindings, RestServer} from '@loopback/rest';
@@ -38,10 +40,10 @@ import * as http from 'http';
 import * as https from 'https';
 import {
   AuthChecker,
-  buildSchema,
   NonEmptyArray,
   ResolverInterface,
   BuildSchemaOptions as TypeGrahpQLBuildSchemaOptions,
+  buildSchema,
 } from 'type-graphql';
 import {Middleware} from 'type-graphql/build/typings/typings/middleware';
 import {WebSocketServer} from 'ws';
@@ -174,7 +176,6 @@ export class GraphQLServer extends Context implements Server {
     const serverConfig = {
       ...this.options.apollo,
       schema,
-      status400ForVariableCoercionErrors: true,
       // plugins: [ApolloServerPluginDrainHttpServer({ httpServer: this.httpServer })],
     } as ApolloServerOptionsWithSchema<BaseContext>;
     const graphQLServer = new ApolloServer(serverConfig);

--- a/extensions/graphql/src/keys.ts
+++ b/extensions/graphql/src/keys.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ExpressMiddlewareOptions} from '@apollo/server/dist/esm/express4';
+import {ExpressMiddlewareOptions} from '@as-integrations/express4';
 import {BindingKey, Constructor, CoreBindings} from '@loopback/core';
 import {AuthChecker, PubSub, ResolverData} from 'type-graphql';
 import {GraphQLComponent} from './graphql.component';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1723,7 +1723,8 @@
       "version": "0.13.3",
       "license": "MIT",
       "dependencies": {
-        "@apollo/server": "^4.13.0",
+        "@apollo/server": "^5.5.1",
+        "@as-integrations/express4": "^1.1.2",
         "@graphql-tools/utils": "^11.1.0",
         "@loopback/http-server": "^7.0.12",
         "body-parser": "^2.2.2",
@@ -2224,79 +2225,86 @@
       }
     },
     "node_modules/@apollo/server": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.13.0.tgz",
-      "integrity": "sha512-t4GzaRiYIcPwYy40db6QjZzgvTr9ztDKBddykUXmBb2SVjswMKXbkaJ5nPeHqmT3awr9PAaZdCZdZhRj55I/8A==",
-      "deprecated": "Apollo Server v4 is end-of-life since January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.",
-      "license": "MIT",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.5.1.tgz",
+      "integrity": "sha512-Rn3g5TJQsMSUY23CWZTghWdBWyjX7dP1eaEBPkvmM2RHi82cDcpgTIkSCbGvtTUEGjwopLv1AAooU/n7iIZ20A==",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.3",
-        "@apollo/server-gateway-interface": "^1.1.1",
+        "@apollo/server-gateway-interface": "^2.0.0",
         "@apollo/usage-reporting-protobuf": "^4.1.1",
-        "@apollo/utils.createhash": "^2.0.2",
-        "@apollo/utils.fetcher": "^2.0.0",
-        "@apollo/utils.isnodelike": "^2.0.0",
-        "@apollo/utils.keyvaluecache": "^2.1.0",
-        "@apollo/utils.logger": "^2.0.0",
+        "@apollo/utils.createhash": "^3.0.0",
+        "@apollo/utils.fetcher": "^3.0.0",
+        "@apollo/utils.isnodelike": "^3.0.0",
+        "@apollo/utils.keyvaluecache": "^4.0.0",
+        "@apollo/utils.logger": "^3.0.0",
         "@apollo/utils.usagereporting": "^2.1.0",
-        "@apollo/utils.withrequired": "^2.0.0",
-        "@graphql-tools/schema": "^9.0.0",
-        "@types/express": "^4.17.13",
-        "@types/express-serve-static-core": "^4.17.30",
-        "@types/node-fetch": "^2.6.1",
+        "@apollo/utils.withrequired": "^3.0.0",
+        "@graphql-tools/schema": "^10.0.0",
         "async-retry": "^1.2.1",
+        "body-parser": "^2.2.2",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "express": "^4.21.1",
+        "finalhandler": "^2.1.0",
         "loglevel": "^1.6.8",
-        "lru-cache": "^7.10.1",
-        "negotiator": "^0.6.3",
-        "node-abort-controller": "^3.1.1",
-        "node-fetch": "^2.6.7",
-        "uuid": "^9.0.0",
-        "whatwg-mimetype": "^3.0.0"
+        "lru-cache": "^11.1.0",
+        "negotiator": "^1.0.0",
+        "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">=14.16.0"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "graphql": "^16.6.0"
+        "graphql": "^16.11.0"
       }
     },
     "node_modules/@apollo/server-gateway-interface": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.1.1.tgz",
-      "integrity": "sha512-pGwCl/po6+rxRmDMFgozKQo2pbsSwE91TpsDBAOgf74CRDPXHHtM88wbwjab0wMMZh95QfR45GGyDIdhY24bkQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-2.0.0.tgz",
+      "integrity": "sha512-3HEMD6fSantG2My3jWkb9dvfkF9vJ4BDLRjMgsnD790VINtuPaEp+h3Hg9HOHiWkML6QsOhnaRqZ+gvhp3y8Nw==",
       "dependencies": {
         "@apollo/usage-reporting-protobuf": "^4.1.1",
-        "@apollo/utils.fetcher": "^2.0.0",
-        "@apollo/utils.keyvaluecache": "^2.1.0",
-        "@apollo/utils.logger": "^2.0.0"
+        "@apollo/utils.fetcher": "^3.0.0",
+        "@apollo/utils.keyvaluecache": "^4.0.0",
+        "@apollo/utils.logger": "^3.0.0"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
       }
     },
-    "node_modules/@apollo/server/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
+    "node_modules/@apollo/server/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/@apollo/server/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+    "node_modules/@apollo/server/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@apollo/usage-reporting-protobuf": {
@@ -2308,16 +2316,15 @@
       }
     },
     "node_modules/@apollo/utils.createhash": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-2.0.2.tgz",
-      "integrity": "sha512-UkS3xqnVFLZ3JFpEmU/2cM2iKJotQXMoSTgxXsfQgXLC5gR1WaepoXagmYnPSA7Q/2cmnyTYK5OgAgoC4RULPg==",
-      "license": "MIT",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-3.0.1.tgz",
+      "integrity": "sha512-CKrlySj4eQYftBE5MJ8IzKwIibQnftDT7yGfsJy5KSEEnLlPASX0UTpbKqkjlVEwPPd4mEwI7WOM7XNxEuO05A==",
       "dependencies": {
-        "@apollo/utils.isnodelike": "^2.0.1",
+        "@apollo/utils.isnodelike": "^3.0.0",
         "sha.js": "^2.4.11"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@apollo/utils.dropunuseddefinitions": {
@@ -2333,50 +2340,47 @@
       }
     },
     "node_modules/@apollo/utils.fetcher": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-2.0.1.tgz",
-      "integrity": "sha512-jvvon885hEyWXd4H6zpWeN3tl88QcWnHp5gWF5OPF34uhvoR+DFqcNxs9vrRaBBSY3qda3Qe0bdud7tz2zGx1A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-3.1.0.tgz",
+      "integrity": "sha512-Z3QAyrsQkvrdTuHAFwWDNd+0l50guwoQUoaDQssLOjkmnmVuvXlJykqlEJolio+4rFwBnWdoY1ByFdKaQEcm7A==",
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@apollo/utils.isnodelike": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-2.0.1.tgz",
-      "integrity": "sha512-w41XyepR+jBEuVpoRM715N2ZD0xMD413UiJx8w5xnAZD2ZkSJnMJBoIzauK83kJpSgNuR6ywbV29jG9NmxjK0Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-3.0.0.tgz",
+      "integrity": "sha512-xrjyjfkzunZ0DeF6xkHaK5IKR8F1FBq6qV+uZ+h9worIF/2YSzA0uoBxGv6tbTeo9QoIQnRW4PVFzGix5E7n/g==",
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@apollo/utils.keyvaluecache": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.1.tgz",
-      "integrity": "sha512-qVo5PvUUMD8oB9oYvq4ViCjYAMWnZ5zZwEjNF37L2m1u528x5mueMlU+Cr1UinupCgdB78g+egA1G98rbJ03Vw==",
-      "license": "MIT",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-4.0.0.tgz",
+      "integrity": "sha512-mKw1myRUkQsGPNB+9bglAuhviodJ2L2MRYLTafCMw5BIo7nbvCPNCkLnIHjZ1NOzH7SnMAr5c9LmXiqsgYqLZw==",
       "dependencies": {
-        "@apollo/utils.logger": "^2.0.1",
-        "lru-cache": "^7.14.1"
+        "@apollo/utils.logger": "^3.0.0",
+        "lru-cache": "^11.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/@apollo/utils.keyvaluecache/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "engines": {
-        "node": ">=12"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@apollo/utils.logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
-      "license": "MIT",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-3.0.0.tgz",
+      "integrity": "sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==",
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@apollo/utils.printwithreducedwhitespace": {
@@ -2451,11 +2455,23 @@
       }
     },
     "node_modules/@apollo/utils.withrequired": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-2.0.1.tgz",
-      "integrity": "sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-3.0.0.tgz",
+      "integrity": "sha512-aaxeavfJ+RHboh7c2ofO5HHtQobGX4AgUujXP4CXpREHp9fQ9jPi6K9T1jrAKe7HIipoP0OJ1gd6JamSkFIpvA==",
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
+      }
+    },
+    "node_modules/@as-integrations/express4": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@as-integrations/express4/-/express4-1.1.2.tgz",
+      "integrity": "sha512-PGeMcwoOKdYnZ4LtsmM7aLNoel3tbK8wKnfyahdRau1qb7wLbuaXB35zg3w34Ov4bm3WJtO3yzd8Bw5jVE+aIQ==",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@apollo/server": "^4.0.0 || ^5.0.0",
+        "express": "^4.0.0"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3601,54 +3617,31 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
-      "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
-      "license": "MIT",
+      "version": "9.1.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.9.tgz",
+      "integrity": "sha512-iHUWNjRHeQRYdgIMIuChThOwoKzA9vrzYeslgfBo5eUYEyHGZCoDPjAavssoYXLwstYt1dZj2J22jSzc2DrN0Q==",
       "dependencies": {
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-tools/utils": "^11.1.0",
         "tslib": "^2.4.0"
       },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "tslib": "^2.4.0"
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "9.0.19",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
-      "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
-      "license": "MIT",
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.33.tgz",
+      "integrity": "sha512-O6P3RIftO0jafnSsFAqpjurUuUxJ43s/AdPVLQsBkI6y4Ic/tKm4C1Qm1KKQsCDTOxXPJClh/v3g7k7yLKCFBQ==",
       "dependencies": {
-        "@graphql-tools/merge": "^8.4.1",
-        "@graphql-tools/utils": "^9.2.1",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
+        "@graphql-tools/merge": "^9.1.9",
+        "@graphql-tools/utils": "^11.1.0",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -9261,6 +9254,7 @@
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.5.tgz",
       "integrity": "sha512-OZsUlr2nxvkqUFLSaY2ZbA+P1q22q+KrlxWOn/38RX+u5kTkYL2mTujEpzUhGkS+K/QCYp9oagfXG39XOzyySg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
@@ -26537,7 +26531,8 @@
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "dev": true
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
@@ -36246,15 +36241,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/value-or-promise": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
-      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -36554,11 +36540,11 @@
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {


### PR DESCRIPTION
# [graphql] Migrate GraphQL Extension to Apollo Server 5

Currently, the GraphQL extension uses Apollo Server 4, which has been end-of-life since January 26, 2026. This PR migrates the extension to Apollo Server 5.
