### PR TITLE
fix: conditionally import param and requestBody in controller template

### DIFF
--- a/packages/cli/generators/openapi/spec-helper.js
+++ b/packages/cli/generators/openapi/spec-helper.js
@@ -455,6 +455,13 @@ function buildControllerSpecs(operationsMapByController, options) {
     controllerSpec.methods = entry.operations.map(op =>
       buildMethodSpec(controllerSpec, op, options),
     );
+    // Track whether param and requestBody decorators are used
+    controllerSpec.usesParam = controllerSpec.methods.some(m =>
+      m.signature && m.signature.includes('@param('),
+    );
+    controllerSpec.usesRequestBody = controllerSpec.methods.some(m =>
+      m.signature && m.signature.includes('@requestBody('),
+    );
     controllerSpec.methodMappingObject = printSpecObject(
       controllerSpec.methodMapping,
     );

--- a/packages/cli/generators/openapi/templates/src/controllers/controller-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/controllers/controller-template.ts.ejs
@@ -1,4 +1,4 @@
-import {api, operation, param, requestBody} from '@loopback/rest';<%if (withImplementation) { %>
+import {api, operation<% if (usesParam) { %>, param<% } %><% if (usesRequestBody) { %>, requestBody<% } %>} from '@loopback/rest';<%if (withImplementation) { %>
 import {inject} from '@loopback/core';
 
 import {<%- serviceClassName %>} from '../services';


### PR DESCRIPTION
## Summary

Fixes #3335 - The OpenAPI controller template unconditionally imported `param` and `requestBody` decorators from `@loopback/rest`, even when the generated controller did not use any parameters or request bodies.

## Changes

- **`spec-helper.js`**: Added tracking for whether `@param` and `@requestBody` decorators are used in controller methods
- **`controller-template.ts.ejs`**: Conditionally import these decorators only when needed

## Before

```ts
import {api, operation, param, requestBody} from "@loopback/rest";

export class MyController {
  constructor() {}
  
  async getAll(): Promise<string[]> {
    throw new Error("Not implemented");
  }
}
```

## After

```ts
import {api, operation} from "@loopback/rest";

export class MyController {
  constructor() {}
  
  async getAll(): Promise<string[]> {
    throw new Error("Not implemented");
  }
}
```

## Benefits

- Eliminates ESLint `no-unused-imports` errors
- Cleaner generated code
- Better developer experience

Closes #3335