### PR TITLE
chore: drop node.js 20 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
         include:
           - os: windows-2022
             node-version: 22 # LTS

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Make sure you have the following installed:
 
 | Package                                    | Version/-s                                                             | Link                                  | Note                                                                                                  |
 | ------------------------------------------ | ---------------------------------------------------------------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| [Node.js](https://nodejs.org/en/download/) | Maintenance LTS (_v20_) <br/> Active LTS (_v22_) <br/> Current (_v24_) | https://nodejs.org/en/about/releases/ | <span style="color: yellow;">The use of the current version for production is not recommended</span>. |
+| [Node.js](https://nodejs.org/en/download/) | Maintenance LTS (_v22_) <br/> Active LTS (_v24_) <br/> Current (_v26_) | https://nodejs.org/en/about/releases/ | <span style="color: yellow;">The use of the current version for production is not recommended</span>. |
 
 You can generate a project with our generator or with the CLI as follows:
 

--- a/acceptance/extension-logging-fluentd/package.json
+++ b/acceptance/extension-logging-fluentd/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/extension-logging-fluentd"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-cloudant/package.json
+++ b/acceptance/repository-cloudant/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/repository-cloudant"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-mongodb/package.json
+++ b/acceptance/repository-mongodb/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/repository-mongodb"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-mysql/package.json
+++ b/acceptance/repository-mysql/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/repository-mysql"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-postgresql/package.json
+++ b/acceptance/repository-postgresql/package.json
@@ -14,7 +14,7 @@
     "directory": "acceptance/repository-postgresql"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -19,7 +19,7 @@
     "directory": "benchmark"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/bodyparsers/rest-msgpack/package.json
+++ b/bodyparsers/rest-msgpack/package.json
@@ -13,7 +13,7 @@
     "directory": "bodyparsers/rest-msgpack"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
     "directory": "docs"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "version": "node ./bin/copy-readmes.js && node ./bin/copy-changelogs.js && cd .. && npm run tsdocs",

--- a/examples/access-control-migration/package.json
+++ b/examples/access-control-migration/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/access-control-migration"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/binding-resolution/package.json
+++ b/examples/binding-resolution/package.json
@@ -21,7 +21,7 @@
     "directory": "examples/binding-resolution"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/context/package.json
+++ b/examples/context/package.json
@@ -19,7 +19,7 @@
     "directory": "examples/context"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -20,7 +20,7 @@
     "directory": "examples/express-composition"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/file-transfer/package.json
+++ b/examples/file-transfer/package.json
@@ -20,7 +20,7 @@
     "directory": "examples/file-transfer"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -17,7 +17,7 @@
     "directory": "examples/graphql"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/loopbackio/loopback-next/issues"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/greeting-app/package.json
+++ b/examples/greeting-app/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/loopbackio/loopback-next/issues"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -19,7 +19,7 @@
     "directory": "examples/hello-world"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/lb3-application/package.json
+++ b/examples/lb3-application/package.json
@@ -18,7 +18,7 @@
     "directory": "examples/lb3-application"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/loopbackio/loopback-next/issues"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/metrics-prometheus/package.json
+++ b/examples/metrics-prometheus/package.json
@@ -19,7 +19,7 @@
     "directory": "examples/metrics-prometheus"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/examples/multi-tenancy/package.json
+++ b/examples/multi-tenancy/package.json
@@ -18,7 +18,7 @@
     "directory": "examples/multi-tenancy"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/passport-login/package.json
+++ b/examples/passport-login/package.json
@@ -21,7 +21,7 @@
     "directory": "examples/passport-login"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/references-many/package.json
+++ b/examples/references-many/package.json
@@ -24,7 +24,7 @@
     "directory": "examples/references-many"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/rest-crud/package.json
+++ b/examples/rest-crud/package.json
@@ -21,7 +21,7 @@
     "directory": "examples/rest-crud"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -17,7 +17,7 @@
     "directory": "examples/rpc-server"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -20,7 +20,7 @@
     "directory": "examples/soap-calculator"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/socketio/package.json
+++ b/examples/socketio/package.json
@@ -17,7 +17,7 @@
     "directory": "examples/socketio"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/todo-jwt/package.json
+++ b/examples/todo-jwt/package.json
@@ -24,7 +24,7 @@
     "directory": "examples/todo-jwt"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -24,7 +24,7 @@
     "directory": "examples/todo-list"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/todo"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/validation-app/package.json
+++ b/examples/validation-app/package.json
@@ -19,7 +19,7 @@
     "directory": "examples/validation-app"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -20,7 +20,7 @@
     "directory": "examples/webpack"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/apiconnect/package.json
+++ b/extensions/apiconnect/package.json
@@ -17,7 +17,7 @@
     "directory": "extensions/apiconnect"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/authentication-jwt/package.json
+++ b/extensions/authentication-jwt/package.json
@@ -18,7 +18,7 @@
     "directory": "extensions/authentication-jwt"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/authentication-passport/package.json
+++ b/extensions/authentication-passport/package.json
@@ -18,7 +18,7 @@
     "directory": "extensions/authentication-passport"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/context-explorer/package.json
+++ b/extensions/context-explorer/package.json
@@ -19,7 +19,7 @@
     "directory": "extensions/context-explorer"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/cron/package.json
+++ b/extensions/cron/package.json
@@ -18,7 +18,7 @@
     "directory": "extensions/cron"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/graphql/package.json
+++ b/extensions/graphql/package.json
@@ -17,7 +17,7 @@
     "directory": "extensions/graphql"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/health/package.json
+++ b/extensions/health/package.json
@@ -18,7 +18,7 @@
     "directory": "extensions/health"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/logging/package.json
+++ b/extensions/logging/package.json
@@ -20,7 +20,7 @@
     "directory": "extensions/logging"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/metrics/package.json
+++ b/extensions/metrics/package.json
@@ -19,7 +19,7 @@
     "directory": "extensions/metrics"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/pooling/package.json
+++ b/extensions/pooling/package.json
@@ -17,7 +17,7 @@
     "directory": "extensions/pooling"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/sequelize/package.json
+++ b/extensions/sequelize/package.json
@@ -19,7 +19,7 @@
     "directory": "extensions/sequelize"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/sequelize/src/__tests__/fixtures/datasources/config.ts
+++ b/extensions/sequelize/src/__tests__/fixtures/datasources/config.ts
@@ -54,8 +54,12 @@ export const datasourceTestConfig: Record<
       url: 'postgres://postgres:super-secret@localhost:5002/postgres',
     },
     sqlite3: {
+      // 'sqlite::memory:' is not a valid URL per the WHATWG URL standard.
+      // Node.js 26 made url.parse() throw on it (DEP0170 became a hard error).
+      // Use structured config to avoid Sequelize v6's legacy url.parse() path.
       name: 'using-url',
-      url: 'sqlite::memory:',
+      connector: 'sqlite3',
+      file: ':memory:',
     },
   },
   wrongPassword: {
@@ -65,8 +69,10 @@ export const datasourceTestConfig: Record<
       url: 'postgres://postgres:super-secret-wrong@localhost:5002/postgres',
     },
     sqlite3: {
+      // Same reason as above — use structured config instead of sqlite URL.
       name: 'wrongPassword',
-      url: 'sqlite::memory:',
+      connector: 'sqlite3',
+      file: ':memory:',
     },
   },
 };

--- a/extensions/sequelize/src/__tests__/unit/sequelize.datasource.unit.ts
+++ b/extensions/sequelize/src/__tests__/unit/sequelize.datasource.unit.ts
@@ -19,7 +19,7 @@ describe('Sequelize DataSource', () => {
     }
   });
 
-  it('accepts url strings for connection', async () => {
+  it('accepts url strings for connection (postgresql) / structured config (sqlite3)', async () => {
     const dataSource = new SequelizeDataSource(
       datasourceTestConfig.url[
         primaryDataSourceConfig.connector === 'postgresql'

--- a/extensions/socketio/package.json
+++ b/extensions/socketio/package.json
@@ -21,7 +21,7 @@
     "directory": "extensions/socketio"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/typeorm/package.json
+++ b/extensions/typeorm/package.json
@@ -13,7 +13,7 @@
     "directory": "extensions/typeorm"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/fixtures/mock-oauth2-provider/package.json
+++ b/fixtures/mock-oauth2-provider/package.json
@@ -13,7 +13,7 @@
     "directory": "fixtures/mock-oauth2-provider"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/fixtures/tsdocs-monorepo/package.json
+++ b/fixtures/tsdocs-monorepo/package.json
@@ -12,7 +12,7 @@
     "directory": "fixtures/tsdocs-monorepo"
   },
   "engines": {
-    "node": "20 || 22 || 24",
+    "node": "22 || 24 || 26",
     "npm": ">=7"
   },
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24",
+        "node": "22 || 24 || 26",
         "npm": ">=7"
       }
     },
@@ -64,7 +64,7 @@
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "acceptance/extension-logging-fluentd/node_modules/@types/node": {
@@ -105,7 +105,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "acceptance/repository-cloudant/node_modules/@types/node": {
@@ -140,7 +140,7 @@
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "acceptance/repository-mongodb/node_modules/@types/node": {
@@ -175,7 +175,7 @@
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "acceptance/repository-mysql/node_modules/@types/node": {
@@ -210,7 +210,7 @@
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "acceptance/repository-postgresql/node_modules/@types/node": {
@@ -261,7 +261,7 @@
         "source-map-support": "^0.5.21"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "benchmark/node_modules/@types/node": {
@@ -301,7 +301,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.1",
@@ -337,7 +337,7 @@
         "@loopback/build": "^12.0.14"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/access-control-migration": {
@@ -372,7 +372,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/access-control-migration/node_modules/@types/node": {
@@ -414,7 +414,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/binding-resolution/node_modules/@types/node": {
@@ -451,7 +451,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/context/node_modules/@types/node": {
@@ -495,7 +495,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/express-composition/node_modules/@types/node": {
@@ -538,7 +538,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/file-transfer/node_modules/@types/node": {
@@ -585,7 +585,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/graphql/node_modules/@types/node": {
@@ -625,7 +625,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/greeter-extension/node_modules/@types/node": {
@@ -668,7 +668,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/greeting-app/node_modules/@types/node": {
@@ -706,7 +706,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/hello-world/node_modules/@types/node": {
@@ -758,7 +758,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/lb3-application/node_modules/@types/node": {
@@ -799,7 +799,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/log-extension/node_modules/@types/node": {
@@ -839,7 +839,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/metrics-prometheus/node_modules/@types/node": {
@@ -886,7 +886,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/multi-tenancy/node_modules/@types/node": {
@@ -964,7 +964,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/passport-login/node_modules/@types/node": {
@@ -1010,7 +1010,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/references-many/node_modules/@types/node": {
@@ -1056,7 +1056,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/rest-crud/node_modules/@types/node": {
@@ -1095,7 +1095,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/rpc-server/node_modules/@types/node": {
@@ -1141,7 +1141,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/soap-calculator/node_modules/@types/node": {
@@ -1187,7 +1187,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/socketio/node_modules/@types/node": {
@@ -1235,7 +1235,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/todo-jwt": {
@@ -1268,7 +1268,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/todo-jwt/node_modules/@types/node": {
@@ -1314,7 +1314,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/todo-list/node_modules/@types/node": {
@@ -1375,7 +1375,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/validation-app/node_modules/@types/node": {
@@ -1420,7 +1420,7 @@
         "webpack-cli": "^7.2.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/webpack/node_modules/@types/node": {
@@ -1456,7 +1456,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -1508,7 +1508,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/authentication": "^12.0.1",
@@ -1571,7 +1571,7 @@
         "supertest": "^7.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/authentication": "^12.0.1",
@@ -1613,7 +1613,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -1655,7 +1655,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -1712,7 +1712,7 @@
         "class-transformer": "^0.5.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/boot": "^8.0.1",
@@ -1754,7 +1754,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -1799,7 +1799,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -1842,7 +1842,7 @@
         "express": "^4.22.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -1884,7 +1884,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -1931,7 +1931,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -1979,7 +1979,7 @@
         "socket.io-client": "^4.8.3"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/boot": "^8.0.1",
@@ -2009,7 +2009,7 @@
         "sqlite3": "^5.1.7"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/boot": "^8.0.1",
@@ -2058,7 +2058,7 @@
         "@loopback/testlab": "^8.0.14"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "fixtures/mock-oauth2-provider/node_modules/@types/node": {
@@ -2087,7 +2087,7 @@
         "@loopback/build": "^12.0.14"
       },
       "engines": {
-        "node": "20 || 22 || 24",
+        "node": "22 || 24 || 26",
         "npm": ">=7"
       }
     },
@@ -9165,6 +9165,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.24",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
@@ -9724,6 +9731,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "11.0.0",
@@ -12066,6 +12080,39 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
       "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g=="
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/chardet": {
       "version": "0.7.0",
@@ -14495,6 +14542,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -14686,6 +14747,16 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/des.js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
@@ -14729,6 +14800,20 @@
       "devOptional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/devtools-protocol": {
@@ -18708,6 +18793,32 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -18839,6 +18950,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -18909,6 +19031,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-in-ci": {
@@ -19859,6 +19992,16 @@
         "node": ">= 10.16.0"
       }
     },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -19945,6 +20088,33 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/keygrip": {
@@ -22112,6 +22282,26 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "17.1.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.1.0.tgz",
@@ -24212,6 +24402,10 @@
         "which": "bin/which"
       }
     },
+    "node_modules/loopback.io-workflow-scripts": {
+      "resolved": "sandbox/loopback.io",
+      "link": true
+    },
     "node_modules/loopback/node_modules/async": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
@@ -24835,6 +25029,44 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -24844,6 +25076,150 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
+      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "4.0.2",
+        "micromark-core-commonmark": "2.0.3",
+        "micromark-extension-directive": "4.0.0",
+        "micromark-extension-gfm-autolink-literal": "2.1.0",
+        "micromark-extension-gfm-footnote": "2.1.0",
+        "micromark-extension-gfm-table": "2.1.1",
+        "micromark-extension-math": "3.1.0",
+        "micromark-util-types": "2.0.2",
+        "string-width": "8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.48.0.tgz",
+      "integrity": "sha512-NkZQNu2E0Q5qLEEHwWj674eYISTLD4jMHkBzDobujXd1kv+yCxi8jOaD/rZoQNW1FBBMMGQpuW5So8B51N/e0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "~14.0.3",
+        "deep-extend": "~0.6.0",
+        "ignore": "~7.0.5",
+        "js-yaml": "~4.1.1",
+        "jsonc-parser": "~3.3.1",
+        "jsonpointer": "~5.0.1",
+        "markdown-it": "~14.1.1",
+        "markdownlint": "~0.40.0",
+        "minimatch": "~10.2.4",
+        "run-con": "~1.3.2",
+        "smol-toml": "~1.6.0",
+        "tinyglobby": "~0.2.15"
+      },
+      "bin": {
+        "markdownlint": "markdownlint.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/markdownlint-cli/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdownlint/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/markdownlint/node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdownlint/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/math-intrinsics": {
@@ -24863,6 +25239,13 @@
         "crypt": "0.0.2",
         "is-buffer": "~1.1.6"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -25001,6 +25384,542 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -28603,6 +29522,26 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -29872,6 +30811,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pupa": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz",
@@ -30859,6 +31808,32 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/run-con": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.3.tgz",
+      "integrity": "sha512-Lb7OKM9aaykzyoNiHGhSVCjZsvbyy6qDMp2vDXL+MoCfz3GfNJtHYH7uYsU3QNMyInBk++xx+EZ8xZ8Sxs5fNQ==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~7.0.0",
+        "minimist": "^1.2.8",
+        "strip-json-comments": "~3.1.1"
+      },
+      "bin": {
+        "run-con": "cli.js"
+      }
+    },
+    "node_modules/run-con/node_modules/ini": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -31710,6 +32685,19 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/smtp-connection": {
@@ -35247,6 +36235,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -38355,7 +39350,7 @@
         "jsonwebtoken": "^9.0.3"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -38397,7 +39392,7 @@
         "casbin": "^5.51.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -38443,7 +39438,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -38537,7 +39532,7 @@
         "loopback-boot": "^3.3.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/boot": "^8.0.1",
@@ -38593,7 +39588,7 @@
         "lb-ttsc": "bin/compile-package.js"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/build/node_modules/@types/node": {
@@ -38725,7 +39720,7 @@
         "yeoman-test": "^6.3.0"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/cli/node_modules/@npmcli/agent": {
@@ -39914,7 +40909,7 @@
         "bluebird": "^3.7.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/context/node_modules/@types/node": {
@@ -39951,7 +40946,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/core/node_modules/@types/node": {
@@ -39983,7 +40978,7 @@
         "eslint-plugin-mocha": "^10.5.0"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "eslint": "^8.57.1"
@@ -40019,7 +41014,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -40056,7 +41051,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/filter/node_modules/@types/node": {
@@ -40098,7 +41093,7 @@
         "tunnel": "0.0.6"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/http-caching-proxy/node_modules/@npmcli/fs": {
@@ -40248,7 +41243,7 @@
         "@types/stoppable": "^1.1.3"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/http-server/node_modules/@types/node": {
@@ -40287,7 +41282,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/metadata/node_modules/@types/node": {
@@ -40321,7 +41316,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -40360,7 +41355,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/openapi-spec-builder/node_modules/@types/node": {
@@ -40406,7 +41401,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -40452,7 +41447,7 @@
         "bson": "7.3.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -40478,7 +41473,7 @@
         "ajv-formats": "^3.0.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -40522,7 +41517,7 @@
         "lodash": "^4.18.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -40618,7 +41613,7 @@
         "multer": "^2.2.0"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -40643,7 +41638,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -40689,7 +41684,7 @@
         "express": "^4.22.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -40758,7 +41753,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.1"
@@ -40797,7 +41792,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -40845,7 +41840,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/testlab/node_modules/@types/node": {
@@ -40896,7 +41891,7 @@
         "@types/npmcli__package-json": "^4.0.4"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/tsdocs/node_modules/@types/node": {
@@ -40921,7 +41916,79 @@
       "version": "7.0.0",
       "license": "MIT",
       "engines": {
+        "node": "22 || 24 || 26"
+      }
+    },
+    "sandbox/loopback.io": {
+      "name": "loopback.io-workflow-scripts",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.1"
+      },
+      "devDependencies": {
+        "@loopback/docs": "latest",
+        "chalk": "^5.6.2",
+        "fs-extra": "^11.3.5",
+        "markdownlint-cli": "^0.48.0",
+        "retry": "^0.13.1",
+        "swagger-ui-dist": "^5.32.6",
+        "xml2js": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=24.16.0"
+      }
+    },
+    "sandbox/loopback.io/node_modules/@loopback/docs": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/@loopback/docs/-/docs-8.0.16.tgz",
+      "integrity": "sha512-m7vKheB4uZLdxZ2U4648Pz9VcicrXjjuucSQ0UQQBDveJ7smm4CAi1gV4hk7EH4HYHvif69iBwuw2L2M5R8RZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fs-extra": "^11.3.6",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
         "node": "20 || 22 || 24"
+      }
+    },
+    "sandbox/loopback.io/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "sandbox/loopback.io/node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "sandbox/loopback.io/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24",
+        "node": "22 || 24 || 26",
         "npm": ">=7"
       }
     },
@@ -64,7 +64,7 @@
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "acceptance/extension-logging-fluentd/node_modules/@types/node": {
@@ -105,7 +105,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "acceptance/repository-cloudant/node_modules/@types/node": {
@@ -140,7 +140,7 @@
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "acceptance/repository-mongodb/node_modules/@types/node": {
@@ -175,7 +175,7 @@
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "acceptance/repository-mysql/node_modules/@types/node": {
@@ -210,7 +210,7 @@
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "acceptance/repository-postgresql/node_modules/@types/node": {
@@ -261,7 +261,7 @@
         "source-map-support": "^0.5.21"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "benchmark/node_modules/@types/node": {
@@ -301,7 +301,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.1",
@@ -337,7 +337,7 @@
         "@loopback/build": "^12.0.15"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/access-control-migration": {
@@ -372,7 +372,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/access-control-migration/node_modules/@types/node": {
@@ -414,7 +414,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/binding-resolution/node_modules/@types/node": {
@@ -451,7 +451,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/context/node_modules/@types/node": {
@@ -495,7 +495,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/express-composition/node_modules/@types/node": {
@@ -538,7 +538,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/file-transfer/node_modules/@types/node": {
@@ -585,7 +585,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/graphql/node_modules/@types/node": {
@@ -625,7 +625,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/greeter-extension/node_modules/@types/node": {
@@ -668,7 +668,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/greeting-app/node_modules/@types/node": {
@@ -706,7 +706,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/hello-world/node_modules/@types/node": {
@@ -758,7 +758,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/lb3-application/node_modules/@types/node": {
@@ -799,7 +799,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/log-extension/node_modules/@types/node": {
@@ -839,7 +839,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/metrics-prometheus/node_modules/@types/node": {
@@ -886,7 +886,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/multi-tenancy/node_modules/@types/node": {
@@ -964,7 +964,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/passport-login/node_modules/@types/node": {
@@ -1010,7 +1010,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/references-many/node_modules/@types/node": {
@@ -1056,7 +1056,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/rest-crud/node_modules/@types/node": {
@@ -1095,7 +1095,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/rpc-server/node_modules/@types/node": {
@@ -1141,7 +1141,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/soap-calculator/node_modules/@types/node": {
@@ -1187,7 +1187,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/socketio/node_modules/@types/node": {
@@ -1235,7 +1235,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/todo-jwt": {
@@ -1268,7 +1268,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/todo-jwt/node_modules/@types/node": {
@@ -1314,7 +1314,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/todo-list/node_modules/@types/node": {
@@ -1375,7 +1375,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/validation-app/node_modules/@types/node": {
@@ -1420,7 +1420,7 @@
         "webpack-cli": "^7.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "examples/webpack/node_modules/@types/node": {
@@ -1456,7 +1456,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -1508,7 +1508,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/authentication": "^12.0.1",
@@ -1571,7 +1571,7 @@
         "supertest": "^7.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/authentication": "^12.0.1",
@@ -1613,7 +1613,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -1655,7 +1655,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -1712,7 +1712,7 @@
         "class-transformer": "^0.5.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/boot": "^8.0.1",
@@ -1754,7 +1754,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -1799,7 +1799,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -1842,7 +1842,7 @@
         "express": "^4.22.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -1884,7 +1884,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -1931,7 +1931,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -1979,7 +1979,7 @@
         "socket.io-client": "^4.8.3"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/boot": "^8.0.1",
@@ -2009,7 +2009,7 @@
         "sqlite3": "^6.0.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/boot": "^8.0.1",
@@ -2058,7 +2058,7 @@
         "@loopback/testlab": "^8.0.15"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "fixtures/mock-oauth2-provider/node_modules/@types/node": {
@@ -2087,7 +2087,7 @@
         "@loopback/build": "^12.0.15"
       },
       "engines": {
-        "node": "20 || 22 || 24",
+        "node": "22 || 24 || 26",
         "npm": ">=7"
       }
     },
@@ -9232,6 +9232,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
@@ -9791,6 +9798,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "11.0.0",
@@ -12120,6 +12134,39 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
       "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g=="
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/chardet": {
       "version": "0.7.0",
@@ -14549,6 +14596,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -14740,6 +14801,16 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/des.js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
@@ -14783,6 +14854,20 @@
       "devOptional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/devtools-protocol": {
@@ -18775,6 +18860,32 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -18906,6 +19017,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -18976,6 +19098,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-in-ci": {
@@ -19926,6 +20059,16 @@
         "node": ">= 10.16.0"
       }
     },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -20012,6 +20155,33 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/keygrip": {
@@ -22179,6 +22349,26 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "17.3.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.3.0.tgz",
@@ -24252,6 +24442,10 @@
         "which": "bin/which"
       }
     },
+    "node_modules/loopback.io-workflow-scripts": {
+      "resolved": "sandbox/loopback.io",
+      "link": true
+    },
     "node_modules/loopback/node_modules/async": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
@@ -24875,6 +25069,44 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -24884,6 +25116,150 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
+      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "4.0.2",
+        "micromark-core-commonmark": "2.0.3",
+        "micromark-extension-directive": "4.0.0",
+        "micromark-extension-gfm-autolink-literal": "2.1.0",
+        "micromark-extension-gfm-footnote": "2.1.0",
+        "micromark-extension-gfm-table": "2.1.1",
+        "micromark-extension-math": "3.1.0",
+        "micromark-util-types": "2.0.2",
+        "string-width": "8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.48.0.tgz",
+      "integrity": "sha512-NkZQNu2E0Q5qLEEHwWj674eYISTLD4jMHkBzDobujXd1kv+yCxi8jOaD/rZoQNW1FBBMMGQpuW5So8B51N/e0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "~14.0.3",
+        "deep-extend": "~0.6.0",
+        "ignore": "~7.0.5",
+        "js-yaml": "~4.1.1",
+        "jsonc-parser": "~3.3.1",
+        "jsonpointer": "~5.0.1",
+        "markdown-it": "~14.1.1",
+        "markdownlint": "~0.40.0",
+        "minimatch": "~10.2.4",
+        "run-con": "~1.3.2",
+        "smol-toml": "~1.6.0",
+        "tinyglobby": "~0.2.15"
+      },
+      "bin": {
+        "markdownlint": "markdownlint.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/markdownlint-cli/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdownlint/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/markdownlint/node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdownlint/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/math-intrinsics": {
@@ -24903,6 +25279,13 @@
         "crypt": "0.0.2",
         "is-buffer": "~1.1.6"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -25041,6 +25424,542 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -28638,6 +29557,26 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -29909,6 +30848,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pupa": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz",
@@ -30896,6 +31845,32 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/run-con": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.3.tgz",
+      "integrity": "sha512-Lb7OKM9aaykzyoNiHGhSVCjZsvbyy6qDMp2vDXL+MoCfz3GfNJtHYH7uYsU3QNMyInBk++xx+EZ8xZ8Sxs5fNQ==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~7.0.0",
+        "minimist": "^1.2.8",
+        "strip-json-comments": "~3.1.1"
+      },
+      "bin": {
+        "run-con": "cli.js"
+      }
+    },
+    "node_modules/run-con/node_modules/ini": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -31747,6 +32722,19 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/smtp-connection": {
@@ -35110,6 +36098,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -38216,7 +39211,7 @@
         "jsonwebtoken": "^9.0.3"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -38258,7 +39253,7 @@
         "casbin": "^5.51.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -38304,7 +39299,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -38398,7 +39393,7 @@
         "loopback-boot": "^3.3.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/boot": "^8.0.1",
@@ -38454,7 +39449,7 @@
         "lb-ttsc": "bin/compile-package.js"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/build/node_modules/@types/node": {
@@ -38586,7 +39581,7 @@
         "yeoman-test": "^6.3.0"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/cli/node_modules/@npmcli/agent": {
@@ -39785,7 +40780,7 @@
         "bluebird": "^3.7.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/context/node_modules/@types/node": {
@@ -39822,7 +40817,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/core/node_modules/@types/node": {
@@ -39854,7 +40849,7 @@
         "eslint-plugin-mocha": "^10.5.0"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "eslint": "^8.57.1"
@@ -39890,7 +40885,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -39927,7 +40922,7 @@
         "typescript": "~5.2.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/filter/node_modules/@types/node": {
@@ -39969,7 +40964,7 @@
         "tunnel": "0.0.6"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/http-caching-proxy/node_modules/@npmcli/fs": {
@@ -40119,7 +41114,7 @@
         "@types/stoppable": "^1.1.3"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/http-server/node_modules/@types/node": {
@@ -40158,7 +41153,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/metadata/node_modules/@types/node": {
@@ -40192,7 +41187,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -40231,7 +41226,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/openapi-spec-builder/node_modules/@types/node": {
@@ -40277,7 +41272,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -40323,7 +41318,7 @@
         "bson": "7.3.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -40349,7 +41344,7 @@
         "ajv-formats": "^3.0.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -40393,7 +41388,7 @@
         "lodash": "^4.18.1"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -40489,7 +41484,7 @@
         "multer": "^2.2.0"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -40514,7 +41509,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -40560,7 +41555,7 @@
         "express": "^4.22.2"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0",
@@ -40629,7 +41624,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.1"
@@ -40668,7 +41663,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
         "@loopback/core": "^7.0.0"
@@ -40716,7 +41711,7 @@
         "@types/node": "^20.19.43"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/testlab/node_modules/@types/node": {
@@ -40767,7 +41762,7 @@
         "@types/npmcli__package-json": "^4.0.4"
       },
       "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "packages/tsdocs/node_modules/@types/node": {
@@ -40792,7 +41787,79 @@
       "version": "7.0.0",
       "license": "MIT",
       "engines": {
+        "node": "22 || 24 || 26"
+      }
+    },
+    "sandbox/loopback.io": {
+      "name": "loopback.io-workflow-scripts",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.1"
+      },
+      "devDependencies": {
+        "@loopback/docs": "latest",
+        "chalk": "^5.6.2",
+        "fs-extra": "^11.3.5",
+        "markdownlint-cli": "^0.48.0",
+        "retry": "^0.13.1",
+        "swagger-ui-dist": "^5.32.6",
+        "xml2js": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=24.16.0"
+      }
+    },
+    "sandbox/loopback.io/node_modules/@loopback/docs": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/@loopback/docs/-/docs-8.0.16.tgz",
+      "integrity": "sha512-m7vKheB4uZLdxZ2U4648Pz9VcicrXjjuucSQ0UQQBDveJ7smm4CAi1gV4hk7EH4HYHvif69iBwuw2L2M5R8RZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fs-extra": "^11.3.6",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
         "node": "20 || 22 || 24"
+      }
+    },
+    "sandbox/loopback.io/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "sandbox/loopback.io/node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "sandbox/loopback.io/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "20 || 22 || 24",
+    "node": "22 || 24 || 26",
     "npm": ">=7"
   },
   "private": true,

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/authentication"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/authorization"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/boot"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/boot/src/__tests__/fixtures/package.json
+++ b/packages/boot/src/__tests__/fixtures/package.json
@@ -7,7 +7,7 @@
     "loopback"
   ],
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {},
   "repository": {

--- a/packages/booter-lb3app/package.json
+++ b/packages/booter-lb3app/package.json
@@ -19,7 +19,7 @@
     "directory": "packages/booter-lb3app"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -21,7 +21,7 @@
     "directory": "packages/build"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "test": "npm run mocha",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "directory": "packages/cli"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "test": "lb-mocha --lang en_US.UTF-8 \"test/**/*.js\"",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -22,7 +22,7 @@
     "directory": "packages/context"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/core"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/eslint-config"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/express"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/filter"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -20,7 +20,7 @@
     "directory": "packages/http-caching-proxy"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/http-server"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/metadata"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/model-api-builder/package.json
+++ b/packages/model-api-builder/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/model-api-builder"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -20,7 +20,7 @@
     "directory": "packages/openapi-spec-builder"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/openapi-v3"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/repository-json-schema"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/repository-tests/package.json
+++ b/packages/repository-tests/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/repository-tests"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/repository"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/rest-crud/package.json
+++ b/packages/rest-crud/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/rest-crud"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/rest-explorer"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/rest"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/rest/src/__tests__/integration/rest.server.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.server.integration.ts
@@ -1349,14 +1349,19 @@ paths:
     }
     const server = await givenAServer();
     server.controller(MyController);
-    const client = createClientForHandler(server.requestHandler);
-    const requests: Promise<unknown>[] = Array(10)
-      .fill([
-        client.get('/hello').expect(200, 'hello'),
-        client.get('/greet').expect(200, 'greet'),
-      ])
-      .flat();
-    await Promise.all(requests);
+    await server.start();
+    try {
+      const client = supertest(server.url);
+      const requests: Promise<unknown>[] = Array(10)
+        .fill([
+          client.get('/hello').expect(200, 'hello'),
+          client.get('/greet').expect(200, 'greet'),
+        ])
+        .flat();
+      await Promise.all(requests);
+    } finally {
+      await server.stop();
+    }
   });
 
   describe('basePath', () => {

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/security"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/service-proxy"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/testlab"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/tsdocs/package.json
+++ b/packages/tsdocs/package.json
@@ -23,7 +23,7 @@
     "directory": "packages/tsdocs"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "build:tsdocs": "npm run build && npm run -s extract-apidocs && npm run -s document-apidocs && npm run -s update-apidocs",

--- a/sandbox/example/package.json
+++ b/sandbox/example/package.json
@@ -13,7 +13,7 @@
     "directory": "sandbox/example"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": "22 || 24 || 26"
   },
   "scripts": {
     "test": "echo \"This is an example for sandbox\""


### PR DESCRIPTION
BREAKING CHANGE: drop Node.js 20 support as Node.js 20 has reached end of life. 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
