### PR TITLE
fix(repository): dedupe/filter source ids before querying in hasMany and hasOne inclusion resolvers

### DIFF
--- a/packages/repository-tests/src/crud/relations/acceptance/has-many-inclusion-resolver.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-many-inclusion-resolver.relation.acceptance.ts
@@ -372,6 +372,44 @@ export function hasManyInclusionResolverAcceptance(
       );
     });
 
+    it('tolerates duplicate and missing source key values when resolving inclusion', async () => {
+      // Regression test: the hasMany inclusion resolver used to pass its
+      // raw, unfiltered source-id list by reference straight to
+      // findByForeignKeys(), which hands that same array on to the
+      // connector inside an `{inq: [...]}` where clause. A connector/query
+      // layer that sanitizes an `inq` array in place (stripping falsy
+      // values before running the query, as the in-memory connector does)
+      // then mutates that shared array out from under the caller, shrinking
+      // the very array the resolver still needed - unmodified - to zip
+      // results back onto each original entity. That silently truncated
+      // and misaligned the resolver's return value whenever any source
+      // entity's key was undefined (e.g. excluded by a fields filter) or
+      // duplicated another entity's. belongsTo/referencesMany already pass
+      // a fresh, deduplicated, filtered array (never the original
+      // reference) before querying; hasMany now does the same.
+      const thor = await customerRepo.create({name: 'Thor'});
+      const thorOrder = await orderRepo.create({
+        customerId: thor.id,
+        description: "Thor's Mjolnir",
+      });
+
+      const resolver = customerRepo.inclusionResolvers.get('orders')!;
+      const result = await resolver(
+        [
+          thor,
+          thor, // duplicate id
+          {name: 'no id'} as unknown as Customer, // id is undefined
+        ],
+        'orders',
+      );
+
+      expect(toJSON(result)).to.deepEqual([
+        [toJSON(thorOrder)],
+        [toJSON(thorOrder)],
+        undefined,
+      ]);
+    });
+
     it('throws error if the target repository does not have the registered resolver', async () => {
       const customer = await customerRepo.create({name: 'customer'});
       await orderRepo.create({

--- a/packages/repository-tests/src/crud/relations/acceptance/has-many-inclusion-resolver.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-many-inclusion-resolver.relation.acceptance.ts
@@ -403,10 +403,13 @@ export function hasManyInclusionResolverAcceptance(
         'orders',
       );
 
+      // The entity with no source key has no related entities; after JSON
+      // serialization that slot is `null` (JSON has no `undefined`). The key
+      // point is that the result stays length-3 and aligned with the input.
       expect(toJSON(result)).to.deepEqual([
         [toJSON(thorOrder)],
         [toJSON(thorOrder)],
-        undefined,
+        null,
       ]);
     });
 

--- a/packages/repository-tests/src/crud/relations/acceptance/has-one.inclusion-resolver.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-one.inclusion-resolver.acceptance.ts
@@ -194,10 +194,13 @@ export function hasOneInclusionResolverAcceptance(
         'address',
       );
 
+      // The entity with no source key has no related entity; after JSON
+      // serialization that slot is `null` (JSON has no `undefined`). The key
+      // point is that the result stays length-3 and aligned with the input.
       expect(toJSON(result)).to.deepEqual([
         toJSON(thorAddress),
         toJSON(thorAddress),
-        undefined,
+        null,
       ]);
     });
 

--- a/packages/repository-tests/src/crud/relations/acceptance/has-one.inclusion-resolver.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-one.inclusion-resolver.acceptance.ts
@@ -160,6 +160,47 @@ export function hasOneInclusionResolverAcceptance(
       expect(toJSON(result)).to.deepEqual(toJSON(expected));
     });
 
+    it('tolerates duplicate and missing source key values when resolving inclusion', async () => {
+      // Regression test: the hasOne inclusion resolver used to pass its raw,
+      // unfiltered source-id list by reference straight to
+      // findByForeignKeys(), which hands that same array on to the
+      // connector inside an `{inq: [...]}` where clause. A connector/query
+      // layer that sanitizes an `inq` array in place (stripping falsy
+      // values before running the query, as the in-memory connector does)
+      // then mutates that shared array out from under the caller, shrinking
+      // the very array the resolver still needed - unmodified - to zip
+      // results back onto each original entity. That silently truncated
+      // and misaligned the resolver's return value whenever any source
+      // entity's key was undefined (e.g. excluded by a fields filter) or
+      // duplicated another entity's. belongsTo/referencesMany already pass
+      // a fresh, deduplicated, filtered array (never the original
+      // reference) before querying; hasOne now does the same.
+      const thor = await customerRepo.create({name: 'Thor'});
+      const thorAddress = await addressRepo.create({
+        street: 'home of Thor Rd.',
+        city: 'Thrudheim',
+        province: 'Asgard',
+        zipcode: '8200',
+        customerId: thor.id,
+      });
+
+      const resolver = customerRepo.inclusionResolvers.get('address')!;
+      const result = await resolver(
+        [
+          thor,
+          thor, // duplicate id
+          {name: 'no id'} as unknown as Customer, // id is undefined
+        ],
+        'address',
+      );
+
+      expect(toJSON(result)).to.deepEqual([
+        toJSON(thorAddress),
+        toJSON(thorAddress),
+        undefined,
+      ]);
+    });
+
     it('throws error if the target repository does not have the registered resolver', async () => {
       const customer = await customerRepo.create({name: 'customer'});
       await addressRepo.create({

--- a/packages/repository/src/relations/has-many/has-many.inclusion-resolver.ts
+++ b/packages/repository/src/relations/has-many/has-many.inclusion-resolver.ts
@@ -9,6 +9,7 @@ import {AnyObject, Options} from '../../common-types';
 import {Entity} from '../../model';
 import {EntityCrudRepository} from '../../repositories';
 import {
+  deduplicate,
   findByForeignKeys,
   flattenTargetsOfOneToManyRelation,
   StringKeyOf,
@@ -69,7 +70,24 @@ export function createHasManyInclusionResolver<
     const targetsFound = await findByForeignKeys(
       targetRepo,
       targetKey,
-      sourceIds,
+      // Source ids can contain duplicates (e.g. the same source entity
+      // fetched more than once) and undefined/null values (e.g. when the
+      // source key field was excluded via a fields filter). Passing the raw
+      // array straight through is unsafe: `findByForeignKeys` wraps it in an
+      // `{inq: [...]}` where clause and hands that array to the connector
+      // by reference, without cloning it first. A connector/query layer
+      // that sanitizes an `inq` array in place (e.g. stripping falsy
+      // values before running the query) then mutates *this exact array*
+      // out from under us - shrinking the very `sourceIds` array we still
+      // need below, unmodified, to correctly zip results back onto each
+      // original entity. That silently misaligns or truncates the returned
+      // array relative to the input entities. Passing a fresh
+      // (deduplicated, filtered) array here - never the original
+      // `sourceIds` reference - avoids that aliasing entirely, on top of
+      // avoiding the redundant/undefined values in the query itself.
+      // belongsTo/referencesMany inclusion resolvers already do this;
+      // hasMany didn't.
+      deduplicate(sourceIds).filter(e => e),
       scope,
       options,
     );

--- a/packages/repository/src/relations/has-one/has-one.inclusion-resolver.ts
+++ b/packages/repository/src/relations/has-one/has-one.inclusion-resolver.ts
@@ -9,6 +9,7 @@ import {AnyObject, Options} from '../../common-types';
 import {Entity} from '../../model';
 import {EntityCrudRepository} from '../../repositories';
 import {
+  deduplicate,
   findByForeignKeys,
   flattenTargetsOfOneToOneRelation,
   StringKeyOf,
@@ -110,7 +111,24 @@ export function createHasOneInclusionResolver<
       const targetsFound = await findByForeignKeys(
         targetRepo,
         targetKey,
-        sourceIdsCategorized[k],
+        // Source ids can contain duplicates and undefined/null values (e.g.
+        // when the source key field was excluded via a fields filter).
+        // Passing the raw array straight through is unsafe:
+        // `findByForeignKeys` wraps it in an `{inq: [...]}` where clause and
+        // hands that array to the connector by reference, without cloning
+        // it first. A connector/query layer that sanitizes an `inq` array
+        // in place (e.g. stripping falsy values before running the query)
+        // then mutates *this exact array* out from under us - shrinking the
+        // very `sourceIdsCategorized[k]` array we still need below,
+        // unmodified, to correctly zip results back onto each original
+        // entity. That silently misaligns or truncates the returned array
+        // relative to the input entities. Passing a fresh (deduplicated,
+        // filtered) array here - never the original array reference -
+        // avoids that aliasing entirely, on top of avoiding the
+        // redundant/undefined values in the query itself. belongsTo/
+        // referencesMany inclusion resolvers already do this; hasOne
+        // didn't.
+        deduplicate(sourceIdsCategorized[k]).filter(e => e),
         scope,
         {...options, polymorphicType: k},
       );


### PR DESCRIPTION
### Summary

`createHasManyInclusionResolver` and `createHasOneInclusionResolver` both build their list of source ids (`sourceIds` / `sourceIdsCategorized[k]`) and then pass that array **by reference** straight into `findByForeignKeys()`. That function wraps a multi-element array in an `{inq: [...]}` where clause and hands the same array reference on to the target repository's `find()` - it never clones it.

`belongsTo` and `referencesMany`'s inclusion resolvers don't have this problem: both already call `deduplicate(sourceIds).filter(e => e)` (a fresh array) before querying. `hasMany` and `hasOne` didn't - this PR brings them in line.

### The actual bug (not just theoretical)

I initially expected the risk here to be "an `undefined` id collapses the where clause and over-fetches unrelated data" via JSON-serialization dropping an `undefined`-valued key. That's not what I found when I actually reproduced it.

What's really happening: because the raw, unfiltered array is passed *by reference*, if anything downstream (a connector, a query-normalization layer) sanitizes the `inq` array **in place** - e.g. stripping falsy values before running the query, which is exactly what the built-in memory connector does - that mutation happens to the *same array object* the resolver still needs, unmodified, a few lines later to zip the fetched results back onto each original source entity (`flattenTargetsOfOneToManyRelation`/`flattenTargetsOfOneToOneRelation` expect `sourceIds.length` to still equal the original entity count).

I confirmed this concretely with a standalone script (real compiled resolvers + a real in-memory `DataSource`, `@hasMany`/`@hasOne` models, no mocks):
- 3 entities in the batch, the third with an `undefined` id (e.g. as if its key field had been excluded by a `fields` filter).
- **Before this fix**: the resolver returns an array of length **2**, not 3 - the third element isn't merely `undefined`, it's *gone*, silently misaligning every subsequent lookup against the wrong source entity.
- **After this fix**: the resolver returns the correct length-3 array, with `undefined` in the third slot as expected.

So this isn't just a wasted-query-size nitpick - it's a real correctness/data-integrity bug: any hasMany/hasOne inclusion over a batch containing a source entity with a missing key (or a duplicate id, which triggers similar `inq`-array handling) can return relation data misaligned to the wrong parent entities.

### Fix

Pass `deduplicate(sourceIds).filter(e => e)` (a fresh array, matching the existing `belongsTo`/`referencesMany` convention exactly) into `findByForeignKeys()`, while leaving the original `sourceIds` / `sourceIdsCategorized[k]` array completely untouched for the later flatten/zip step. No new helper needed - `deduplicate` already exists in `relation.helpers.ts` and is already used by the two siblings.

### Testing

Added a regression test to each of the two existing acceptance suites (`has-one.inclusion-resolver.acceptance.ts`, `has-many-inclusion-resolver.relation.acceptance.ts`), calling the registered `inclusionResolver` directly with a batch containing a duplicate id and a missing id, asserting the correct length and per-entity alignment. These run against every connector already covered by the acceptance-suite loader (`acceptance/repository-{mongodb,mysql,postgresql,cloudant}`) once merged.

I don't have Docker/a live external database in my environment, so I couldn't run those acceptance packages themselves end-to-end. What I *did* verify for real, locally:
- `npm run build` for both `packages/repository` and `packages/repository-tests` - clean.
- `eslint` and `prettier --check` on all four changed files - clean.
- A standalone script (not included in this PR - just my own local verification) exercising the actual compiled resolvers against a real in-memory `DataSource` with real `@hasMany`/`@hasOne`-decorated models, confirming both the bug (by temporarily reverting just the source fix) and the fix.

### Checklist

- [x] `npm run build` passes locally
- [x] `npm run lint` (eslint + prettier) passes locally on changed files
- [x] New tests added for the fix
- [ ] Full acceptance suite (`npm test`) run locally - not possible here, no Docker/live DB; would appreciate a CI run