### PR TITLE
fix: update Chrome installation for Puppeteer across platforms

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,6 +44,28 @@ jobs:
         env:
           PYTHON: ${{env.pythonLocation}}/bin/python3
         run: npm ci
+      - name: Install Chrome (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-stable
+      - name: Install Chrome (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install --cask google-chrome
+      - name: Install Chrome (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install googlechrome --ignore-checksums -y
+      - name: Set Chrome path (Linux)
+        if: runner.os == 'Linux'
+        run: echo "PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome" >> $GITHUB_ENV
+      - name: Set Chrome path (macOS)
+        if: runner.os == 'macOS'
+        run: echo "PUPPETEER_EXECUTABLE_PATH=/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" >> $GITHUB_ENV
+      - name: Set Chrome path (Windows)
+        if: runner.os == 'Windows'
+        run: echo "PUPPETEER_EXECUTABLE_PATH=C:/Program Files/Google/Chrome/Application/chrome.exe" >> $env:GITHUB_ENV
       - name: Build
         run: node packages/build/bin/compile-package -b
       - name: Run package tests


### PR DESCRIPTION
# Fix Chrome Installation for Puppeteer Across Platforms

## Description

This PR updates the CI workflow to properly install and configure Google Chrome for Puppeteer across all supported operating systems (Linux, macOS, and Windows).

Previously, Chrome was only installed and configured for Linux, causing Puppeteer-based tests to fail on other platforms.

## Changes

- Added Chrome installation steps for:
  - macOS using `brew install --cask google-chrome`
  - Windows using `choco install googlechrome`
- Ensured Chrome is installed on Linux via `apt-get`
- Configured `PUPPETEER_EXECUTABLE_PATH` environment variable for:
  - Linux (`/usr/bin/google-chrome`)
  - macOS (`/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`)
  - Windows (`C:/Program Files/Google/Chrome/Application/chrome.exe`)

## Motivation

Puppeteer requires a Chromium/Chrome executable to run browser-based tests. Without proper installation and configuration, tests fail in CI environments.

This change ensures consistent test execution across all supported CI platforms.

## Checklist

- [x] DCO (Developer Certificate of Origin) signed in all commits
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified (N/A)
- [x] Code conforms with the style guide
- [ ] Documentation updated (N/A)
